### PR TITLE
Don't use "pub mod" and reexports at the same time.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! use nom::{Consumer,ConsumerState,MemProducer,IResult};
 //! use nom::IResult::*;
-//! 
+//!
 //! // Parser definition
 //!
 //! named!( om_parser,                   tag!( "om" ) );
@@ -130,15 +130,15 @@ pub use self::consumer::*;//{ConsumerState,Consumer};
 
 pub use self::nom::*;
 
-#[macro_use] pub mod util;
-pub mod internal;
-#[macro_use] pub mod macros;
+#[macro_use] mod util;
+mod internal;
+#[macro_use] mod macros;
 
 #[macro_use]
 #[cfg(not(feature = "core"))]
-pub mod producer;
+mod producer;
 #[cfg(not(feature = "core"))]
-pub mod consumer;
+mod consumer;
 
-#[macro_use] pub mod nom;
+#[macro_use] mod nom;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -238,7 +238,7 @@ macro_rules! tag (
   ($i:expr, $inp: expr) => (
     {
       #[inline(always)]
-      fn as_bytes<T: $crate::util::AsBytes>(b: &T) -> &[u8] {
+      fn as_bytes<T: $crate::AsBytes>(b: &T) -> &[u8] {
         b.as_bytes()
       }
 
@@ -724,7 +724,7 @@ macro_rules! is_not(
   ($input:expr, $arr:expr) => (
     {
       #[inline(always)]
-      fn as_bytes<T: $crate::util::AsBytes>(b: &T) -> &[u8] {
+      fn as_bytes<T: $crate::AsBytes>(b: &T) -> &[u8] {
         b.as_bytes()
       }
 
@@ -772,7 +772,7 @@ macro_rules! is_a(
   ($input:expr, $arr:expr) => (
     {
       #[inline(always)]
-      fn as_bytes<T: $crate::util::AsBytes>(b: &T) -> &[u8] {
+      fn as_bytes<T: $crate::AsBytes>(b: &T) -> &[u8] {
         b.as_bytes()
       }
 
@@ -1498,7 +1498,7 @@ macro_rules! take_until_and_consume(
   ($i:expr, $inp:expr) => (
     {
       #[inline(always)]
-      fn as_bytes<T: $crate::util::AsBytes>(b: &T) -> &[u8] {
+      fn as_bytes<T: $crate::AsBytes>(b: &T) -> &[u8] {
         b.as_bytes()
       }
 
@@ -1537,7 +1537,7 @@ macro_rules! take_until(
   ($i:expr, $inp:expr) => (
     {
       #[inline(always)]
-      fn as_bytes<T: $crate::util::AsBytes>(b: &T) -> &[u8] {
+      fn as_bytes<T: $crate::AsBytes>(b: &T) -> &[u8] {
         b.as_bytes()
       }
 
@@ -1576,7 +1576,7 @@ macro_rules! take_until_either_and_consume(
   ($i:expr, $inp:expr) => (
     {
       #[inline(always)]
-      fn as_bytes<T: $crate::util::AsBytes>(b: &T) -> &[u8] {
+      fn as_bytes<T: $crate::AsBytes>(b: &T) -> &[u8] {
         b.as_bytes()
       }
 
@@ -1617,7 +1617,7 @@ macro_rules! take_until_either(
   ($i:expr, $inp:expr) => (
     {
       #[inline(always)]
-      fn as_bytes<T: $crate::util::AsBytes>(b: &T) -> &[u8] {
+      fn as_bytes<T: $crate::AsBytes>(b: &T) -> &[u8] {
         b.as_bytes()
       }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -138,7 +138,7 @@ macro_rules! dbg (
 macro_rules! dbg_dmp (
   ($i: expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use $crate::util::HexDisplay;
+      use $crate::HexDisplay;
       let l = line!();
       match $submac!($i, $($args)*) {
         $crate::IResult::Error(a) => {


### PR DESCRIPTION
This makes rustdoc inline everything that is re-exported into the crate root,
making it easier to see what can be used.