### PR TITLE
Add AtEof trait to determine when input has finished.

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -56,7 +56,7 @@ macro_rules! bits_impl (
         $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
         $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
           //println!("bits parser returned Needed::Size({})", i);
-          $crate::IResult::Incomplete($crate::Needed::Size(i / 8 + 1))
+          $crate::need_more($i, $crate::Needed::Size(i / 8 + 1))
         },
         $crate::IResult::Done((i, bit_index), o)             => {
           let byte_index = bit_index / 8 + if bit_index % 8 == 0 { 0 } else { 1 } ;
@@ -97,7 +97,7 @@ macro_rules! take_bits (
         let cnt = ($count as usize + bit_offset).div(8);
         if input.len() * 8 < $count as usize + bit_offset {
           //println!("returning incomplete: {}", $count as usize + bit_offset);
-          $crate::IResult::Incomplete($crate::Needed::Size($count as usize))
+          $crate::need_more($i, $crate::Needed::Size($count as usize))
         } else {
           let mut acc:$t            = 0;
           let mut offset: usize     = bit_offset;

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -78,7 +78,7 @@ macro_rules! tag_bytes (
       let res : $crate::IResult<&[u8],&[u8]> = if reduced != b {
         $crate::IResult::Error($crate::Err::Position($crate::ErrorKind::Tag, $i))
       } else if m < blen {
-        $crate::IResult::Incomplete($crate::Needed::Size(blen))
+        $crate::need_more($i, $crate::Needed::Size(blen))
       } else {
         $crate::IResult::Done(&$i[blen..], reduced)
       };
@@ -510,7 +510,7 @@ macro_rules! take(
     {
       let cnt = $count as usize;
       let res: $crate::IResult<&[u8],&[u8]> = if $i.len() < cnt {
-        $crate::IResult::Incomplete($crate::Needed::Size(cnt))
+        $crate::need_more($i, $crate::Needed::Size(cnt))
       } else {
         $crate::IResult::Done(&$i[cnt..],&$i[0..cnt])
       };
@@ -549,7 +549,7 @@ macro_rules! take_until_and_consume_bytes (
   ($i:expr, $bytes:expr) => (
     {
       let res: $crate::IResult<&[u8],&[u8]> = if $bytes.len() > $i.len() {
-        $crate::IResult::Incomplete($crate::Needed::Size($bytes.len()))
+        $crate::need_more($i, $crate::Needed::Size($bytes.len()))
       } else {
         let mut index  = 0;
         let mut parsed = false;
@@ -600,7 +600,7 @@ macro_rules! take_until_bytes(
   ($i:expr, $bytes:expr) => (
     {
       let res: $crate::IResult<&[u8],&[u8]> = if $bytes.len() > $i.len() {
-        $crate::IResult::Incomplete($crate::Needed::Size($bytes.len()))
+        $crate::need_more($i, $crate::Needed::Size($bytes.len()))
       } else {
         let mut index  = 0;
         let mut parsed = false;
@@ -651,7 +651,7 @@ macro_rules! take_until_either_and_consume_bytes(
   ($i:expr, $bytes:expr) => (
     {
       let res: $crate::IResult<&[u8],&[u8]> = if 1 > $i.len() {
-        $crate::IResult::Incomplete($crate::Needed::Size(1))
+        $crate::need_more($i, $crate::Needed::Size(1))
       } else {
         let mut index  = 0;
         let mut parsed = false;
@@ -704,7 +704,7 @@ macro_rules! take_until_either_bytes(
   ($i:expr, $bytes:expr) => (
     {
       let res: $crate::IResult<&[u8],&[u8]> = if 1 > $i.len() {
-        $crate::IResult::Incomplete($crate::Needed::Size(1))
+        $crate::need_more($i, $crate::Needed::Size(1))
       } else {
         let mut index  = 0;
         let mut parsed = false;
@@ -748,7 +748,7 @@ macro_rules! length_bytes(
         $crate::IResult::Done(i1,nb)   => {
           let length_remaining = i1.len();
           if length_remaining < nb {
-            $crate::IResult::Incomplete(Needed::Size(nb - length_remaining))
+            $crate::need_more($i, Needed::Size(nb - length_remaining))
           } else {
             $crate::IResult::Done(&i1[nb..], &i1[..nb])
           }

--- a/src/character.rs
+++ b/src/character.rs
@@ -1,7 +1,7 @@
 /// Character level parsers
 
 use internal::{IResult,Needed,Err};
-use util::ErrorKind;
+use util::{ErrorKind, need_more};
 
 /// matches one of the provided characters
 #[macro_export]
@@ -9,7 +9,7 @@ macro_rules! one_of (
   ($i:expr, $inp: expr) => (
     {
       if $i.is_empty() {
-        $crate::IResult::Incomplete($crate::Needed::Size(1))
+        $crate::need_more($i, $crate::Needed::Size(1))
       } else {
         #[inline(always)]
         fn as_bytes<T: $crate::AsBytes>(b: &T) -> &[u8] {
@@ -29,7 +29,7 @@ macro_rules! one_of_bytes (
   ($i:expr, $bytes: expr) => (
     {
       if $i.is_empty() {
-        $crate::IResult::Incomplete($crate::Needed::Size(1))
+        $crate::need_more($i, $crate::Needed::Size(1))
       } else {
         let mut found = false;
 
@@ -56,7 +56,7 @@ macro_rules! none_of (
   ($i:expr, $inp: expr) => (
     {
       if $i.is_empty() {
-        $crate::IResult::Incomplete($crate::Needed::Size(1))
+        $crate::need_more($i, $crate::Needed::Size(1))
       } else {
         #[inline(always)]
         fn as_bytes<T: $crate::AsBytes>(b: &T) -> &[u8] {
@@ -76,7 +76,7 @@ macro_rules! none_of_bytes (
   ($i:expr, $bytes: expr) => (
     {
       if $i.is_empty() {
-        $crate::IResult::Incomplete($crate::Needed::Size(1))
+        $crate::need_more($i, $crate::Needed::Size(1))
       } else {
         let mut found = false;
 
@@ -103,7 +103,7 @@ macro_rules! char (
   ($i:expr, $c: expr) => (
     {
       if $i.is_empty() {
-        let res: $crate::IResult<&[u8], char> = $crate::IResult::Incomplete($crate::Needed::Size(1));
+        let res: $crate::IResult<&[u8], char> = $crate::need_more($i, $crate::Needed::Size(1));
         res
       } else {
         if $i[0] == $c as u8 {
@@ -120,7 +120,7 @@ named!(pub newline<char>, char!('\n'));
 
 pub fn crlf(input:&[u8]) -> IResult<&[u8], char> {
   if input.len() < 2 {
-    IResult::Incomplete(Needed::Size(2))
+    need_more(input, Needed::Size(2))
   } else {
     if &input[0..2] == &b"\r\n"[..] {
       IResult::Done(&input[2..], '\n')
@@ -135,7 +135,7 @@ named!(pub tab<char>, char!('\t'));
 
 pub fn anychar(input:&[u8]) -> IResult<&[u8], char> {
   if input.is_empty() {
-    IResult::Incomplete(Needed::Size(1))
+    need_more(input, Needed::Size(1))
   } else {
     IResult::Done(&input[1..], input[0] as char)
   }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1857,7 +1857,7 @@ macro_rules! count(
       } else if cnt == $count {
         $crate::IResult::Done(input, res)
       } else {
-        $crate::IResult::Incomplete($crate::Needed::Unknown)
+        $crate::need_more(input, $crate::Needed::Unknown)
       }
     }
   );
@@ -1922,7 +1922,7 @@ macro_rules! count_fixed (
       } else if cnt == $count {
         $crate::IResult::Done(input, res)
       } else {
-        $crate::IResult::Incomplete($crate::Needed::Unknown)
+        $crate::need_more(input, $crate::Needed::Unknown)
       }
     }
   );
@@ -2048,7 +2048,7 @@ mod tests {
         let bytes = as_bytes(&expected);
 
         let res : $crate::IResult<&[u8],&[u8]> = if bytes.len() > $i.len() {
-          $crate::IResult::Incomplete($crate::Needed::Size(bytes.len()))
+          $crate::need_more($i, $crate::Needed::Size(bytes.len()))
         } else if &$i[0..bytes.len()] == bytes {
           $crate::IResult::Done(&$i[bytes.len()..], &$i[0..bytes.len()])
         } else {
@@ -2064,7 +2064,7 @@ mod tests {
       {
         let cnt = $count as usize;
         let res:$crate::IResult<&[u8],&[u8]> = if $i.len() < cnt {
-          $crate::IResult::Incomplete($crate::Needed::Size(cnt))
+          $crate::need_more($i, $crate::Needed::Size(cnt))
         } else {
           $crate::IResult::Done(&$i[cnt..],&$i[0..cnt])
         };

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use internal::{IResult,Err};
+use internal::{IResult,Err,Needed};
 
 #[cfg(not(feature = "core"))]
 use std::collections::HashMap;
@@ -435,6 +435,31 @@ pub fn print_offsets(input: &[u8], from: usize, offsets: &[(ErrorKind, usize, us
   }
 
   String::from_utf8_lossy(&v[..]).into_owned()
+}
+
+pub trait AtEof {
+  fn at_eof(&self) -> bool;
+}
+
+pub fn need_more<I: AtEof, O, E=u32>(input: I, needed: Needed) -> IResult<I, O, E> {
+  if input.at_eof() {
+    IResult::Error(Err::Position(ErrorKind::Eof, input))
+  } else {
+    IResult::Incomplete(needed)
+  }
+}
+
+// Tuple for bit parsing
+impl<I: AtEof, T> AtEof for (I, T) {
+  fn at_eof(&self) -> bool { self.0.at_eof() }
+}
+
+impl<'a> AtEof for &'a [u8] {
+  fn at_eof(&self) -> bool { self.is_empty() }
+}
+
+impl<'a> AtEof for &'a str {
+  fn at_eof(&self) -> bool { self.is_empty() }
 }
 
 pub trait AsBytes {


### PR DESCRIPTION
This is an attempt to address issue #144.

With this trait, it becomes possible to distinguish between a partial input
and a complete input. If there's a partial input, then it makes sense to
return Incomplete, but if the input is finished then it's just a plain
Error. The need_more() function encapsulates this logic.

This is still a work in progress; it breaks a couple of unit tests, presumably because they're expecting Incomplete where now they're getting eof.
