### PR TITLE
Add rest_s function

### DIFF
--- a/src/nom.rs
+++ b/src/nom.rs
@@ -529,6 +529,12 @@ pub fn rest(input: &[u8]) -> IResult<&[u8], &[u8]> {
     IResult::Done(&input[input.len()..], input)
 }
 
+/// Return the remaining input, for strings.
+#[inline]
+pub fn rest_s(input: &str) -> IResult<&str, &str> {
+    IResult::Done(&input[input.len()..], input)
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;


### PR DESCRIPTION
Simple enough to write when needed, but I thought it should be in `nom` to go with the rest of the `_s` functions.