### PR TITLE
Updated tag and test macro and test overhaul

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2586,7 +2586,7 @@ mod tests {
     assert_eq!(r2, Done(&b"WXYZ"[..], C{a: 1, b: None}));
 
     let r3 = f(&b"abcdX"[..]);
-    assert_eq!(r3, Incomplete(Needed::Size(8)));
+    assert_eq!(r3, Done(&b"X"[..], C{a: 1, b: None}));
   }
 
   use util::{error_to_list, add_error_pattern, print_error};
@@ -2954,8 +2954,8 @@ mod tests {
     let c = &b"azerty"[..];
     let d = &b"abcdab"[..];
 
-    //let res1 = vec![&b"abcd"[..]];
-    assert_eq!(multi(a), Incomplete(Needed::Size(8)));
+    let res1 = vec![&b"abcd"[..]];
+    assert_eq!(multi(a), Done(&b"ef"[..], res1));
     let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
     assert_eq!(multi(b), Done(&b"efgh"[..], res2));
     assert_eq!(multi(c), Done(&b"azerty"[..], Vec::new()));
@@ -2983,8 +2983,8 @@ mod tests {
     let c = &b"azerty"[..];
     let d = &b"abcdab"[..];
 
-    //let res1 = vec![&b"abcd"[..]];
-    assert_eq!(multi(a), Incomplete(Needed::Size(8)));
+    let res1 = vec![&b"abcd"[..]];
+    assert_eq!(multi(a), Done(&b"ef"[..], res1));
     let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
     assert_eq!(multi(b), Done(&b"efgh"[..], res2));
     assert_eq!(multi(c), Error(Position(ErrorKind::Many1,c)));
@@ -3018,14 +3018,13 @@ mod tests {
     let d = &b"AbcdAbcdAbcdAbcdAbcdefgh"[..];
     let e = &b"AbcdAb"[..];
 
-    //let res1 = vec![&b"abcd"[..]];
-    assert_eq!(multi(a), Incomplete(Needed::Size(8)));
-    let res2 = vec![&b"Abcd"[..], &b"Abcd"[..]];
-    assert_eq!(multi(b), Done(&b"efgh"[..], res2));
+    assert_eq!(multi(a), Error(Err::Position(ErrorKind::ManyMN,a)));
+    let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
+    assert_eq!(multi(b), Done(&b"efgh"[..], res1));
+    let res2 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
+    assert_eq!(multi(c), Done(&b"efgh"[..], res2));
     let res3 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
-    assert_eq!(multi(c), Done(&b"efgh"[..], res3));
-    let res4 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
-    assert_eq!(multi(d), Done(&b"Abcdefgh"[..], res4));
+    assert_eq!(multi(d), Done(&b"Abcdefgh"[..], res3));
     assert_eq!(multi(e), Incomplete(Needed::Size(8)));
   }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2416,14 +2416,29 @@ mod tests {
         }
 
         let expected = $inp;
-        let bytes = as_bytes(&expected);
+        let bytes    = as_bytes(&expected);
 
-        let res : $crate::IResult<&[u8],&[u8]> = if bytes.len() > $i.len() {
-          $crate::IResult::Incomplete($crate::Needed::Size(bytes.len()))
-        } else if &$i[0..bytes.len()] == bytes {
-          $crate::IResult::Done(&$i[bytes.len()..], &$i[0..bytes.len()])
-        } else {
+        tag_bytes!($i,bytes)
+      }
+    );
+  );
+
+  macro_rules! tag_bytes (
+    ($i:expr, $bytes: expr) => (
+      {
+        use std::cmp::min;
+        let len = $i.len();
+        let blen = $bytes.len();
+        let m   = min(len, blen);
+        let reduced = &$i[..m];
+        let b       = &$bytes[..m];
+
+        let res: $crate::IResult<_,_> = if reduced != b {
           $crate::IResult::Error($crate::Err::Position($crate::ErrorKind::Tag, $i))
+        } else if m < blen {
+          $crate::IResult::Incomplete($crate::Needed::Size(blen))
+        } else {
+          $crate::IResult::Done(&$i[blen..], reduced)
         };
         res
       }


### PR DESCRIPTION
Becaus I f*cked up my git tree a little bit, I need to open this as a new PR. This is basically what was ment to be in #180 

Now the tag and take macros in the test in `macros.rs` are those from `bytes.rs` (copied). To get a better test coverage the test in `macros.rs` got a treatment. I spared some, because they might fail after an overhaul of the according macros.

Someone needs to refactor the macros to ditch circular inclusions, resp. copying code. I will make a proposal for this in the near future via a PR.

Based upon this commit I will rewrite the separeted_list and many0 macros.