### PR TITLE
Fix type inference failing with custom error types on str macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -268,24 +268,24 @@ macro_rules! fix_error (
         $crate::IResult::Done(i, o)    => $crate::IResult::Done(i, o),
         $crate::IResult::Error(e) => {
           let err = match e {
-            $crate::Err::Code(ErrorKind::Custom(_)) |
-              $crate::Err::Node(ErrorKind::Custom(_), _) => {
-              let e: ErrorKind<$t> = ErrorKind::Fix;
+            $crate::Err::Code($crate::ErrorKind::Custom(_)) |
+              $crate::Err::Node($crate::ErrorKind::Custom(_), _) => {
+              let e: $crate::ErrorKind<$t> = $crate::ErrorKind::Fix;
               $crate::Err::Code(e)
             },
-            $crate::Err::Position(ErrorKind::Custom(_), p) |
-              $crate::Err::NodePosition(ErrorKind::Custom(_), p, _) => {
-              let e: ErrorKind<$t> = ErrorKind::Fix;
+            $crate::Err::Position($crate::ErrorKind::Custom(_), p) |
+              $crate::Err::NodePosition($crate::ErrorKind::Custom(_), p, _) => {
+              let e: $crate::ErrorKind<$t> = $crate::ErrorKind::Fix;
               $crate::Err::Position(e, p)
             },
             $crate::Err::Code(_) |
               $crate::Err::Node(_, _) => {
-              let e: ErrorKind<$t> = ErrorKind::Fix;
+              let e: $crate::ErrorKind<$t> = $crate::ErrorKind::Fix;
               $crate::Err::Code(e)
             },
             $crate::Err::Position(_, p) |
               $crate::Err::NodePosition(_, p, _) => {
-              let e: ErrorKind<$t> = ErrorKind::Fix;
+              let e: $crate::ErrorKind<$t> = $crate::ErrorKind::Fix;
               $crate::Err::Position(e, p)
             },
           };

--- a/src/str.rs
+++ b/src/str.rs
@@ -100,13 +100,14 @@ macro_rules! is_not_s (
           break;
         }
       }
-      if offset == 0 {
+      let res: $crate::IResult<_,_> = if offset == 0 {
         $crate::IResult::Error($crate::Err::Position($crate::ErrorKind::IsAStr,$input))
       } else if offset < $input.len() {
         $crate::IResult::Done(&$input[offset..], &$input[..offset])
       } else {
         $crate::IResult::Done("", $input)
-      }
+      };
+      res
     }
   );
 );
@@ -140,13 +141,14 @@ macro_rules! is_a_s (
           break;
         }
       }
-      if offset == 0 {
+      let res: $crate::IResult<_,_> = if offset == 0 {
         $crate::IResult::Error($crate::Err::Position($crate::ErrorKind::IsAStr,$input))
       } else if offset < $input.len() {
         $crate::IResult::Done(&$input[offset..], &$input[..offset])
       } else {
         $crate::IResult::Done("", $input)
-      }
+      };
+      res
     }
   );
 );
@@ -180,11 +182,12 @@ macro_rules! take_while_s (
           break;
         }
       }
-      if offset < $input.len() {
+      let res: $crate::IResult<_,_> = if offset < $input.len() {
         $crate::IResult::Done(&$input[offset..], &$input[..offset])
       } else {
         $crate::IResult::Done("", $input)
-      }
+      };
+      res
     }
   );
   ($input:expr, $f:expr) => (
@@ -219,13 +222,14 @@ macro_rules! take_while1_s (
           break;
         }
       }
-      if offset == 0 {
+      let res: $crate::IResult<_,_> = if offset == 0 {
         $crate::IResult::Error($crate::Err::Position($crate::ErrorKind::TakeWhile1Str,$input))
       } else if offset < $input.len() {
         $crate::IResult::Done(&$input[offset..], &$input[..offset])
       } else {
         $crate::IResult::Done("", $input)
-      }
+      };
+      res
     }
   );
   ($input:expr, $f:expr) => (
@@ -250,11 +254,12 @@ macro_rules! take_till_s (
             break;
         }
       }
-      if offset < $input.len() {
+      let res: $crate::IResult<_,_> = if offset < $input.len() {
         $crate::IResult::Done(&$input[offset..], &$input[..offset])
       } else {
         $crate::IResult::Done("", $input)
-      }
+      };
+      res
     }
   );
   ($input:expr, $f:expr) => (


### PR DESCRIPTION
When using custom error types, a number of the macros in `str.rs` fail to infer the error type.

For example, this fails to compile:

```rust
#[macro_use]
extern crate nom;
use std::str::FromStr;
use nom::{digit, ErrorKind, IResult};

#[derive(Debug,PartialEq)]
enum MyError { Bad, VeryBad }

named!(numeric_data<&str, f32, MyError>,
       error!(ErrorKind::Custom(MyError::Bad),
              fix_error!(MyError,
                         map_res!(
                                  fix_error!(MyError, is_a_s!("12345")),
                                  FromStr::from_str))));

fn main() {
    assert_eq!(numeric_data("12,test"), IResult::Done(",test", 12.0));
}
```

With this error:
```
<nom macros>:7:1: 7:26 error: unable to infer enough type information about `_`; type annotations or generic parameter binding required [E0282]
<nom macros>:7 $ crate:: IResult:: Error (
               ^~~~~~~~~~~~~~~~~~~~~~~~~
<nom macros>:3:7: 3:42 note: in this expansion of is_a_s! (defined in <nom macros>)
<nom macros>:5:7: 5:42 note: in this expansion of fix_error! (defined in <nom macros>)
<nom macros>:2:1: 2:72 note: in this expansion of map_res_impl! (defined in <nom macros>)
<nom macros>:3:7: 3:42 note: in this expansion of map_res! (defined in <nom macros>)
<nom macros>:4:15: 4:50 note: in this expansion of fix_error! (defined in <nom macros>)
<nom macros>:9:1: 9:34 note: in this expansion of error! (defined in <nom macros>)
src/main.rs:9:1: 14:57 note: in this expansion of named! (defined in <nom macros>)
<nom macros>:7:1: 7:26 help: run `rustc --explain E0282` to see a detailed explanation
```

It turns out using the same pattern present elsewhere, of binding to `res` which has its type specified as `IResult<_,_>` and then returned, works fine. All the macros that already do this work, so I added this pattern to the remaining macros in `str.rs`, and now they also work (as does the sample code above).

On a related note, `fix_error` doesn't use `$crate` to reference `ErrorKind` so fails if the user doesn't have `ErrorKind` in scope, so fix that too.