### PR TITLE
Sep list trip consume

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2806,12 +2806,14 @@ mod tests {
   #[test]
   fn separated_list() {
     named!(multi<&[u8],Vec<&[u8]> >, separated_list!(tag!(","), tag!("abcd")));
-    named!(multi_empty<&[u8],Vec<&[u8]> >, separated_list!(tag!(","), tag!("")));
+    named!(multi_empty_elems<&[u8],Vec<&[u8]> >, separated_list!(tag!(","), tag!("")));
+    named!(multi_empty_sep<&[u8],Vec<&[u8]> >, separated_list!(tag!(""), tag!("abcd")));
 
     let a = &b"abcdef"[..];
     let b = &b"abcd,abcdef"[..];
     let c = &b"azerty"[..];
     let d = &b",,abc"[..];
+    let e = &b"abcabcabcxxx"[..];
 
     let res1 = vec![&b"abcd"[..]];
     assert_eq!(multi(a), Done(&b"ef"[..], res1));
@@ -2819,7 +2821,9 @@ mod tests {
     assert_eq!(multi(b), Done(&b"ef"[..], res2));
     assert_eq!(multi(c), Done(&b"azerty"[..], Vec::new()));
     let res3 = vec![&b""[..], &b""[..], &b""[..]];
-    assert_eq!(multi_empty(d), Done(&b"abc"[..], res3));
+    assert_eq!(multi_empty_elems(d), Done(&b"abc"[..], res3));
+    let res4 = vec![&b"abc"[..], &b"abc"[..], &b"abc"[..]];
+    assert_eq!(multi_empty_sep(e), Done(&b""[..], res4));
   }
 
   #[test]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1756,8 +1756,8 @@ macro_rules! separated_list(
           $crate::IResult::Error(_)           => { return $crate::IResult::Done(input, res); },
           $crate::IResult::Incomplete(i)      => { return $crate::IResult::Incomplete(i); },
           $crate::IResult::Done(i, _)         => {
-            // separator must allways consume
-            if i == input {
+            // loop trip must always consume
+            if i == buff_sep {
               return $crate::IResult::Error($crate::Err::Position($crate::ErrorKind::SeparatedList,input));
             }
 
@@ -2807,7 +2807,7 @@ mod tests {
   fn separated_list() {
     named!(multi<&[u8],Vec<&[u8]> >, separated_list!(tag!(","), tag!("abcd")));
     named!(multi_empty_elems<&[u8],Vec<&[u8]> >, separated_list!(tag!(","), tag!("")));
-    named!(multi_empty_sep<&[u8],Vec<&[u8]> >, separated_list!(tag!(""), tag!("abcd")));
+    named!(multi_empty_sep<&[u8],Vec<&[u8]> >, separated_list!(tag!(""), tag!("abc")));
 
     let a = &b"abcdef"[..];
     let b = &b"abcd,abcdef"[..];
@@ -2823,7 +2823,7 @@ mod tests {
     let res3 = vec![&b""[..], &b""[..], &b""[..]];
     assert_eq!(multi_empty_elems(d), Done(&b"abc"[..], res3));
     let res4 = vec![&b"abc"[..], &b"abc"[..], &b"abc"[..]];
-    assert_eq!(multi_empty_sep(e), Done(&b""[..], res4));
+    assert_eq!(multi_empty_sep(e), Done(&b"xxx"[..], res4));
   }
 
   #[test]


### PR DESCRIPTION
Now you are able to have empty separators. This will only fail if

`elem.len() + sep.len() == 0`

in one loop trip.