### PR TITLE
recognize! sometimes panics when it leaves no more input

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -20,8 +20,12 @@ macro_rules! recognize (
       use $crate::HexDisplay;
       match $submac!($i, $($args)*) {
         $crate::IResult::Done(i,_)     => {
-          let index = ($i).offset(i);
-          $crate::IResult::Done(i, &($i)[..index])
+          if i.is_empty() {
+            $crate::IResult::Done(i, $i)
+          } else {
+            let index = ($i).offset(i);
+            $crate::IResult::Done(i, &($i)[..index])
+          }
         },
         $crate::IResult::Error(e)      => return $crate::IResult::Error(e),
         $crate::IResult::Incomplete(i) => return $crate::IResult::Incomplete(i)

--- a/tests/test1.rs
+++ b/tests/test1.rs
@@ -43,3 +43,12 @@ fn exported_public_method_defined_by_macro() {
   let a = &b"ab12cd\nefgh"[..];
   assert_eq!(not_line_ending(a), IResult::Done(&b"\nefgh"[..], &b"ab12cd"[..]));
 }
+
+#[test]
+fn recognize_leaving_empty_input() {
+  named!(number< &[u8] >,  recognize!(is_a!("0123456789")));
+
+  assert_eq!(IResult::Done(&b""[..], &b"42"[..]), number(&b"42"[..]));
+  assert_eq!(IResult::Done(&b""[..], &b"3"[..]), number(&b"3"[..]));
+  assert_eq!(IResult::Done(&b""[..], &b"0"[..]), number(&b"0"[..]));
+}


### PR DESCRIPTION
I've encountered an issue with `recognize!` panicking with:
```
---- recognize_leaving_empty_input stdout ----
	thread 'recognize_leaving_empty_input' panicked at 'arithmetic operation overflowed', src/util.rs:137
```

when applied to an input that is consumed wholly by it. I reproduced it with `is_a!`, which is where I encountered it, though it may also occur for other macros.

The included test case is a minimal one where the issue still existed. My fix went directly to `recognize!`, though it's possible the root cause may be in `HexDisplay::offset`, which `recognize!` uses, or perhaps `is_a!`.