### PR TITLE
Remove `filter!`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Here are the basic macros available:
 - **tag!**: will match the byte array provided as argument
 - **is_not!**: will match the longest array not containing any of the bytes of the array provided to the macro
 - **is_a!**: will match the longest array containing only bytes of the array provided to the macro
-- **filter!**: will walk the whole array and apply the closure to each suffix until the function fails
+- **take_while!**: will walk the whole array and apply the closure to each suffix until the function fails
 - **take!**: will take as many bytes as the number provided
 - **take_until!**: will take as many bytes as possible until it encounters the provided byte array, and will leave it in the remaining input
 - **take_until_and_consume!**: will take as many bytes as possible until it encounters the provided byte array, and will skip it

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -531,9 +531,9 @@ mod tests {
 
   #[cfg(feature = "nightly")]
   #[bench]
-  fn filter(b: &mut Bencher) {
+  fn take_while(b: &mut Bencher) {
     use nom::is_alphabetic;
-    named!(f, filter!(is_alphabetic));
+    named!(f, take_while!(is_alphabetic));
     b.iter(|| {
       f(&b"abcdefghijklABCDEejfrfrjgro12aa"[..])
     });

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -130,30 +130,6 @@ macro_rules! is_a(
   );
 );
 
-/// `filter!(&[T] -> bool) => &[T] -> IResult<&[T], &[T]>`
-/// returns the longest list of bytes until the provided function fails.
-///
-/// The argument is either a function `&[T] -> bool` or a macro returning a `bool
-#[macro_export]
-macro_rules! filter(
-  ($input:expr, $submac:ident!( $($args:tt)* )) => (
-    {
-      match $input.iter().position(|c| !$submac!(*c, $($args)*)) {
-        Some(n) => {
-          let res = $crate::IResult::Done(&$input[n..], &$input[..n]);
-          res
-        },
-        None    => {
-          $crate::IResult::Done(&b""[..], $input)
-        }
-      }
-    }
-  );
-  ($input:expr, $f:expr) => (
-    filter!($input, call!($f));
-  );
-);
-
 /// `take_while!(&[T] -> bool) => &[T] -> IResult<&[T], &[T]>`
 /// returns the longest list of bytes until the provided function fails.
 ///

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -134,18 +134,6 @@ macro_rules! is_a(
 /// returns the longest list of bytes until the provided function fails.
 ///
 /// The argument is either a function `&[T] -> bool` or a macro returning a `bool
-///
-/// ```
-/// # #[macro_use] extern crate nom;
-/// # use nom::IResult::Done;
-/// # use nom::is_alphanumeric;
-/// # fn main() {
-///  named!( alpha, filter!( is_alphanumeric ) );
-///
-///  let r = alpha(&b"abcd\nefgh"[..]);
-///  assert_eq!(r, Done(&b"\nefgh"[..], &b"abcd"[..]));
-/// # }
-/// ```
 #[macro_export]
 macro_rules! filter(
   ($input:expr, $submac:ident!( $($args:tt)* )) => (
@@ -170,6 +158,18 @@ macro_rules! filter(
 /// returns the longest list of bytes until the provided function fails.
 ///
 /// The argument is either a function `&[T] -> bool` or a macro returning a `bool
+///
+/// ```
+/// # #[macro_use] extern crate nom;
+/// # use nom::IResult::Done;
+/// # use nom::is_alphanumeric;
+/// # fn main() {
+///  named!( alpha, take_while!( is_alphanumeric ) );
+///
+///  let r = alpha(&b"abcd\nefgh"[..]);
+///  assert_eq!(r, Done(&b"\nefgh"[..], &b"abcd"[..]));
+/// # }
+/// ```
 #[macro_export]
 macro_rules! take_while (
   ($input:expr, $submac:ident!( $($args:tt)* )) => (

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -46,10 +46,10 @@
 //!
 //! Combinators must have a specific variant for
 //! non-macro arguments. Example: passing a function
-//! to filter! instead of another combinator.
+//! to take_while! instead of another combinator.
 //!
 //! ```ignore
-//! macro_rules! filter(
+//! macro_rules! take_while(
 //!   ($input:expr, $submac:ident!( $($args:tt)* )) => (
 //!     {
 //!       ...
@@ -58,7 +58,7 @@
 //!
 //!   // wrap the function in a macro to pass it to the main implementation
 //!   ($input:expr, $f:expr) => (
-//!     filter!($input, call!($f));
+//!     take_while!($input, call!($f));
 //!   );
 //! );
 //!


### PR DESCRIPTION
As mented in issue #83, there was a need to rename the `filter!` macro. So I look into it and found that both [`filter!`][filter] and [`take_while!`][take_while] are one in the same. Removing `filter!` out right seems like the logical thing to do and just use `take_while!` instead.

[filter]: https://github.com/Geal/nom/blob/master/src/bytes.rs#L149
[take_while]: https://github.com/Geal/nom/blob/master/src/bytes.rs#L173