### PR TITLE
Absolute macro references

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2869,8 +2869,7 @@ mod tests {
     let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
     assert_eq!(multi(b), Done(&b"ef"[..], res2));
     assert_eq!(multi(c), Done(&b"azerty"[..], Vec::new()));
-    let res3 = vec![&b""[..], &b""[..], &b""[..]];
-    //assert_eq!(multi_empty(d), Done(&b"abc"[..], res3));
+    assert_eq!(multi_empty(d), Error(Position(ErrorKind::SeparatedList, d)));
   }
 
   #[test]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -268,24 +268,24 @@ macro_rules! fix_error (
         $crate::IResult::Done(i, o)    => $crate::IResult::Done(i, o),
         $crate::IResult::Error(e) => {
           let err = match e {
-            $crate::Err::Code(ErrorKind::Custom(_)) |
-              $crate::Err::Node(ErrorKind::Custom(_), _) => {
-              let e: ErrorKind<$t> = ErrorKind::Fix;
+            $crate::Err::Code($crate::ErrorKind::Custom(_)) |
+              $crate::Err::Node($crate::ErrorKind::Custom(_), _) => {
+              let e: $crate::ErrorKind<$t> = $crate::ErrorKind::Fix;
               $crate::Err::Code(e)
             },
-            $crate::Err::Position(ErrorKind::Custom(_), p) |
-              $crate::Err::NodePosition(ErrorKind::Custom(_), p, _) => {
-              let e: ErrorKind<$t> = ErrorKind::Fix;
+            $crate::Err::Position($crate::ErrorKind::Custom(_), p) |
+              $crate::Err::NodePosition($crate::ErrorKind::Custom(_), p, _) => {
+              let e: $crate::ErrorKind<$t> = $crate::ErrorKind::Fix;
               $crate::Err::Position(e, p)
             },
             $crate::Err::Code(_) |
               $crate::Err::Node(_, _) => {
-              let e: ErrorKind<$t> = ErrorKind::Fix;
+              let e: $crate::ErrorKind<$t> = $crate::ErrorKind::Fix;
               $crate::Err::Code(e)
             },
             $crate::Err::Position(_, p) |
               $crate::Err::NodePosition(_, p, _) => {
-              let e: ErrorKind<$t> = ErrorKind::Fix;
+              let e: $crate::ErrorKind<$t> = $crate::ErrorKind::Fix;
               $crate::Err::Position(e, p)
             },
           };

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -528,6 +528,8 @@ macro_rules! consumer_from_parser (
     }
 
     impl $name {
+      // Allow this to go unused, because code in the defining scope can create the struct directly.
+      #[allow(dead_code)]
       fn new() -> $name {
         $name { state: $crate::ConsumerState::Continue($crate::Move::Consume(0)) }
       }

--- a/tests/cross_function_backtracking.rs
+++ b/tests/cross_function_backtracking.rs
@@ -8,8 +8,6 @@
 #[macro_use]
 extern crate nom;
 
-use nom::IResult;
-
 macro_rules! n (
     ($name:ident( $i:ty ) -> $o:ty, $submac:ident!( $($args:tt)* )) => (
         fn $name( i: $i ) -> std::result::Result<nom::IResult<$i,$o,u32>, nom::Err<$i, u32>> {


### PR DESCRIPTION
This makes some `ErrorKind` references in macros absolute.

I noticed that *most* references to stdlib names are not absolute, and references to things like `::regex` aren't portable, either.  I wasn't sure if you'd want those fixed, too, so I just left things at nom's own names.

Incidentally, I also fixed all warnings I found when running tests.