### PR TITLE
Fix `FileProducer` passing an empty slice as input

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -322,7 +322,15 @@ impl<'x> Producer<'x,&'x [u8],Move> for FileProducer {
       //println!("producer state: {:?}", self.state);
       match self.state {
         FileProducerState::Normal => consumer.handle(Input::Element(&self.v[self.start..self.end])),
-        FileProducerState::Eof    => consumer.handle(Input::Eof(Some(&self.v[self.start..self.end]))),
+        FileProducerState::Eof    => {
+          let slice = &self.v[self.start..self.end];
+
+          if slice.is_empty() {
+            consumer.handle(Input::Eof(None))
+          } else {
+            consumer.handle(Input::Eof(Some(slice)))
+          }
+        }
         // is it right?
         FileProducerState::Error  => consumer.state()
       }


### PR DESCRIPTION
I found a bug where `FileProducer` will always return `Input::Eof(Some(_))` even when the slice is empty.

Also, just to let you know, the travis test is reporting the build as passing even when the test `stream::tests::seeking_consumer` is failing because it can't find a file named `testfile.txt`.