### PR TITLE
Use len() to determine size of consumed data in recognize!

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -20,7 +20,7 @@ macro_rules! recognize (
       use $crate::HexDisplay;
       match $submac!($i, $($args)*) {
         $crate::IResult::Done(i,_)     => {
-          let index = ($i).offset(i);
+          let index = $i.len() - i.len();
           $crate::IResult::Done(i, &($i)[..index])
         },
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -17,10 +17,11 @@
 macro_rules! recognize (
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
+      use $crate::InputLength;
       use $crate::HexDisplay;
       match $submac!($i, $($args)*) {
         $crate::IResult::Done(i,_)     => {
-          let index = $i.len() - i.len();
+          let index = $i.input_len() - i.input_len();
           $crate::IResult::Done(i, &($i)[..index])
         },
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),


### PR DESCRIPTION
When using recognize! with &str, it fails because &str has no method offset(). I modified recognize! to use len(), which exists for both &str and slices.