### PR TITLE
Fix typo in `ConsumerState` docs.

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -22,7 +22,7 @@ pub enum Input<I> {
 /// Stores a consumer's current computation state
 #[derive(Debug,Clone)]
 pub enum ConsumerState<O,E=(),M=()> {
-  /// A value pf type O has been produced
+  /// A value of type O has been produced
   Done(M,O),
   /// An error of type E has been encountered
   Error(E),
@@ -51,7 +51,7 @@ impl<O:Clone,E:Copy,M:Copy> ConsumerState<O,E,M> {
 /// it depends on the input type I, the produced value's type O, the error type E, and the message type M
 pub trait Consumer<I,O,E,M> {
 
-  /// implement hndle for the current computation, returning the new state of the consumer
+  /// implement handle for the current computation, returning the new state of the consumer
   fn handle(&mut self, input: Input<I>) -> &ConsumerState<O,E,M>;
   /// returns the current state
   fn state(&self) -> &ConsumerState<O,E,M>;


### PR DESCRIPTION
Just a super small fix.