### PR TITLE
Fixes #171 - alpha, digit, ... return proper value on no match

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -769,6 +769,7 @@ mod tests {
   use internal::IResult::*;
   use internal::Err::*;
   use util::ErrorKind;
+  use nom::{alpha, digit, alphanumeric, space, multispace};
 
   #[test]
   fn is_a() {
@@ -810,7 +811,6 @@ mod tests {
     assert_eq!(a_or_b(f), Done(&b""[..], &b"fghi"[..]));
   }
 
-  use nom::alpha;
   #[test]
   fn escaping() {
     named!(esc, escaped!(call!(alpha), '\\', is_a_bytes!(&b"\"n\\"[..])));
@@ -926,6 +926,28 @@ mod tests {
     named!(x, recognize!(delimited!(tag!("<!--"), take!(5), tag!("-->"))));
     let r = x(&b"<!-- abc --> aaa"[..]);
     assert_eq!(r, Done(&b" aaa"[..], &b"<!-- abc -->"[..]));
+
+    let empty = &b""[..];
+
+    named!(ya, recognize!(alpha));
+    let ra = ya(&b"abc"[..]);
+    assert_eq!(ra, Done(empty, &b"abc"[..]));
+
+    named!(yd, recognize!(digit));
+    let rd = yd(&b"123"[..]);
+    assert_eq!(rd, Done(empty, &b"123"[..]));
+
+    named!(yan, recognize!(alphanumeric));
+    let ran = yan(&b"123abc"[..]);
+    assert_eq!(ran, Done(empty, &b"123abc"[..]));
+
+    named!(ys, recognize!(space));
+    let rs = ys(&b" \t"[..]);
+    assert_eq!(rs, Done(empty, &b" \t"[..]));
+
+    named!(yms, recognize!(multispace));
+    let rms = yms(&b" \t\r\n"[..]);
+    assert_eq!(rms, Done(empty, &b" \t\r\n"[..]));
   }
 
   #[test]

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -528,6 +528,37 @@ mod tests {
     assert_eq!(space(e), Done(&""[..], &" "[..]));
   }
 
+  use util::HexDisplay;
+  #[test]
+  fn offset() {
+    let a = &b"abcd"[..];
+    let b = &b"1234"[..];
+    let c = &b"a123"[..];
+    let d = &b" \t"[..];
+    let e = &b" \t\r\n"[..];
+
+    match alpha(a) {
+        Done(i, _)  => { assert_eq!(a.offset(i) + i.len(), a.len()); }
+        _           => { }
+    }
+    match digit(b) {
+        Done(i, _)  => { assert_eq!(b.offset(i) + i.len(), b.len()); }
+        _           => { }
+    }
+    match alphanumeric(c) {
+        Done(i, _)  => { assert_eq!(c.offset(i) + i.len(), c.len()); }
+        _           => { }
+    }
+    match space(d) {
+        Done(i, _)  => { assert_eq!(d.offset(i) + i.len(), d.len()); }
+        _           => { }
+    }
+    match multispace(e) {
+        Done(i, _)  => { assert_eq!(e.offset(i) + i.len(), e.len()); }
+        _           => { }
+    }
+  }
+
   #[test]
   fn is_not() {
     let a: &[u8] = b"ab12cd\nefgh";

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -539,23 +539,23 @@ mod tests {
 
     match alpha(a) {
         Done(i, _)  => { assert_eq!(a.offset(i) + i.len(), a.len()); }
-        _           => { }
+        _           => { panic!("wrong return type in offset test for alpha") }
     }
     match digit(b) {
         Done(i, _)  => { assert_eq!(b.offset(i) + i.len(), b.len()); }
-        _           => { }
+        _           => { panic!("wrong return type in offset test for digit") }
     }
     match alphanumeric(c) {
         Done(i, _)  => { assert_eq!(c.offset(i) + i.len(), c.len()); }
-        _           => { }
+        _           => { panic!("wrong return type in offset test for alphanumeric") }
     }
     match space(d) {
         Done(i, _)  => { assert_eq!(d.offset(i) + i.len(), d.len()); }
-        _           => { }
+        _           => { panic!("wrong return type in offset test for space") }
     }
     match multispace(e) {
         Done(i, _)  => { assert_eq!(e.offset(i) + i.len(), e.len()); }
-        _           => { }
+        _           => { panic!("wrong return type in offset test for multispace") }
     }
   }
 

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -92,7 +92,8 @@ use std::ops::{Index,Range,RangeFrom};
 pub fn alpha<'a, T: ?Sized>(input:&'a T) -> IResult<&'a T, &'a T> where
     T:Index<Range<usize>, Output=T>+Index<RangeFrom<usize>, Output=T>,
     &'a T: IterIndices+InputLength {
-  if input.input_len() == 0 {
+  let input_length = input.input_len();
+  if input_length == 0 {
     return Error(Position(ErrorKind::Alpha, input))
   }
 
@@ -105,14 +106,15 @@ pub fn alpha<'a, T: ?Sized>(input:&'a T) -> IResult<&'a T, &'a T> where
       }
     }
   }
-  Done(&input[0..0], input)
+  Done(&input[input_length..], input)
 }
 
 /// Recognizes numerical characters: 0-9
 pub fn digit<'a, T: ?Sized>(input:&'a T) -> IResult<&'a T, &'a T> where
     T:Index<Range<usize>, Output=T>+Index<RangeFrom<usize>, Output=T>,
     &'a T: IterIndices+InputLength {
-  if input.input_len() == 0 {
+  let input_length = input.input_len();
+  if input_length == 0 {
     return Error(Position(ErrorKind::Digit, input))
   }
 
@@ -125,14 +127,15 @@ pub fn digit<'a, T: ?Sized>(input:&'a T) -> IResult<&'a T, &'a T> where
       }
     }
   }
-  Done(&input[0..0], input)
+  Done(&input[input_length..], input)
 }
 
 /// Recognizes numerical and alphabetic characters: 0-9a-zA-Z
 pub fn alphanumeric<'a, T: ?Sized>(input:&'a T) -> IResult<&'a T, &'a T> where
     T:Index<Range<usize>, Output=T>+Index<RangeFrom<usize>, Output=T>,
     &'a T: IterIndices+InputLength {
-  if input.input_len() == 0 {
+  let input_length = input.input_len();
+  if input_length == 0 {
     return Error(Position(ErrorKind::AlphaNumeric, input));
   }
 
@@ -145,14 +148,15 @@ pub fn alphanumeric<'a, T: ?Sized>(input:&'a T) -> IResult<&'a T, &'a T> where
       }
     }
   }
-  Done(&input[0..0], input)
+  Done(&input[input_length..], input)
 }
 
 /// Recognizes spaces and tabs
 pub fn space<'a, T: ?Sized>(input:&'a T) -> IResult<&'a T, &'a T> where
     T:Index<Range<usize>, Output=T>+Index<RangeFrom<usize>, Output=T>,
     &'a T: IterIndices+InputLength {
-  if input.input_len() == 0 {
+  let input_length = input.input_len();
+  if input_length == 0 {
     return Error(Position(ErrorKind::Space, input));
   }
 
@@ -166,14 +170,15 @@ pub fn space<'a, T: ?Sized>(input:&'a T) -> IResult<&'a T, &'a T> where
       }
     }
   }
-  Done(&input[0..0], input)
+  Done(&input[input_length..], input)
 }
 
 /// Recognizes spaces, tabs, carriage returns and line feeds
 pub fn multispace<'a, T: ?Sized>(input:&'a T) -> IResult<&'a T, &'a T> where
     T:Index<Range<usize>, Output=T>+Index<RangeFrom<usize>, Output=T>,
     &'a T: IterIndices+InputLength {
-  if input.input_len() == 0 {
+  let input_length = input.input_len();
+  if input_length == 0 {
     return Error(Position(ErrorKind::MultiSpace, input));
   }
 
@@ -187,7 +192,7 @@ pub fn multispace<'a, T: ?Sized>(input:&'a T) -> IResult<&'a T, &'a T> where
       }
     }
   }
-  Done(&input[0..0], input)
+  Done(&input[input_length..], input)
 }
 
 pub fn sized_buffer(input:&[u8]) -> IResult<&[u8], &[u8]> {


### PR DESCRIPTION
The functions `alpha`, `digit`, `alphanumeric`, `space` and
`multispace` returned `Done(&input[0..0], input)`. This was a
problem in `recognize`, because it uses the pointer offset of
`s` and `t` in the returned `Done(s, t)`. This offset would be
zero before and therefore `recognize` would return `Done([], [])`
as it was `Done(s, &t[..0])`.

Now `alpha`, etc. return `Done(&input[input_length..], input)`
and therefore `recognize` returns `Done(s, &t[..t.len()])`,
which equals `Done([], &t[..])`.

Someone should probably write a test for this.
Also this functions could be combined into a macro, since they are basically the same except one function and one error in each.