### PR TITLE
Fix seeking_consumer test to use a file that exists

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -961,7 +961,7 @@ mod tests {
 
   #[test]
   fn seeking_consumer() {
-    let mut f = FileProducer::new("testfile.txt", 200).unwrap();
+    let mut f = FileProducer::new("LICENSE", 200).unwrap();
     f.refill();
 
     let mut a  = SeekingConsumer { state: ConsumerState::Continue(Move::Consume(0)), position: SeekState::Begin };


### PR DESCRIPTION
This test was failing for me because it was trying to use a nonexistent file.