### PR TITLE
Simplify API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/*
+Cargo.lock

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ There is already a large list of parsers available, like:
 Some macros make it easier to create new parsers. Here are a few of them:
 
 ```rust
-tag!(abcd_parser  b"abcd"); // will consume bytes if the input begins with "abcd"
+tag!(abcd_parser  "abcd"); // will consume bytes if the input begins with "abcd"
+
 
 take!(take_10     10);                // will consume 10 bytes of input
 ```
@@ -153,8 +154,8 @@ pub trait FlatMapOpt<I,O,N> {
 Here again, we use macros to combine parsers easily in useful patterns:
 
 ```rust
-tag!(abcd_p b"abcd");
-tag!(efgh_p b"efgh");
+tag!(abcd_p "abcd");
+tag!(efgh_p "efgh");
 
 // the types indicates the input and output types, that must match for all alternatives
 alt!(alt_tags<&[u8],&[u8]>, abcd_p, efgh_p);
@@ -195,8 +196,8 @@ struct A {
   b: u8
 }
 
-tag!(abcd_p b"abcd");
-tag!(efgh_p b"efgh");
+tag!(abcd_p "abcd");
+tag!(efgh_p "efgh");
 
 fn ret_int1(i:&[u8]) -> IResult<&[u8], u8> { Done(i,1) };
 fn ret_int2(i:&[u8]) -> IResult<&[u8], u8> { Done(i,2) };
@@ -341,10 +342,10 @@ struct TestConsumer {
 Then, we define the parsers that we will use at every state of our consumer. Note that we do not make one big parser at once. We just build some small, reusable, testable components
 
 ```rust
-tag!(om_parser                     b"om");
-tag!(nom_parser                    b"nom");
+tag!(om_parser                     "om");
+tag!(nom_parser                    "nom");
 many1!(nomnom_parser<&[u8],&[u8]>  nom_parser);
-tag!(end_parser                    b"kthxbye");
+tag!(end_parser                    "kthxbye");
 ```
 
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -184,7 +184,7 @@ impl<'x,'z,T> FlatMap<(),(),T> for IResult<(),()> {
 /// use nom::IResult::Done;
 /// use nom::FlatMapOpt;
 /// use std::str;
-/// let res = Done((),b"abcd").map_res(|&: data| { str::from_utf8(data) });
+/// let res = Done((), b"abcd").map_res(|&: data| { str::from_utf8(data) });
 /// assert_eq!(res, Done((), "abcd"));
 /// ```
 pub trait FlatMapOpt<I,O,N> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -50,3 +50,35 @@ impl HexDisplay for [u8] {
     }
   }
 }
+
+pub trait AsBytes {
+  fn as_bytes(&self) -> &[u8];
+}
+
+impl<'a> AsBytes for &'a str {
+  #[inline(always)]
+  fn as_bytes(&self) -> &[u8] {
+    <str as StrExt>::as_bytes(self)
+  }
+}
+
+impl AsBytes for str {
+  #[inline(always)]
+  fn as_bytes(&self) -> &[u8] {
+    <str as StrExt>::as_bytes(&self)
+  }
+}
+
+impl<'a> AsBytes for &'a [u8] {
+  #[inline(always)]
+  fn as_bytes(&self) -> &[u8] {
+    *self
+  }
+}
+
+impl AsBytes for [u8] {
+  #[inline(always)]
+  fn as_bytes(&self) -> &[u8] {
+    self
+  }
+}

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -9,19 +9,19 @@ use std::collections::HashMap;
 
 
 fn empty_result(i:&[u8]) -> IResult<&[u8], ()> { Done(i,()) }
-tag!(semicolon b";");
-tag!(lsb       b"[");
-tag!(rsb       b"]");
-tag!(equal     b"=");
+tag!(semicolon ";");
+tag!(lsb       "[");
+tag!(rsb       "]");
+tag!(equal     "=");
 
 
-take_until_and_leave!(category_bytes b"]");
+take_until_and_leave!(category_bytes "]");
 fn category_name(input: &[u8]) -> IResult<&[u8], &str> {
   category_bytes(input).map_res(str::from_utf8)
 }
 
-take_until!(not_equal      b"=");
-take_until_either_and_leave!(value_bytes b"\n;");
+take_until!(not_equal      "=");
+take_until_either_and_leave!(value_bytes "\n;");
 
 fn value_parser(input:&[u8]) -> IResult<&[u8], &str> {
   value_bytes(input).map_res(str::from_utf8)
@@ -84,7 +84,7 @@ fn categories<'a>(input: &'a[u8]) -> IResult<&'a[u8], HashMap<&'a str, HashMap<&
 
 #[test]
 fn parse_comment_test() {
-  let ini_file = ";comment
+  let ini_file = b";comment
 [category]
 parameter=value
 key = value2
@@ -93,7 +93,7 @@ key = value2
 number = 1234
 str = a b cc dd ; comment";
 
-  let ini_without_comment = "[category]
+  let ini_without_comment = b"[category]
 parameter=value
 key = value2
 
@@ -101,131 +101,131 @@ key = value2
 number = 1234
 str = a b cc dd ; comment";
 
-  let res = comment(ini_file.as_bytes());
+  let res = comment(ini_file);
   println!("{:?}", res);
   match res {
     IResult::Done(i, o) => println!("i: {:?} | o: {:?}", str::from_utf8(i), o),
     _ => println!("error")
   }
 
-  assert_eq!(res, Done(ini_without_comment.as_bytes(), ()));
+  assert_eq!(res, Done(ini_without_comment, ()));
 }
 
 #[test]
 fn parse_category_test() {
-  let ini_file = "[category]
+  let ini_file = b"[category]
 
 parameter=value
 key = value2";
 
-  let ini_without_category = "parameter=value
+  let ini_without_category = b"parameter=value
 key = value2";
 
-  let res = category(ini_file.as_bytes());
+  let res = category(ini_file);
   println!("{:?}", res);
   match res {
     IResult::Done(i, o) => println!("i: {:?} | o: {:?}", str::from_utf8(i), o),
     _ => println!("error")
   }
 
-  assert_eq!(res, Done(ini_without_category.as_bytes(), "category"));
+  assert_eq!(res, Done(ini_without_category, "category"));
 }
 
 #[test]
 fn parse_value_test() {
-  let ini_file1 = "value
+  let ini_file1 = b"value
 key =";
-  let end = "
+  let end = b"
 key =";
 
-  let res = value_parser(ini_file1.as_bytes());
+  let res = value_parser(ini_file1);
   println!("{:?}", res);
   match res {
     IResult::Done(i, o) => println!("i: {:?} | o: {:?})", str::from_utf8(i), o),
     _ => println!("error")
   }
 
-  assert_eq!(res, Done(end.as_bytes(),  "value"));
+  assert_eq!(res, Done(end,  "value"));
 
-  let ini_file2 = "value;blah
+  let ini_file2 = b"value;blah
 key =";
-  let end2 = ";blah
+  let end2 = b";blah
 key =";
 
-  let res2 = value_parser(ini_file2.as_bytes());
+  let res2 = value_parser(ini_file2);
   println!("{:?}", res2);
   match res2 {
     IResult::Done(i, o) => println!("i: {:?} | o: {:?}", str::from_utf8(i), o),
     _ => println!("error")
   }
 
-  assert_eq!(res2, Done(end2.as_bytes(),  "value"));
+  assert_eq!(res2, Done(end2,  "value"));
 }
 
 #[test]
 fn parse_key_value_test() {
-  let ini_file = "parameter=value
+  let ini_file = b"parameter=value
 key = value2";
 
-  let ini_without_key_value = "key = value2";
+  let ini_without_key_value = b"key = value2";
 
-  let res = key_value(ini_file.as_bytes());
+  let res = key_value(ini_file);
   println!("{:?}", res);
   match res {
     IResult::Done(i, (o1, o2)) => println!("i: {:?} | o: ({:?},{:?})", str::from_utf8(i), o1, o2),
     _ => println!("error")
   }
 
-  assert_eq!(res, Done(ini_without_key_value.as_bytes(), ("parameter", "value")));
+  assert_eq!(res, Done(ini_without_key_value, ("parameter", "value")));
 }
 
 
 #[test]
 fn parse_key_value_with_space_test() {
-  let ini_file = "parameter = value
+  let ini_file = b"parameter = value
 key = value2";
 
-  let ini_without_key_value = "key = value2";
+  let ini_without_key_value = b"key = value2";
 
-  let res = key_value(ini_file.as_bytes());
+  let res = key_value(ini_file);
   println!("{:?}", res);
   match res {
     IResult::Done(i, (o1, o2)) => println!("i: {:?} | o: ({:?},{:?})", str::from_utf8(i), o1, o2),
     _ => println!("error")
   }
 
-  assert_eq!(res, Done(ini_without_key_value.as_bytes(), ("parameter", "value")));
+  assert_eq!(res, Done(ini_without_key_value, ("parameter", "value")));
 }
 
 #[test]
 fn parse_key_value_with_comment_test() {
-  let ini_file = "parameter=value;abc
+  let ini_file = b"parameter=value;abc
 key = value2";
 
-  let ini_without_key_value = "key = value2";
+  let ini_without_key_value = b"key = value2";
 
-  let res = key_value(ini_file.as_bytes());
+  let res = key_value(ini_file);
   println!("{:?}", res);
   match res {
     IResult::Done(i, (o1, o2)) => println!("i: {:?} | o: ({:?},{:?})", str::from_utf8(i), o1, o2),
     _ => println!("error")
   }
 
-  assert_eq!(res, Done(ini_without_key_value.as_bytes(), ("parameter", "value")));
+  assert_eq!(res, Done(ini_without_key_value, ("parameter", "value")));
 }
 
 #[test]
 fn parse_multiple_keys_and_values_test() {
-  let ini_file = "parameter=value;abc
+  let ini_file = b"parameter=value;abc
 
 key = value2
 
 [category]";
 
-  let ini_without_key_value = "[category]";
+  let ini_without_key_value = b"[category]";
 
   let h: HashMap<&str, &str> = HashMap::new();
-  let res = keys_and_values(ini_file.as_bytes(), h);
+  let res = keys_and_values(ini_file, h);
   println!("{:?}", res);
   match res {
     IResult::Done(i, ref o) => println!("i: {:?} | o: {:?}", str::from_utf8(i), o),
@@ -235,22 +235,22 @@ key = value2
   let mut expected: HashMap<&str, &str> = HashMap::new();
   expected.insert("parameter", "value");
   expected.insert("key", "value2");
-  assert_eq!(res, Done(ini_without_key_value.as_bytes(), expected));
+  assert_eq!(res, Done(ini_without_key_value, expected));
 }
 
 #[test]
 fn parse_category_then_multiple_keys_and_values_test() {
   //FIXME: there can be an empty line or a comment line after a category
-  let ini_file = "[abcd]
+  let ini_file = b"[abcd]
 parameter=value;abc
 
 key = value2
 
 [category]";
 
-  let ini_after_parser = "[category]";
+  let ini_after_parser = b"[category]";
 
-  let res = category_and_keys(ini_file.as_bytes());
+  let res = category_and_keys(ini_file);
   println!("{:?}", res);
   match res {
     IResult::Done(i, ref o) => println!("i: {:?} | o: {:?}", str::from_utf8(i), o),
@@ -260,12 +260,12 @@ key = value2
   let mut expected_h: HashMap<&str, &str> = HashMap::new();
   expected_h.insert("parameter", "value");
   expected_h.insert("key", "value2");
-  assert_eq!(res, Done(ini_after_parser.as_bytes(), ("abcd", expected_h)));
+  assert_eq!(res, Done(ini_after_parser, ("abcd", expected_h)));
 }
 
 #[test]
 fn parse_multiple_categories_test() {
-  let ini_file = "[abcd]
+  let ini_file = b"[abcd]
 
 parameter=value;abc
 
@@ -276,9 +276,9 @@ parameter3=value3
 key4 = value4
 ";
 
-  let ini_after_parser = "";
+  let ini_after_parser = b"";
 
-  let res = categories(ini_file.as_bytes());
+  let res = categories(ini_file);
   println!("{:?}", res);
   match res {
     IResult::Done(i, ref o) => println!("i: {:?} | o: {:?}", str::from_utf8(i), o),
@@ -294,6 +294,6 @@ key4 = value4
   let mut expected_h: HashMap<&str, HashMap<&str, &str>> = HashMap::new();
   expected_h.insert("abcd",     expected_1);
   expected_h.insert("category", expected_2);
-  assert_eq!(res, Done(ini_after_parser.as_bytes(), expected_h));
+  assert_eq!(res, Done(ini_after_parser, expected_h));
 }
 

--- a/tests/mp4.rs
+++ b/tests/mp4.rs
@@ -237,7 +237,7 @@ struct MP4BoxHeader {
 }
 
 take!(offset 4);
-tag!(ftyp    b"ftyp");
+tag!(ftyp    "ftyp");
 
 fn brand_name(input:&[u8]) -> IResult<&[u8],&str> {
   take!(major_brand_bytes 4);
@@ -258,29 +258,29 @@ fn filetype_box_type(input:&[u8]) -> IResult<&[u8], MP4BoxType> {
   ftyp(input).map(|_| MP4BoxType::Ftyp)
 }
 
-tag!(moov_tag b"moov");
+tag!(moov_tag "moov");
 
-tag!(mdra    b"mdra");
+tag!(mdra    "mdra");
 fn moov_mdra_type(input:&[u8]) -> IResult<&[u8], MP4BoxType> {
   mdra(input).map(|_| MP4BoxType::Mdra)
 }
 
-tag!(dref    b"dref");
+tag!(dref    "dref");
 fn moov_dref_type(input:&[u8]) -> IResult<&[u8], MP4BoxType> {
   dref(input).map(|_| MP4BoxType::Dref)
 }
 
-tag!(cmov    b"cmov");
+tag!(cmov    "cmov");
 fn moov_cmov_type(input:&[u8]) -> IResult<&[u8], MP4BoxType> {
   cmov(input).map(|_| MP4BoxType::Cmov)
 }
 
-tag!(rmra    b"rmra");
+tag!(rmra    "rmra");
 fn moov_rmra_type(input:&[u8]) -> IResult<&[u8], MP4BoxType> {
   rmra(input).map(|_| MP4BoxType::Rmra)
 }
 
-tag!(iods    b"iods");
+tag!(iods    "iods");
 fn moov_iods_type(input:&[u8]) -> IResult<&[u8], MP4BoxType> {
   iods(input).map(|_| MP4BoxType::Iods)
 }
@@ -297,22 +297,22 @@ fn mvhd_box(input:&[u8]) -> IResult<&[u8],MvhdBox> {
   }
 }
 
-tag!(mvhd    b"mvhd");
+tag!(mvhd    "mvhd");
 fn moov_mvhd_type(input:&[u8]) -> IResult<&[u8], MP4BoxType> {
   mvhd(input).map(|_| MP4BoxType::Mvhd)
 }
 
-tag!(clip    b"clip");
+tag!(clip    "clip");
 fn moov_clip_type(input:&[u8]) -> IResult<&[u8], MP4BoxType> {
   clip(input).map(|_| MP4BoxType::Clip)
 }
 
-tag!(trak    b"trak");
+tag!(trak    "trak");
 fn moov_trak_type(input:&[u8]) -> IResult<&[u8], MP4BoxType> {
   trak(input).map(|_| MP4BoxType::Trak)
 }
 
-tag!(udta    b"udta");
+tag!(udta   "udta");
 fn moov_udta_type(input:&[u8]) -> IResult<&[u8], MP4BoxType> {
   udta(input).map(|_| MP4BoxType::Udta)
 }
@@ -321,22 +321,21 @@ fn moov_box_type(input:&[u8]) -> IResult<&[u8], MP4BoxType> {
   moov_tag(input).map(|_| MP4BoxType::Moov)
 }
 
-tag!(mdat    b"mdat");
+tag!(mdat    "mdat");
 fn mdat_box_type(input:&[u8]) -> IResult<&[u8], MP4BoxType> {
   mdat(input).map(|_| MP4BoxType::Mdat)
 }
-
-tag!(free    b"free");
+tag!(free    "free");
 fn free_box_type(input:&[u8]) -> IResult<&[u8], MP4BoxType> {
   free(input).map(|_| MP4BoxType::Free)
 }
 
-tag!(skip    b"skip");
+tag!(skip    "skip");
 fn skip_box_type(input:&[u8]) -> IResult<&[u8], MP4BoxType> {
   skip(input).map(|_| MP4BoxType::Skip)
 }
 
-tag!(wide    b"wide");
+tag!(wide    "wide");
 fn wide_box_type(input:&[u8]) -> IResult<&[u8], MP4BoxType> {
   wide(input).map(|_| MP4BoxType::Wide)
 }

--- a/tests/omnom.rs
+++ b/tests/omnom.rs
@@ -17,10 +17,10 @@ struct TestConsumer {
   counter: usize,
 }
 
-tag!(om_parser                     b"om");
-tag!(nom_parser                    b"nom");
+tag!(om_parser                     "om");
+tag!(nom_parser                    "nom");
 many1!(nomnom_parser<&[u8],&[u8]>  nom_parser);
-tag!(end_parser                    b"kthxbye");
+tag!(end_parser                    "kthxbye");
 
 impl Consumer for TestConsumer {
   fn consume(&mut self, input: &[u8]) -> ConsumerState {

--- a/tests/test1.rs
+++ b/tests/test1.rs
@@ -18,7 +18,7 @@ fn map_test_x() {
 fn tag() {
   FileProducer::new("links.txt", 20).map(|producer: FileProducer| {
     let mut p = producer;
-    tag!(f b"https://");
+    tag!(f "https://");
     //p.push(|par| par.flat_map(f).flat_map(print));
     fn pr<'a>(data:&'a [u8]) -> IResult<&'a [u8],()> {
       let p = f(data).map_res(str::from_utf8);//.flat_map(print);
@@ -28,7 +28,7 @@ fn tag() {
     pusher!(ps, pr);
     ps(&mut p);
     //assert!(false);
-  }); 
+  });
 }
 
 pub fn print<T: Debug>(input: T) -> IResult<T,()> {


### PR DESCRIPTION
This introduces overhead in non-optimised builds but should optimise out in `-O` builds. 

It's preferable over just specifying strings by `b"foo"` as that syntax doesn't allow for non-ASCII.