### PR TITLE
Improve type inference of (n)one_of(_bytes).

### DIFF
--- a/src/character.rs
+++ b/src/character.rs
@@ -9,7 +9,7 @@ macro_rules! one_of (
   ($i:expr, $inp: expr) => (
     {
       if $i.is_empty() {
-        $crate::IResult::Incomplete($crate::Needed::Size(1))
+        $crate::IResult::Incomplete::<_, _>($crate::Needed::Size(1))
       } else {
         #[inline(always)]
         fn as_bytes<T: $crate::AsBytes>(b: &T) -> &[u8] {
@@ -29,7 +29,7 @@ macro_rules! one_of_bytes (
   ($i:expr, $bytes: expr) => (
     {
       if $i.is_empty() {
-        $crate::IResult::Incomplete($crate::Needed::Size(1))
+        $crate::IResult::Incomplete::<_, _>($crate::Needed::Size(1))
       } else {
         let mut found = false;
 
@@ -56,7 +56,7 @@ macro_rules! none_of (
   ($i:expr, $inp: expr) => (
     {
       if $i.is_empty() {
-        $crate::IResult::Incomplete($crate::Needed::Size(1))
+        $crate::IResult::Incomplete::<_, _>($crate::Needed::Size(1))
       } else {
         #[inline(always)]
         fn as_bytes<T: $crate::AsBytes>(b: &T) -> &[u8] {
@@ -76,7 +76,7 @@ macro_rules! none_of_bytes (
   ($i:expr, $bytes: expr) => (
     {
       if $i.is_empty() {
-        $crate::IResult::Incomplete($crate::Needed::Size(1))
+        $crate::IResult::Incomplete::<_, _>($crate::Needed::Size(1))
       } else {
         let mut found = false;
 


### PR DESCRIPTION
I was playing with nom earlier today, and found that the following doesn't compile:
```
many1!(one_of_bytes!(b"0123456789ABCDEFabcdef"))
```
I tracked this down to some unusual behavior in the type inferencer, which I don't really understand. Basically, adding the `_` type parameter causes the inferencer to correctly determine the type, so that the above (and similar variants) compile.

You can see an extracted version of the same problem here: http://is.gd/fuSl3z

Since I don't really understand the fix, I'm not sure you should merge this. But I assume a pull request is more useful than a bug report.