### PR TITLE
Make MemProducer produce Input::Eof records like FileProducer does

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -212,9 +212,11 @@ impl<'x,'b> Producer<'b,&'x[u8],Move> for MemProducer<'x> {
       }
     }
     {
-      use std::cmp;
-      let end = cmp::min(self.index + self.chunk_size, self.length);
-      consumer.handle(Input::Element(&self.buffer[self.index..end]))
+      if self.index + self.chunk_size > self.length {
+        consumer.handle(Input::Eof(Some(&self.buffer[self.index..self.length])))
+      } else {
+        consumer.handle(Input::Element(&self.buffer[self.index..self.index + self.chunk_size]))
+      }
     } else {
       consumer.state()
     }


### PR DESCRIPTION
If the record `MemProducer` is returning contains the end of the memory slice, this pull request changes it to return as an `Input::Eof` instead of an `Input::Element` to mimic the behavior `FileProducer` exhibits.

The motivation for this is to allow consumers to parse file formats that have an unknown-length final record (such as FASTA files; example using this approach at https://github.com/bovee/needletail/blob/master/src/fastx.rs). Without it, the previously-mentioned consumer that works on a `FileProducer` will, when applied to a `MemProducer`, enter a loop where it keeps issuing `Move::Await()` statements because it can not detect the end of the record (and these will cause a `panic!` because `Move::Await` is not implemented for `MemProducer`).

Although there is also an `eof` parser in `nom`, this may not be reliable in a streaming case where there is no more buffer to read, but the network connection hasn't closed yet (signalling the end of the file) so I think it's better to rely upon the producer's behavior.

This pull request does not affect the tests or coverage.