### PR TITLE
Replace usage of push_all and resize with extend

### DIFF
--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -8,7 +8,6 @@
 //! This consumer will take 4 samples from the input, print them, then stop
 //!
 //! ```rust
-//! #![feature(io)]
 //!  use nom::{IResult,Needed,MemProducer,Consumer,ConsumerState};
 //!  use std::str;
 //!  use std::io::SeekFrom;
@@ -113,7 +112,7 @@ pub trait Consumer {
         let mut tmp = Vec::new();
         //println!("before:\n{}", acc.to_hex(16));
         //println!("after:\n{}", (&acc[consumed..acc.len()]).to_hex(16));
-        tmp.push_all(&acc[consumed..acc.len()]);
+        tmp.extend(acc[consumed..acc.len()].iter().cloned());
         acc.clear();
         acc = tmp;
       } else {
@@ -124,7 +123,7 @@ pub trait Consumer {
           acc.clear();
         } else {
           let mut tmp = Vec::new();
-          tmp.push_all(&acc[consumed..acc.len()]);
+          tmp.extend(acc[consumed..acc.len()].iter().cloned());
           acc.clear();
           acc = tmp;
         }
@@ -134,7 +133,7 @@ pub trait Consumer {
           match state {
             Data(v) => {
               //println!("got data: {} bytes", v.len());
-              acc.push_all(v);
+              acc.extend(v.iter().cloned());
               position = position + v.len();
             },
             Eof(v) => {
@@ -146,7 +145,7 @@ pub trait Consumer {
               } else {
                 //println!("eof with {} bytes", v.len());
                 eof = true;
-                acc.push_all(v);
+                acc.extend(v.iter().cloned());
                 position = position + v.len();
                 break;
               }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,6 @@
 //! ```
 //!
 
-#![feature(collections)]
-
 pub use self::util::*;
 pub use self::internal::*;//{IResult, IResultClosure, GetInput, GetOutput};
 pub use self::map::*;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,3 @@
-extern crate collections;
-
 #[macro_export]
 macro_rules! closure (
     ($ty:ty, $submac:ident!( $($args:tt)* )) => (

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -6,8 +6,6 @@
 //! but the macros system makes no promises.
 //!
 
-extern crate collections;
-
 use std::fmt::Debug;
 use internal::*;
 use internal::IResult::*;

--- a/tests/mp4.rs
+++ b/tests/mp4.rs
@@ -1,4 +1,3 @@
-#![feature(log_syntax,trace_macros)]
 #![allow(dead_code)]
 
 #[macro_use]

--- a/tests/test1.rs
+++ b/tests/test1.rs
@@ -1,5 +1,3 @@
-#![feature(collections,slice_patterns)]
-
 #[macro_use]
 extern crate nom;
 


### PR DESCRIPTION
This allows removal of the collections feature gate.

Builds and tests on beta-1.0.0.

Please note that extend is slower then `push_all` currently: https://github.com/rust-lang/rust/issues/24028#issuecomment-89455384, but the error message says that extend will probably be the future way to go.