### PR TITLE
Fixed take_till! to be usable from the outside of nom crate

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -491,7 +491,7 @@ macro_rules! take_till (
     {
       match $input.iter().position(|c| $submac!(c, $($args)*)) {
         Some(n) => $crate::IResult::Done(&$input[n..], &$input[..n]),
-        None    => $crate::IResult::Done(&$input[($input).input_len()..], $input)
+        None    => $crate::IResult::Done(&$input[$crate::util::InputLength::input_len(&$input)..], $input)
       }
     }
   );

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -487,11 +487,11 @@ macro_rules! take_while1 (
 #[macro_export]
 macro_rules! take_till (
   ($input:expr, $submac:ident!( $($args:tt)* )) => (
-
     {
+      use $crate::InputLength;
       match $input.iter().position(|c| $submac!(c, $($args)*)) {
         Some(n) => $crate::IResult::Done(&$input[n..], &$input[..n]),
-        None    => $crate::IResult::Done(&$input[$crate::util::InputLength::input_len(&$input)..], $input)
+        None    => $crate::IResult::Done(&$input[($input).input_len()..], $input)
       }
     }
   );

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -119,3 +119,13 @@ fn issue_152() {
   );
 }
 */
+
+#[test]
+fn take_till_issue() {
+    named!(nothing,
+        take_till!(call!(|_| true))
+    );
+
+    assert_eq!(nothing(b""), IResult::Done(&b""[..], &b""[..]));
+    assert_eq!(nothing(b"abc"), IResult::Done(&b"abc"[..], &b""[..]));
+}


### PR DESCRIPTION
Because of private trait macro shenanigans, it was impossible to use this macro due to compilation error. The attached test, for example, doesn't compile without this patch.