### PR TITLE
Fix clippy warnings on bit combinators

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -104,14 +104,14 @@ macro_rules! take_bits (
           let mut remaining: usize  = $count;
           let mut end_offset: usize = 0;
 
-          for it in 0..cnt+1 {
+          for byte in input.iter().take(cnt + 1) {
             if remaining == 0 {
               break;
             }
             let val: $t = if offset == 0 {
-              input[it] as $t
+              *byte as $t
             } else {
-              ((input[it] << offset) as u8 >> offset) as $t
+              ((*byte << offset) as u8 >> offset) as $t
             };
 
             if remaining < 8 - offset {

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -119,7 +119,7 @@ macro_rules! take_bits (
               end_offset = remaining + offset;
               break;
             } else {
-              acc += val << remaining - (8 - offset);
+              acc += val << (remaining - (8 - offset));
               remaining -= 8 - offset;
               offset = 0;
             }


### PR DESCRIPTION
Small changes to `take_bits!` macro that were found in sourrust/flac#5.