### PR TITLE
Remove core feature dependency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //! ```
 //!
 
-#![feature(core,collections)]
+#![feature(collections)]
 
 pub use self::util::*;
 pub use self::internal::*;//{IResult, IResultClosure, GetInput, GetOutput};

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,3 @@
-use std::raw::{self, Repr};
 
 pub trait HexDisplay {
   fn offset(&self, second:&[u8]) -> usize;
@@ -15,10 +14,10 @@ static CHARS: &'static[u8] = b"0123456789abcdef";
 
 impl HexDisplay for [u8] {
   fn offset(&self, second:&[u8]) -> usize {
-    let fst: raw::Slice<u8> = self.repr();
-    let snd: raw::Slice<u8> = second.repr();
+    let fst = self.as_ptr();
+    let snd = second.as_ptr();
 
-    snd.data as usize - fst.data as usize
+    snd as usize - fst as usize
   }
 
   #[allow(unused_variables)]


### PR DESCRIPTION
Remove dependency from core by not using Repr,
but direct pointer access instead.