### PR TITLE
Minor standardizations

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -138,7 +138,7 @@ macro_rules! tag_bits (
   ($i:expr, $t:ty, $count:expr, $p: pat) => (
     {
       match take_bits!($i, $t, $count) {
-        $crate::IResult::Incomplete(i) => $crate::IResult::Incomplete(i),
+        $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i, o)    => {
           if let $p = o {
             let res: $crate::IResult<(&[u8],usize),$t> = $crate::IResult::Done(i, o);
@@ -147,7 +147,7 @@ macro_rules! tag_bits (
             $crate::IResult::Error($crate::Err::Position($crate::ErrorKind::TagBits, $i))
           }
         },
-        _                              => {
+        $crate::IResult::Error(_)      => {
           $crate::IResult::Error($crate::Err::Position($crate::ErrorKind::TagBits, $i))
         }
       }

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -54,9 +54,9 @@ macro_rules! bits_impl (
           $crate::IResult::Error(err)
         }
         $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
-          //println!("bits parser returned Needed::Size({})", i);
-          $crate::IResult::Incomplete($crate::Needed::Size(i / 8 + 1))
+        $crate::IResult::Incomplete($crate::Needed::Size(n)) => {
+          //println!("bits parser returned Needed::Size({})", n);
+          $crate::IResult::Incomplete($crate::Needed::Size(n / 8 + 1))
         },
         $crate::IResult::Done((i, bit_index), o)             => {
           let byte_index = bit_index / 8 + if bit_index % 8 == 0 { 0 } else { 1 } ;

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -759,7 +759,7 @@ macro_rules! length_bytes(
   ($i:expr, $f:expr) => (
     {
       match $f($i) {
-        $crate::IResult::Error(a)      => $crate::IResult::Error(a),
+        $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i1,nb)   => {
           let length_remaining = i1.len();

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -236,20 +236,20 @@ macro_rules! escaped (
 #[doc(hidden)]
 #[macro_export]
 macro_rules! escaped1 (
-  ($i:expr, $submac1:ident!( $($args:tt)* ), $control_char: expr, $submac2:ident!( $($args2:tt)*) ) => (
+  ($i:expr, $submac1:ident!( $($args1:tt)* ), $control_char: expr, $submac2:ident!( $($args2:tt)*) ) => (
     {
-     escaped_impl!($i, $submac1!($($args)*), $control_char,  $submac2!($($args2)*))
+     escaped_impl!($i, $submac1!($($args1)*), $control_char,  $submac2!($($args2)*))
     }
   );
-  ($i:expr, $submac1:ident!( $($args:tt)* ), $control_char: expr, $g:expr) => (
-     escaped_impl!($i, $submac1!($($args)*), $control_char, call!($g))
+  ($i:expr, $submac:ident!( $($args:tt)* ), $control_char: expr, $g:expr) => (
+     escaped_impl!($i, $submac!($($args)*), $control_char, call!($g))
   );
 );
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! escaped_impl (
-  ($i: expr, $normal:ident!(  $($args:tt)* ), $control_char: expr, $escapable:ident!(  $($args2:tt)* )) => (
+  ($i: expr, $normal:ident!(  $($argsn:tt)* ), $control_char: expr, $escapable:ident!(  $($argse:tt)* )) => (
     {
       use $crate::InputLength;
       let cl = || {
@@ -257,7 +257,7 @@ macro_rules! escaped_impl (
         let mut index  = 0;
 
         while index < $i.len() {
-          if let $crate::IResult::Done(i,_) = $normal!(&$i[index..], $($args)*) {
+          if let $crate::IResult::Done(i,_) = $normal!(&$i[index..], $($argsn)*) {
             if i.is_empty() {
               return $crate::IResult::Done(&$i[$i.input_len()..], $i)
             } else {
@@ -267,7 +267,7 @@ macro_rules! escaped_impl (
             if index + 1 >= $i.len() {
               return $crate::IResult::Error($crate::Err::Position($crate::ErrorKind::Escaped,&$i[index..]));
             } else {
-              match $escapable!(&$i[index+1..], $($args2)*) {
+              match $escapable!(&$i[index+1..], $($argse)*) {
                 $crate::IResult::Error(e)      => return $crate::IResult::Error(e),
                 $crate::IResult::Incomplete(x) => return $crate::IResult::Incomplete(x),
                 $crate::IResult::Done(i,_) => {
@@ -349,20 +349,20 @@ macro_rules! escaped_transform (
 #[doc(hidden)]
 #[macro_export]
 macro_rules! escaped_transform1 (
-  ($i:expr, $submac1:ident!( $($args:tt)* ), $control_char: expr, $submac2:ident!( $($args2:tt)*) ) => (
+  ($i:expr, $submac1:ident!( $($args1:tt)* ), $control_char: expr, $submac2:ident!( $($args2:tt)*) ) => (
     {
-     escaped_transform_impl!($i, $submac1!($($args)*), $control_char,  $submac2!($($args2)*))
+     escaped_transform_impl!($i, $submac1!($($args1)*), $control_char,  $submac2!($($args2)*))
     }
   );
-  ($i:expr, $submac1:ident!( $($args:tt)* ), $control_char: expr, $g:expr) => (
-     escaped_transform_impl!($i, $submac1!($($args)*), $control_char, call!($g))
+  ($i:expr, $submac:ident!( $($args:tt)* ), $control_char: expr, $g:expr) => (
+     escaped_transform_impl!($i, $submac!($($args)*), $control_char, call!($g))
   );
 );
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! escaped_transform_impl (
-  ($i: expr, $normal:ident!(  $($args:tt)* ), $control_char: expr, $transform:ident!(  $($args2:tt)* )) => (
+  ($i: expr, $normal:ident!(  $($argsn:tt)* ), $control_char: expr, $transform:ident!( $($argst:tt)* )) => (
     {
       use $crate::InputLength;
       let cl = || {
@@ -371,7 +371,7 @@ macro_rules! escaped_transform_impl (
         let mut res = Vec::new();
 
         while index < $i.len() {
-          if let $crate::IResult::Done(i,o) = $normal!(&$i[index..], $($args)*) {
+          if let $crate::IResult::Done(i,o) = $normal!(&$i[index..], $($argsn)*) {
             res.extend(o.iter().cloned());
             if i.is_empty() {
               return $crate::IResult::Done(&$i[$i.input_len()..], res)
@@ -382,7 +382,7 @@ macro_rules! escaped_transform_impl (
             if index + 1 >= $i.len() {
               return $crate::IResult::Error($crate::Err::Position($crate::ErrorKind::EscapedTransform,&$i[index..]));
             } else {
-              match $transform!(&$i[index+1..], $($args2)*) {
+              match $transform!(&$i[index+1..], $($argst)*) {
                 $crate::IResult::Error(e)      => return $crate::IResult::Error(e),
                 $crate::IResult::Incomplete(x) => return $crate::IResult::Incomplete(x),
                 $crate::IResult::Done(i,o) => {

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -19,12 +19,12 @@ macro_rules! recognize (
     {
       use $crate::HexDisplay;
       match $submac!($i, $($args)*) {
+        $crate::IResult::Error(e)      => return $crate::IResult::Error(e),
+        $crate::IResult::Incomplete(x) => return $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i,_)     => {
           let index = ($i).offset(i);
           $crate::IResult::Done(i, &($i)[..index])
-        },
-        $crate::IResult::Error(e)      => return $crate::IResult::Error(e),
-        $crate::IResult::Incomplete(i) => return $crate::IResult::Incomplete(i)
+        }
       }
     }
   );
@@ -268,15 +268,15 @@ macro_rules! escaped_impl (
               return $crate::IResult::Error($crate::Err::Position($crate::ErrorKind::Escaped,&$i[index..]));
             } else {
               match $escapable!(&$i[index+1..], $($args2)*) {
+                $crate::IResult::Error(e)      => return $crate::IResult::Error(e),
+                $crate::IResult::Incomplete(x) => return $crate::IResult::Incomplete(x),
                 $crate::IResult::Done(i,_) => {
                   if i.is_empty() {
                     return $crate::IResult::Done(&$i[$i.input_len()..], $i)
                   } else {
                     index = $i.offset(i);
                   }
-                },
-                $crate::IResult::Incomplete(i) => return $crate::IResult::Incomplete(i),
-                $crate::IResult::Error(e)      => return $crate::IResult::Error(e)
+                }
               }
             }
           } else {
@@ -290,8 +290,8 @@ macro_rules! escaped_impl (
         $crate::IResult::Done(&$i[index..], &$i[..index])
       };
       match cl() {
-        $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i, o)    => $crate::IResult::Done(i, o),
+        $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Error(e)      => {
           return $crate::IResult::Error($crate::Err::NodePosition($crate::ErrorKind::Escaped, $i, Box::new(e)))
         }
@@ -383,6 +383,8 @@ macro_rules! escaped_transform_impl (
               return $crate::IResult::Error($crate::Err::Position($crate::ErrorKind::EscapedTransform,&$i[index..]));
             } else {
               match $transform!(&$i[index+1..], $($args2)*) {
+                $crate::IResult::Error(e)      => return $crate::IResult::Error(e),
+                $crate::IResult::Incomplete(x) => return $crate::IResult::Incomplete(x),
                 $crate::IResult::Done(i,o) => {
                   res.extend(o.iter().cloned());
                   if i.is_empty() {
@@ -390,9 +392,7 @@ macro_rules! escaped_transform_impl (
                   } else {
                     index = $i.offset(i);
                   }
-                },
-                $crate::IResult::Incomplete(i) => return $crate::IResult::Incomplete(i),
-                $crate::IResult::Error(e)      => return $crate::IResult::Error(e)
+                }
               }
             }
           } else {
@@ -406,8 +406,8 @@ macro_rules! escaped_transform_impl (
         $crate::IResult::Done(&$i[index..], res)
       };
       match cl() {
-        $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i, o)    => $crate::IResult::Done(i, o),
+        $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Error(e)      => {
           return $crate::IResult::Error($crate::Err::NodePosition($crate::ErrorKind::EscapedTransform, $i, Box::new(e)))
         }
@@ -760,7 +760,7 @@ macro_rules! length_bytes(
     {
       match $f($i) {
         $crate::IResult::Error(a)      => $crate::IResult::Error(a),
-        $crate::IResult::Incomplete(i) => $crate::IResult::Incomplete(i),
+        $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i1,nb)   => {
           let length_remaining = i1.len();
           if length_remaining < nb {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -76,7 +76,7 @@ impl<I,O,E> IResult<I,O,E> {
     match self {
       Done(i, o)    => Done(i, f(o)),
       Error(e)      => Error(e),
-      Incomplete(n) => Incomplete(n),
+      Incomplete(x) => Incomplete(x),
     }
   }
 
@@ -88,7 +88,7 @@ impl<I,O,E> IResult<I,O,E> {
    where F: FnOnce(Err<I, E>) -> Err<I, N> {
     match self {
       Error(e)      => Error(f(e)),
-      Incomplete(n) => Incomplete(n),
+      Incomplete(x) => Incomplete(x),
       Done(i, o)    => Done(i, o),
     }
   }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -681,7 +681,7 @@ macro_rules! chaining_parser (
       match $submac!($i, $($args)*) {
         $crate::IResult::Error(e)                            => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(n)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
         $crate::IResult::Done(i,_)                           => {
           chaining_parser!(i, $consumed + (($i).input_len() - i.input_len()), $($rest)*)
         }
@@ -700,7 +700,7 @@ macro_rules! chaining_parser (
       if let $crate::IResult::Incomplete(x) = res {
         match x {
           $crate::Needed::Unknown => $crate::IResult::Incomplete($crate::Needed::Unknown),
-          $crate::Needed::Size(i) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+          $crate::Needed::Size(n) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
         }
       } else {
         let input = if let $crate::IResult::Done(i,_) = res {
@@ -723,7 +723,7 @@ macro_rules! chaining_parser (
       match  $submac!($i, $($args)*) {
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(n)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
         $crate::IResult::Done(i,o)     => {
           let $field = o;
           chaining_parser!(i, $consumed + (($i).input_len() - i.input_len()), $($rest)*)
@@ -742,7 +742,7 @@ macro_rules! chaining_parser (
       match  $submac!($i, $($args)*) {
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(n)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
         $crate::IResult::Done(i,o)     => {
           let mut $field = o;
           chaining_parser!(i, $consumed + ($i).input_len() - i.input_len(), $($rest)*)
@@ -762,7 +762,7 @@ macro_rules! chaining_parser (
       if let $crate::IResult::Incomplete(x) = res {
         match x {
           $crate::Needed::Unknown => $crate::IResult::Incomplete($crate::Needed::Unknown),
-          $crate::Needed::Size(i) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+          $crate::Needed::Size(n) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
         }
       } else {
         let ($field,input) = if let $crate::IResult::Done(i,o) = res {
@@ -786,7 +786,7 @@ macro_rules! chaining_parser (
       if let $crate::IResult::Incomplete(x) = res {
         match x {
           $crate::Needed::Unknown => $crate::IResult::Incomplete($crate::Needed::Unknown),
-          $crate::Needed::Size(i) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+          $crate::Needed::Size(n) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
         }
       } else {
         let (mut $field,input) = if let $crate::IResult::Done(i,o) = res {
@@ -808,7 +808,7 @@ macro_rules! chaining_parser (
     match $submac!($i, $($args)*) {
       $crate::IResult::Error(e)      => $crate::IResult::Error(e),
       $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
-      $crate::IResult::Incomplete($crate::Needed::Size(i)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+      $crate::IResult::Incomplete($crate::Needed::Size(n)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
       $crate::IResult::Done(i,_)     => {
         $crate::IResult::Done(i, $assemble())
       }
@@ -824,7 +824,7 @@ macro_rules! chaining_parser (
     if let $crate::IResult::Incomplete(x) = res {
       match x {
         $crate::Needed::Unknown => $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::Needed::Size(i) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::Needed::Size(n) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
       }
     } else {
       let input = if let $crate::IResult::Done(i,_) = res {
@@ -844,7 +844,7 @@ macro_rules! chaining_parser (
     match $submac!($i, $($args)*) {
       $crate::IResult::Error(e)      => $crate::IResult::Error(e),
       $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
-      $crate::IResult::Incomplete($crate::Needed::Size(i)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+      $crate::IResult::Incomplete($crate::Needed::Size(n)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
       $crate::IResult::Done(i,o)     => {
         let $field = o;
         $crate::IResult::Done(i, $assemble())
@@ -860,7 +860,7 @@ macro_rules! chaining_parser (
     match $submac!($i, $($args)*) {
       $crate::IResult::Error(e)      => $crate::IResult::Error(e),
       $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
-      $crate::IResult::Incomplete($crate::Needed::Size(i)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+      $crate::IResult::Incomplete($crate::Needed::Size(n)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
       $crate::IResult::Done(i,o)     => {
         let mut $field = o;
         $crate::IResult::Done(i, $assemble())
@@ -877,7 +877,7 @@ macro_rules! chaining_parser (
     if let $crate::IResult::Incomplete(x) = res {
       match x {
         $crate::Needed::Unknown => $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::Needed::Size(i) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::Needed::Size(n) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
       }
     } else {
       let ($field,input) = if let $crate::IResult::Done(i,o) = res {
@@ -898,7 +898,7 @@ macro_rules! chaining_parser (
     if let $crate::IResult::Incomplete(x) = res {
       match x {
         $crate::Needed::Unknown => $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::Needed::Size(i) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::Needed::Size(n) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
       }
     } else {
       let (mut $field,input) = if let $crate::IResult::Done(i,o) = res {
@@ -971,7 +971,7 @@ macro_rules! tuple_parser (
       match $submac!($i, $($args)*) {
         $crate::IResult::Error(e)                            => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(n)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
         $crate::IResult::Done(i,o)     => {
           tuple_parser!(i, $consumed + (($i).input_len() - i.input_len()), (o), $($rest)*)
         }
@@ -984,7 +984,7 @@ macro_rules! tuple_parser (
       match $submac!($i, $($args)*) {
         $crate::IResult::Error(e)                            => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(n)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
         $crate::IResult::Done(i,o)     => {
           tuple_parser!(i, $consumed + (($i).input_len() - i.input_len()), ($($parsed)* , o), $($rest)*)
         }
@@ -1000,7 +1000,7 @@ macro_rules! tuple_parser (
       match $submac!($i, $($args)*) {
         $crate::IResult::Error(e)                            => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(n)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
         $crate::IResult::Done(i,o)     => {
           $crate::IResult::Done(i, (o))
         }
@@ -1013,7 +1013,7 @@ macro_rules! tuple_parser (
       match $submac!($i, $($args)*) {
         $crate::IResult::Error(e)                            => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(n)) => $crate::IResult::Incomplete($crate::Needed::Size($consumed + n)),
         $crate::IResult::Done(i,o)     => {
           $crate::IResult::Done(i, ($($parsed),* , o))
         }
@@ -1904,8 +1904,8 @@ macro_rules! many0(
                     incomplete = ::std::option::Option::Some($crate::Needed::Unknown);
                     break;
                   },
-                  $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
-                    incomplete = ::std::option::Option::Some($crate::Needed::Size(i + ($i).input_len() - input.input_len()));
+                  $crate::IResult::Incomplete($crate::Needed::Size(n)) => {
+                    incomplete = ::std::option::Option::Some($crate::Needed::Size(n + ($i).input_len() - input.input_len()));
                     break;
                   },
                 }
@@ -1979,8 +1979,8 @@ macro_rules! many1(
                   incomplete = ::std::option::Option::Some($crate::Needed::Unknown);
                   break;
                 },
-                $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
-                  incomplete = ::std::option::Option::Some($crate::Needed::Size(i + ($i).input_len() - input.input_len()));
+                $crate::IResult::Incomplete($crate::Needed::Size(n)) => {
+                  incomplete = ::std::option::Option::Some($crate::Needed::Size(n + ($i).input_len() - input.input_len()));
                   break;
                 },
                 $crate::IResult::Done(i, o) => {
@@ -2061,8 +2061,8 @@ macro_rules! many_m_n(
             incomplete = ::std::option::Option::Some($crate::Needed::Unknown);
             break;
           },
-          $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
-            incomplete = ::std::option::Option::Some($crate::Needed::Size(i + ($i).input_len() - input.input_len()));
+          $crate::IResult::Incomplete($crate::Needed::Size(n)) => {
+            incomplete = ::std::option::Option::Some($crate::Needed::Size(n + ($i).input_len() - input.input_len()));
             break;
           },
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -374,7 +374,7 @@ macro_rules! flat_map(
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i, o)    => match $submac2!(o, $($args2)*) {
-          $crate::IResult::Done(_, o2)   => $crate::IResult::Done(i, o2),
+          $crate::IResult::Done(_, p)   => $crate::IResult::Done(i, p),
           $crate::IResult::Incomplete(y) => $crate::IResult::Incomplete(y),
           $crate::IResult::Error(e)                                 => {
             let err = match e {
@@ -1660,8 +1660,8 @@ macro_rules! preceded(
       match tuple!($i, $submac!($($args)*), $submac2!($($args2)*)) {
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
-        $crate::IResult::Done(remaining, (_,o))    => {
-          $crate::IResult::Done(remaining, o)
+        $crate::IResult::Done(i, (_,o))    => {
+          $crate::IResult::Done(i, o)
         }
       }
     }
@@ -1689,8 +1689,8 @@ macro_rules! terminated(
       match tuple!($i, $submac!($($args)*), $submac2!($($args2)*)) {
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
-        $crate::IResult::Done(remaining, (o,_))    => {
-          $crate::IResult::Done(remaining, o)
+        $crate::IResult::Done(i, (o,_))    => {
+          $crate::IResult::Done(i, o)
         }
       }
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -368,9 +368,9 @@ macro_rules! try_parse (
 /// parser R -> IResult<R,T>
 #[macro_export]
 macro_rules! flat_map(
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+  ($i:expr, $submac1:ident!( $($args1:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      match $submac!($i, $($args)*) {
+      match $submac1!($i, $($args1)*) {
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i, o)    => match $submac2!(o, $($args2)*) {
@@ -406,8 +406,8 @@ macro_rules! map(
   ($i:expr, $submac:ident!( $($args:tt)* ), $g:expr) => (
     map_impl!($i, $submac!($($args)*), call!($g));
   );
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
-    map_impl!($i, $submac!($($args)*), $submac2!($($args2)*));
+  ($i:expr, $subma1c:ident!( $($args1:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+    map_impl!($i, $submac1!($($args1)*), $submac2!($($args2)*));
   );
   ($i:expr, $f:expr, $g:expr) => (
     map_impl!($i, call!($f), call!($g));
@@ -421,9 +421,9 @@ macro_rules! map(
 #[doc(hidden)]
 #[macro_export]
 macro_rules! map_impl(
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+  ($i:expr, $submac1:ident!( $($args1:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      match $submac!($i, $($args)*) {
+      match $submac1!($i, $($args1)*) {
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i, o)    => $crate::IResult::Done(i, $submac2!(o, $($args2)*))
@@ -439,8 +439,8 @@ macro_rules! map_res (
   ($i:expr, $submac:ident!( $($args:tt)* ), $g:expr) => (
     map_res_impl!($i, $submac!($($args)*), call!($g));
   );
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
-    map_res_impl!($i, $submac!($($args)*), $submac2!($($args2)*));
+  ($i:expr, $submac1:ident!( $($args1:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+    map_res_impl!($i, $submac1!($($args1)*), $submac2!($($args2)*));
   );
   ($i:expr, $f:expr, $g:expr) => (
     map_res_impl!($i, call!($f), call!($g));
@@ -454,9 +454,9 @@ macro_rules! map_res (
 #[doc(hidden)]
 #[macro_export]
 macro_rules! map_res_impl (
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+  ($i:expr, $submac1:ident!( $($args1:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      match $submac!($i, $($args)*) {
+      match $submac1!($i, $($args1)*) {
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i, o)    => match $submac2!(o, $($args2)*) {
@@ -476,8 +476,8 @@ macro_rules! map_opt (
   ($i:expr, $submac:ident!( $($args:tt)* ), $g:expr) => (
     map_opt_impl!($i, $submac!($($args)*), call!($g));
   );
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
-    map_opt_impl!($i, $submac!($($args)*), $submac2!($($args2)*));
+  ($i:expr, $submac1:ident!( $($args1:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+    map_opt_impl!($i, $submac1!($($args1)*), $submac2!($($args2)*));
   );
   ($i:expr, $f:expr, $g:expr) => (
     map_opt_impl!($i, call!($f), call!($g));
@@ -491,9 +491,9 @@ macro_rules! map_opt (
 #[doc(hidden)]
 #[macro_export]
 macro_rules! map_opt_impl (
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+  ($i:expr, $submac1:ident!( $($args1:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      match $submac!($i, $($args)*) {
+      match $submac1!($i, $($args1)*) {
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i, o)    => match $submac2!(o, $($args2)*) {
@@ -1611,9 +1611,9 @@ macro_rules! tap (
 ///
 #[macro_export]
 macro_rules! pair(
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+  ($i:expr, $submac1:ident!( $($args1:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      tuple!($i, $submac!($($args)*), $submac2!($($args2)*))
+      tuple!($i, $submac1!($($args1)*), $submac2!($($args2)*))
     }
   );
 
@@ -1655,9 +1655,9 @@ macro_rules! separated_pair(
 /// preceded(opening, X) returns X
 #[macro_export]
 macro_rules! preceded(
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+  ($i:expr, $submac1:ident!( $($args1:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      match tuple!($i, $submac!($($args)*), $submac2!($($args2)*)) {
+      match tuple!($i, $submac1!($($args1)*), $submac2!($($args2)*)) {
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i, (_,o))    => {
@@ -1684,9 +1684,9 @@ macro_rules! preceded(
 /// terminated(X, closing) returns X
 #[macro_export]
 macro_rules! terminated(
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+  ($i:expr, $submac1:ident!( $($args1:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      match tuple!($i, $submac!($($args)*), $submac2!($($args2)*)) {
+      match tuple!($i, $submac1!($($args1)*), $submac2!($($args2)*)) {
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i, (o,_))    => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1562,7 +1562,7 @@ macro_rules! peek(
     {
       match $submac!($i, $($args)*) {
         $crate::IResult::Done(_,o)     => $crate::IResult::Done($i, o),
-        $crate::IResult::Error(a)      => $crate::IResult::Error(a),
+        $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x)
       }
     }
@@ -1596,7 +1596,7 @@ macro_rules! tap (
           $e;
           $crate::IResult::Done(i, $name)
         },
-        $crate::IResult::Error(a)      => $crate::IResult::Error(a),
+        $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x)
       }
     }
@@ -1637,7 +1637,7 @@ macro_rules! separated_pair(
   ($i:expr, $submac:ident!( $($args:tt)* ), $($rest:tt)+) => (
     {
       match tuple_parser!($i, 0usize, (), $submac!($($args)*), $($rest)*) {
-        $crate::IResult::Error(a)      => $crate::IResult::Error(a),
+        $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i1, (o1, _, o2))   => {
           $crate::IResult::Done(i1, (o1, o2))
@@ -1658,7 +1658,7 @@ macro_rules! preceded(
   ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
       match tuple!($i, $submac!($($args)*), $submac2!($($args2)*)) {
-        $crate::IResult::Error(a)      => $crate::IResult::Error(a),
+        $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(remaining, (_,o))    => {
           $crate::IResult::Done(remaining, o)
@@ -1687,7 +1687,7 @@ macro_rules! terminated(
   ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
       match tuple!($i, $submac!($($args)*), $submac2!($($args2)*)) {
-        $crate::IResult::Error(a)      => $crate::IResult::Error(a),
+        $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(remaining, (o,_))    => {
           $crate::IResult::Done(remaining, o)
@@ -1716,7 +1716,7 @@ macro_rules! delimited(
   ($i:expr, $submac:ident!( $($args:tt)* ), $($rest:tt)+) => (
     {
       match tuple_parser!($i, 0usize, (), $submac!($($args)*), $($rest)*) {
-        $crate::IResult::Error(a)      => $crate::IResult::Error(a),
+        $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i1, (_, o, _))   => {
           $crate::IResult::Done(i1, o)
@@ -1800,7 +1800,7 @@ macro_rules! separated_nonempty_list(
 
       // get the first element
       match $submac!(input, $($args2)*) {
-        $crate::IResult::Error(a)      => $crate::IResult::Error(a),
+        $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(i,o)     => {
           if i.len() == input.len() {
@@ -2216,7 +2216,7 @@ macro_rules! length_value(
   ($i:expr, $f:expr, $g:expr) => (
     {
       match $f($i) {
-        $crate::IResult::Error(a)      => $crate::IResult::Error(a),
+        $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(inum, onum)   => {
           let ret;
@@ -2255,7 +2255,7 @@ macro_rules! length_value(
   ($i:expr, $f:expr, $g:expr, $length:expr) => (
     {
       match $f($i) {
-        $crate::IResult::Error(a)      => $crate::IResult::Error(a),
+        $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Done(inum, onum)   => {
           let ret;

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -446,7 +446,7 @@ macro_rules! i64 ( ($i:expr, $e:expr) => ( {if $e { $crate::be_i64($i) } else { 
 pub fn be_f32(input: &[u8]) -> IResult<&[u8], f32> {
   match be_u32(input) {
     Error(e)      => Error(e),
-    Incomplete(e) => Incomplete(e),
+    Incomplete(x) => Incomplete(x),
     Done(i,o) => {
       unsafe {
         Done(i, transmute::<u32, f32>(o))
@@ -460,7 +460,7 @@ pub fn be_f32(input: &[u8]) -> IResult<&[u8], f32> {
 pub fn be_f64(input: &[u8]) -> IResult<&[u8], f64> {
   match be_u64(input) {
     Error(e)      => Error(e),
-    Incomplete(e) => Incomplete(e),
+    Incomplete(x) => Incomplete(x),
     Done(i,o) => {
       unsafe {
         Done(i, transmute::<u64, f64>(o))
@@ -474,7 +474,7 @@ pub fn be_f64(input: &[u8]) -> IResult<&[u8], f64> {
 pub fn hex_u32(input: &[u8]) -> IResult<&[u8], u32> {
   match is_a!(input, &b"0123456789abcdef"[..]) {
     Error(e)    => Error(e),
-    Incomplete(e) => Incomplete(e),
+    Incomplete(x) => Incomplete(x),
     Done(i,o) => {
       let mut res = 0;
       for &e in o {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -499,8 +499,8 @@ macro_rules! consumer_from_parser (
           $crate::Input::Empty | $crate::Input::Eof(None)           => &self.state,
           $crate::Input::Element(sl) | $crate::Input::Eof(Some(sl)) => {
             self.state = match $submac!(sl, $($args)*) {
-              $crate::IResult::Incomplete(n)  => {
-                $crate::ConsumerState::Continue($crate::Move::Await(n))
+              $crate::IResult::Incomplete(x)  => {
+                $crate::ConsumerState::Continue($crate::Move::Await(x))
               },
               $crate::IResult::Error(_)       => {
                 $crate::ConsumerState::Error(())
@@ -540,8 +540,8 @@ macro_rules! consumer_from_parser (
           $crate::Input::Empty | $crate::Input::Eof(None)           => &self.state,
           $crate::Input::Element(sl) | $crate::Input::Eof(Some(sl)) => {
             self.state = match $submac!(sl, $($args)*) {
-              $crate::IResult::Incomplete(n)  => {
-                $crate::ConsumerState::Continue($crate::Move::Await(n))
+              $crate::IResult::Incomplete(x)  => {
+                $crate::ConsumerState::Continue($crate::Move::Await(x))
               },
               $crate::IResult::Error(_)       => {
                 $crate::ConsumerState::Error(())
@@ -868,9 +868,9 @@ mod tests {
         Input::Element(sl) | Input::Eof(Some(sl)) => {
           //println!("got slice: {:?}", sl);
           self.state = match line(sl) {
-            IResult::Incomplete(n)  => {
+            IResult::Incomplete(x)  => {
               println!("line not complete, continue (line was \"{}\")", from_utf8(sl).unwrap());
-              ConsumerState::Continue(Move::Await(n))
+              ConsumerState::Continue(Move::Await(x))
             },
             IResult::Error(e)       => {
               println!("LineConsumer parsing error: {:?}", e);

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -441,9 +441,9 @@ impl<'a,'b,R,S:Clone,T:Clone,E:Clone,M:Clone,C1:Consumer<R,S,E,M>, C2:Consumer<S
       ConsumerState::Error(ref e)       => ConsumerState::Error(e.clone()),
       ConsumerState::Continue(ref m)    => ConsumerState::Continue(m.clone()),
       ConsumerState::Done(ref m, ref o) => match *c2.handle(Input::Element(o.clone())) {
-        ConsumerState::Error(ref e)     => ConsumerState::Error(e.clone()),
-        ConsumerState::Continue(ref m2) => ConsumerState::Continue(m2.clone()),
-        ConsumerState::Done(_,ref o2)   => ConsumerState::Done(m.clone(), o2.clone())
+        ConsumerState::Error(ref f)     => ConsumerState::Error(f.clone()),
+        ConsumerState::Continue(ref n)  => ConsumerState::Continue(n.clone()),
+        ConsumerState::Done(_,ref p)    => ConsumerState::Done(m.clone(), p.clone())
       }
     };
 
@@ -464,9 +464,9 @@ impl<'a,'b,R,S:Clone,T:Clone,E:Clone,M:Clone,C1:Consumer<R,S,E,M>, C2:Consumer<S
         ConsumerState::Error(ref e)       => ConsumerState::Error(e.clone()),
         ConsumerState::Continue(ref m)    => ConsumerState::Continue(m.clone()),
         ConsumerState::Done(ref m, ref o) => match *self.consumer2.handle(Input::Element(o.clone())) {
-          ConsumerState::Error(ref e)    => ConsumerState::Error(e.clone()),
-          ConsumerState::Continue(ref m) => ConsumerState::Continue(m.clone()),
-          ConsumerState::Done(_, ref o2)    => ConsumerState::Done(m.clone(), o2.clone())
+          ConsumerState::Error(ref f)     => ConsumerState::Error(f.clone()),
+          ConsumerState::Continue(ref n)  => ConsumerState::Continue(n.clone()),
+          ConsumerState::Done(_, ref p)   => ConsumerState::Done(m.clone(), p.clone())
         }
       };
     &self.state

--- a/src/util.rs
+++ b/src/util.rs
@@ -218,9 +218,9 @@ macro_rules! dbg (
           println!("Error({:?}) at l.{} by ' {} '", a, l, stringify!($submac!($($args)*)));
           $crate::IResult::Error(a)
         },
-        $crate::IResult::Incomplete(a) => {
-          println!("Incomplete({:?}) at {} by ' {} '", a, l, stringify!($submac!($($args)*)));
-          $crate::IResult::Incomplete(a)
+        $crate::IResult::Incomplete(x) => {
+          println!("Incomplete({:?}) at {} by ' {} '", x, l, stringify!($submac!($($args)*)));
+          $crate::IResult::Incomplete(x)
         },
         a => a
       }
@@ -262,9 +262,9 @@ macro_rules! dbg_dmp (
           println!("Error({:?}) at l.{} by ' {} '\n{}", a, l, stringify!($submac!($($args)*)), $i.to_hex(8));
           $crate::IResult::Error(a)
         },
-        $crate::IResult::Incomplete(a) => {
-          println!("Incomplete({:?}) at {} by ' {} '\n{}", a, l, stringify!($submac!($($args)*)), $i.to_hex(8));
-          $crate::IResult::Incomplete(a)
+        $crate::IResult::Incomplete(x) => {
+          println!("Incomplete({:?}) at {} by ' {} '\n{}", x, l, stringify!($submac!($($args)*)), $i.to_hex(8));
+          $crate::IResult::Incomplete(x)
         },
         a => a
       }

--- a/src/util.rs
+++ b/src/util.rs
@@ -214,9 +214,9 @@ macro_rules! dbg (
     {
       let l = line!();
       match $submac!($i, $($args)*) {
-        $crate::IResult::Error(a) => {
-          println!("Error({:?}) at l.{} by ' {} '", a, l, stringify!($submac!($($args)*)));
-          $crate::IResult::Error(a)
+        $crate::IResult::Error(e) => {
+          println!("Error({:?}) at l.{} by ' {} '", e, l, stringify!($submac!($($args)*)));
+          $crate::IResult::Error(e)
         },
         $crate::IResult::Incomplete(x) => {
           println!("Incomplete({:?}) at {} by ' {} '", x, l, stringify!($submac!($($args)*)));
@@ -258,9 +258,9 @@ macro_rules! dbg_dmp (
       use $crate::HexDisplay;
       let l = line!();
       match $submac!($i, $($args)*) {
-        $crate::IResult::Error(a) => {
-          println!("Error({:?}) at l.{} by ' {} '\n{}", a, l, stringify!($submac!($($args)*)), $i.to_hex(8));
-          $crate::IResult::Error(a)
+        $crate::IResult::Error(e) => {
+          println!("Error({:?}) at l.{} by ' {} '\n{}", e, l, stringify!($submac!($($args)*)), $i.to_hex(8));
+          $crate::IResult::Error(e)
         },
         $crate::IResult::Incomplete(x) => {
           println!("Incomplete({:?}) at {} by ' {} '\n{}", x, l, stringify!($submac!($($args)*)), $i.to_hex(8));

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -58,7 +58,7 @@ fn keys_and_values(input:&[u8]) -> IResult<&[u8], HashMap<&str, &str> > {
       IResult::Done(i, h)
     },
     IResult::Incomplete(x)     => IResult::Incomplete(x),
-    IResult::Error(a)          => IResult::Error(a)
+    IResult::Error(e)          => IResult::Error(e)
   }
 }
 
@@ -83,7 +83,7 @@ fn categories(input: &[u8]) -> IResult<&[u8], HashMap<&str, HashMap<&str, &str> 
       IResult::Done(i, h)
     },
     IResult::Incomplete(x)     => IResult::Incomplete(x),
-    IResult::Error(a)          => IResult::Error(a)
+    IResult::Error(e)          => IResult::Error(e)
   }
 }
 

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -57,7 +57,7 @@ fn keys_and_values(input:&[u8]) -> IResult<&[u8], HashMap<&str, &str> > {
       }
       IResult::Done(i, h)
     },
-    IResult::Incomplete(a)     => IResult::Incomplete(a),
+    IResult::Incomplete(x)     => IResult::Incomplete(x),
     IResult::Error(a)          => IResult::Error(a)
   }
 }
@@ -82,7 +82,7 @@ fn categories(input: &[u8]) -> IResult<&[u8], HashMap<&str, HashMap<&str, &str> 
       }
       IResult::Done(i, h)
     },
-    IResult::Incomplete(a)     => IResult::Incomplete(a),
+    IResult::Incomplete(x)     => IResult::Incomplete(x),
     IResult::Error(a)          => IResult::Error(a)
   }
 }

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -71,7 +71,7 @@ fn keys_and_values(input:&str) -> IResult<&str, HashMap<&str, &str> > {
       }
       IResult::Done(i, h)
     },
-    IResult::Incomplete(a)     => IResult::Incomplete(a),
+    IResult::Incomplete(x)     => IResult::Incomplete(x),
     IResult::Error(a)          => IResult::Error(a)
   }
 }
@@ -93,7 +93,7 @@ fn categories(input: &str) -> IResult<&str, HashMap<&str, HashMap<&str, &str> > 
       }
       IResult::Done(i, h)
     },
-    IResult::Incomplete(a)     => IResult::Incomplete(a),
+    IResult::Incomplete(x)     => IResult::Incomplete(x),
     IResult::Error(a)          => IResult::Error(a)
   }
 }

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -72,7 +72,7 @@ fn keys_and_values(input:&str) -> IResult<&str, HashMap<&str, &str> > {
       IResult::Done(i, h)
     },
     IResult::Incomplete(x)     => IResult::Incomplete(x),
-    IResult::Error(a)          => IResult::Error(a)
+    IResult::Error(e)          => IResult::Error(e)
   }
 }
 
@@ -94,7 +94,7 @@ fn categories(input: &str) -> IResult<&str, HashMap<&str, HashMap<&str, &str> > 
       IResult::Done(i, h)
     },
     IResult::Incomplete(x)     => IResult::Incomplete(x),
-    IResult::Error(a)          => IResult::Error(a)
+    IResult::Error(e)          => IResult::Error(e)
   }
 }
 

--- a/tests/mp4.rs
+++ b/tests/mp4.rs
@@ -353,8 +353,8 @@ impl MP4Consumer {
                     //return ConsumerState::Await(header.length as usize, header.length as usize - 8);
                     return ConsumerState::Continue(Move::Consume(sl.offset(rest)));
                   }
-                  Error(a) => {
-                    println!("ftyp parsing error: {:?}", a);
+                  Error(e) => {
+                    println!("ftyp parsing error: {:?}", e);
                     assert!(false);
                     return ConsumerState::Error(());
                   },
@@ -384,8 +384,8 @@ impl MP4Consumer {
             }
             return ConsumerState::Continue(Move::Seek(SeekFrom::Current((header.length) as i64)))
           },
-          Error(a) => {
-            println!("mp4 parsing error: {:?}", a);
+          Error(e) => {
+            println!("mp4 parsing error: {:?}", e);
             assert!(false);
             return ConsumerState::Error(());
           },
@@ -438,8 +438,8 @@ impl MP4Consumer {
             println!("remaining moov_bytes: {}", self.moov_bytes);
             return ConsumerState::Continue(Move::Seek(SeekFrom::Current((header.length) as i64)))
           },
-          Error(a) => {
-            println!("moov parsing error: {:?}", a);
+          Error(e) => {
+            println!("moov parsing error: {:?}", e);
             println!("data:\n{}", sl.to_hex(8));
             assert!(false);
             return ConsumerState::Error(());

--- a/tests/mp4.rs
+++ b/tests/mp4.rs
@@ -23,7 +23,7 @@ fn mp4_box(input:&[u8]) -> IResult<&[u8], &[u8]> {
       }
     }
     Error(e)      => Error(e),
-    Incomplete(e) => Incomplete(e)
+    Incomplete(x) => Incomplete(x)
   }
 }
 
@@ -358,9 +358,9 @@ impl MP4Consumer {
                     assert!(false);
                     return ConsumerState::Error(());
                   },
-                  Incomplete(n) => {
+                  Incomplete(x) => {
                     println!("ftyp incomplete -> await: {}", sl.len());
-                    return ConsumerState::Continue(Move::Await(n));
+                    return ConsumerState::Continue(Move::Await(x));
                     //return ConsumerState::Await(0, input.len() + 100);
                   }
                 }
@@ -389,10 +389,10 @@ impl MP4Consumer {
             assert!(false);
             return ConsumerState::Error(());
           },
-          Incomplete(i) => {
+          Incomplete(x) => {
             // FIXME: incomplete should send the required size
             println!("mp4 incomplete -> await: {}", sl.len());
-            return ConsumerState::Continue(Move::Await(i));
+            return ConsumerState::Continue(Move::Await(x));
           }
         }
       }
@@ -444,9 +444,9 @@ impl MP4Consumer {
             assert!(false);
             return ConsumerState::Error(());
           },
-          Incomplete(i) => {
+          Incomplete(x) => {
             println!("moov incomplete -> await: {}", sl.len());
-            return ConsumerState::Continue(Move::Await(i));
+            return ConsumerState::Continue(Move::Await(x));
           }
         }
       }
@@ -526,6 +526,3 @@ fn small_test() {
 fn big_bunny_test() {
   explore_mp4_file("assets/bigbuckbunny.mp4");
 }
-
-
-

--- a/tests/omnom.rs
+++ b/tests/omnom.rs
@@ -43,8 +43,8 @@ impl<'a> Consumer<&'a[u8], usize, (), Move> for TestConsumer {
                 self.state   = State::Error;
                 self.c_state = ConsumerState::Error(());
               },
-              IResult::Incomplete(n) => {
-                self.c_state = ConsumerState::Continue(Move::Await(n));
+              IResult::Incomplete(x) => {
+                self.c_state = ConsumerState::Continue(Move::Await(x));
               },
               IResult::Done(i,_)     => {
                 self.state = State::Middle;
@@ -66,9 +66,9 @@ impl<'a> Consumer<&'a[u8], usize, (), Move> for TestConsumer {
                 self.state   = State::End;
                 self.c_state = ConsumerState::Continue(Move::Consume(0));
               },
-              IResult::Incomplete(n) => {
-                println!("Middle got Incomplete({:?})", n);
-                self.c_state = ConsumerState::Continue(Move::Await(n));
+              IResult::Incomplete(x) => {
+                println!("Middle got Incomplete({:?})", x);
+                self.c_state = ConsumerState::Continue(Move::Await(x));
               },
               IResult::Done(i,noms_vec)     => {
                 self.counter = self.counter + noms_vec.len();
@@ -91,8 +91,8 @@ impl<'a> Consumer<&'a[u8], usize, (), Move> for TestConsumer {
                 self.state   = State::Error;
                 self.c_state = ConsumerState::Error(());
               },
-              IResult::Incomplete(n) => {
-                self.c_state = ConsumerState::Continue(Move::Await(n));
+              IResult::Incomplete(x) => {
+                self.c_state = ConsumerState::Continue(Move::Await(x));
               },
               IResult::Done(i,_)     => {
                 self.state = State::Done;


### PR DESCRIPTION
This is a standardization patch:

- standard pattern in matching IResult and Needed (i.e. Done(i,o), Error(e), Incomplete(x); Size(n) [varibale names and ordering])
- Contracting Incomplete(Unknown) and Incomplete(Size(n)) to  Incomplete(x) if possible
- submac, args -> submac1, args1 if submac2 resp. args2 is present

I know this is a lot, but this are mere renamings and reorderings.
I thought this was a good idea. In some parts of the code I always had to look up the variables...