### PR TITLE
Added Unicode support to the str module

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1260,7 +1260,7 @@ macro_rules! peek(
     }
   );
   ($i:expr, $f:expr) => (
-    peek!($i, call!(f));
+    peek!($i, call!($f));
   );
 );
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -547,6 +547,7 @@ pub enum ErrorKind<E=u32> {
   IsNotStr,
   IsAStr,
   TakeWhile1Str,
+  TakeUntilAndConsumeStr,
 }
 
 pub fn error_to_u32(e: &ErrorKind) -> u32 {
@@ -598,5 +599,6 @@ pub fn error_to_u32(e: &ErrorKind) -> u32 {
     ErrorKind::IsNotStr                  => 53,
     ErrorKind::IsAStr                    => 54,
     ErrorKind::TakeWhile1Str             => 55,
+    ErrorKind::TakeUntilAndConsumeStr    => 56,
   }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -614,6 +614,7 @@ pub enum ErrorKind<E=u32> {
   NonEmpty,
   ManyMN,
   TakeUntilAndConsumeStr,
+  TakeUntilStr,
 }
 
 pub fn error_to_u32(e: &ErrorKind) -> u32 {
@@ -668,5 +669,6 @@ pub fn error_to_u32(e: &ErrorKind) -> u32 {
     ErrorKind::NonEmpty                  => 56,
     ErrorKind::ManyMN                    => 57,
     ErrorKind::TakeUntilAndConsumeStr    => 58,
+    ErrorKind::TakeUntilStr              => 59,
   }
 }


### PR DESCRIPTION
As I was going in to add `take_while_s` and `take_while_and_consume_s` macros to the `str` module, I noticed that `str` character offsets were being used to offset into arrays of bytes (e.g.):

```rust
// position() returns character offsets
match $input.chars().position(|c| !$submac!(c, $($args)*)) {
          Some(0) => $crate::IResult::Error($crate::Err::Position($crate::ErrorKind::TakeWhile1Str,$input)),
          Some(n) => {
            let res = $crate::IResult::Done(&$input[n..], &$input[..n]);
                                         // &str[..n] takes byte offsets
// ...snip
```
The `position` function returns a character offset into the `str`, but `&str[..offset]` and `&str[offset..]` take byte offsets.

Now, for ASCII characters this is not a problem because `sizeof(char) == sizeof(byte)`, but for non-ASCII characters the sizes aren't equal; Unicode characters can be from 1 to 4 bytes. The result is that if you run these macros with non-ASCII strings it returns parsed slices that are smaller than expected.

Example:

`$input = "ÒA🀝z5"`

byte index |` 0 `|` 1 `|` 2 `|` 3 `|` 4 `|` 5 `|` 6 `|` 7 `
--------------|---|---|---|---|---|---|---|---
character  |`Ò`|  |`A`|`🀝`|   |   |`z`|`5` 
**char index**|**`0`**|   |**`1`**|**`2`**|   |   |**`3`**|**`4`**

If you got the character position of `'z'`, 3, and then created the slices `&*$input[..3]` and `&*$input[3..]` you would end up with `"ÒA"` and `"🀝z5"` instead of the intended `"ÒA🀝"` and `"z5"`. Even worse if it is split on the `'5'` the strings wouldn't even end and begin on Unicode character boundaries and the resulting `str` slices would be totally messed up.

The good news is that I fixed all the `str` module macros  to use byte offsets that line up with character boundaries.  I used `str.chars().char_indices()` to get the byte offset of each character while keeping track of the number of characters when needed. Then i used the byte offset to create `str` slices. I had to do this for every `str` macro except `tag_s` which works fine as-is, then I  added the `take_while_s` and `take_while_and_consume_s` macros and added test functions for all macros that currently don't have any. Then I ran my [tomllib](https://github.com/joelself/toml_parser), which uses the `str` module and 'regex_macros' exclusively, against [this new hard TOML file I produced](https://github.com/joelself/toml/blob/master/tests/hard_example_unicode.toml) and it parsed and reproduced the file perfectly, so everything seems to work just fine.

There are two other minor things I changed:
* In macros.rs line 1366 `peek!($i, call!(f));` was missing a `$` before the `f` so I added one.
* `is_not_s` and `is_a_s` loop through the entire `$arr` str for each character in the input looking for a match/non-match. This is an `O(n^2)` algorithm. I put `$arr`'s characters into a `HashSet` so each comparison against `$arr`'s chars would be `O(1)` making the overall algorithm `O(n)`.

One thing about the `use std::collections::HashSet;` statement. I tried putting it everywhere, but no matter where I put it, the compiler would complain that `HashSet` isn't defined. The only way i could get it to work was to put the declaration directly inside the macros themselves which just doesn't seem right...but works. If there's a better way to do this then please change it and please tell me what I need to do to to get this right in the future.

Thanks.