### PR TITLE
Partial fix for using named parsers in switch! macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1157,7 +1157,7 @@ macro_rules! switch (
   );
   ($i:expr, $e:ident, $($rest:tt)*) => (
     {
-      switch!($i, call!(e), $($rest)*)
+      switch!($i, call!($e), $($rest)*)
     }
   );
 );

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -95,3 +95,17 @@ fn issue_142(){
    let expected = IResult::Done(&b" "[..], vec![12, 34, 5689]);
    assert_eq!(subject, expected)
 }
+
+#[allow(dead_code)]
+#[test]
+fn issue_switch() {
+    named!(take4, take!(4));
+    named!(xyz, tag!("XYZ"));
+    named!(abc, tag!("abc"));
+    named!(sw,
+        switch!(take4,
+            b"abcd" => xyz |
+            b"efgh" => abc
+        )
+    );
+}


### PR DESCRIPTION
This addresses part of the issue raised in #152, and adds a test case to ensure the problem is solved.
