### PR TITLE
Fix missing $ in the second form of the tap! macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1045,7 +1045,7 @@ macro_rules! tap (
     }
   );
   ($i:expr, $name: ident: $f:expr => $e:expr) => (
-    tap!($i, $name: call!(f) => $e);
+    tap!($i, $name: call!($f) => $e);
   );
 );
 


### PR DESCRIPTION
I was trying to check what a length_value! parser was doing, and ended up turning this
```rust
fields: length_value!(be_u16, fielddesc) ~ // fields
```
into this
```rust
 len: tap!(d: be_u16 => { println!("got {} fields", d) }) ~                                                                                                                   
 fields: count!(fielddesc, len as usize) ~ // fields
```
but got the following error
```
<nom macros>:11:33: 11:34 error: unresolved name `f`. Did you mean `i`? [E0425]
<nom macros>:11 tap ! ( $ i , $ name : call ! ( f ) => $ e ) ; ) ;
```
This pull request fixes the (trivial) issue.