### PR TITLE
Proof of concept: change default error bound to Box<std::error::Error>

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -6,6 +6,7 @@ use util::ErrorKind;
 #[cfg(feature = "core")]
 use std::prelude::v1::*;
 use std::boxed::Box;
+use std::error;
 
 /*
 /// (Experimental) Closure used to hold the temporary state of resumable parsing
@@ -38,9 +39,9 @@ impl<'a,I:Eq,O:Eq> Eq for IResultClosure<'a,I,O> {}
 /// Contains the error that a parser can return
 ///
 /// It can represent a linked list of errors, indicating the path taken in the parsing tree, with corresponding position in the input data.
-/// It depends on P, the input position (for a &[u8] parser, it would be a &[u8]), and E, the custom error type (by default, u32)
+/// It depends on P, the input position (for a &[u8] parser, it would be a &[u8]), and E, the custom error type (by default, Box<std::error::Error>)
 #[derive(Debug,PartialEq,Eq,Clone)]
-pub enum Err<P,E=u32>{
+pub enum Err<P,E=Box<error::Error>>{
   /// An error code, represented by an ErrorKind, which can contain a custom error code represented by E
   Code(ErrorKind<E>),
   /// An error code, and the next error
@@ -65,7 +66,7 @@ pub enum Needed {
 /// It depends on I, the input type, O, the output type, and E, the error type (by default u32)
 ///
 #[derive(Debug,PartialEq,Eq,Clone)]
-pub enum IResult<I,O,E=u32> {
+pub enum IResult<I,O,E=Box<error::Error>> {
    /// indicates a correct parsing, the first field containing the rest of the unparsed data, the second field contains the parsed data
   Done(I,O),
   /// contains a Err, an enum that can indicate an error code, a position in the input, and a pointer to another error, making a list of errors in the parsing tree

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 use std::prelude::v1::*;
 use std::vec::Vec;
 use std::string::ToString;
+use std::error;
+use std::hash::Hash;
 
 /// useful functions to calculate the offset between slices and show a hexdump of a slice
 #[cfg(not(feature = "core"))]
@@ -194,8 +196,9 @@ macro_rules! dbg_dmp (
   );
 );
 
-pub fn error_to_list<P>(e:&Err<P>) -> Vec<ErrorKind> {
-  let mut v:Vec<ErrorKind> = Vec::new();
+pub fn error_to_list<P, E>(e: &Err<P, E>) -> Vec<ErrorKind<E>>
+where ErrorKind<E>: Clone {
+  let mut v:Vec<ErrorKind<E>> = Vec::new();
   let mut err = e;
   loop {
     match *err {
@@ -211,12 +214,14 @@ pub fn error_to_list<P>(e:&Err<P>) -> Vec<ErrorKind> {
   }
 }
 
-pub fn compare_error_paths<P>(e1:&Err<P>, e2:&Err<P>) -> bool {
+pub fn compare_error_paths<P, E>(e1:&Err<P, E>, e2:&Err<P, E>) -> bool
+where ErrorKind<E>: Clone + PartialEq<ErrorKind<E>> {
   error_to_list(e1) == error_to_list(e2)
 }
 
 #[cfg(not(feature = "core"))]
-pub fn add_error_pattern<'a,I,O>(h: &mut HashMap<Vec<ErrorKind>, &'a str>, res: IResult<I,O>, message: &'a str) -> bool {
+pub fn add_error_pattern<'a,I,O,E>(h: &mut HashMap<Vec<ErrorKind<E>>, &'a str>, res: IResult<I,O,E>, message: &'a str) -> bool
+where ErrorKind<E>: Clone + Eq + Hash {
   if let IResult::Error(e) = res {
     h.insert(error_to_list(&e), message);
     true
@@ -236,7 +241,7 @@ pub fn slice_to_offsets(input: &[u8], s: &[u8]) -> (usize, usize) {
 pub fn prepare_errors<O>(input: &[u8], res: IResult<&[u8],O>) -> Option<Vec<(ErrorKind, usize, usize)> > {
   if let IResult::Error(e) = res {
     let mut v:Vec<(ErrorKind, usize, usize)> = Vec::new();
-    let mut err = e.clone();
+    let mut err = e;
     loop {
       match err {
         Err::Position(i,s)            => {
@@ -499,7 +504,7 @@ array_impls! {
 
 /// indicates which parser returned an error
 #[derive(Debug,PartialEq,Eq,Hash,Clone)]
-pub enum ErrorKind<E=u32> {
+pub enum ErrorKind<E=Box<error::Error>> {
   Custom(E),
   Tag,
   MapRes,


### PR DESCRIPTION
OK here is a proof of concept of what it would take to change the default error bound from `u32` to `Box<std::error::Error>`.  The crate compiles, but the tests are failing to compile because most of them implicitly depend on the default `Err` type being `Eq`, which it no longer is.  You can see a few places in `util` where I had to make explicit some of those trait bounds.

The biggest issue I see with this is that `std::error::Error` is not part of core.  However, neither is `Box`, and that is already being used as part of `Err`, so I'm not really sure core is supported anyway.

I'm happy to fix up the tests if you think this is worth pursuing.
