### PR TITLE
Merge `_impl!` and `1!` macros into base macro

### DIFF
--- a/src/branch.rs
+++ b/src/branch.rs
@@ -310,23 +310,8 @@ macro_rules! alt_complete (
 ///
 #[macro_export]
 macro_rules! switch (
-  ($i:expr, $submac:ident!( $($args:tt)*), $($rest:tt)*) => (
-    {
-      switch_impl!($i, $submac!($($args)*), $($rest)*)
-    }
-  );
-  ($i:expr, $e:ident, $($rest:tt)*) => (
-    {
-      switch_impl!($i, call!($e), $($rest)*)
-    }
-  );
-);
-
-/// Internal parser, do not use directly
-#[doc(hidden)]
-#[macro_export]
-macro_rules! switch_impl (
-  ($i:expr, $submac:ident!( $($args:tt)* ), $($p:pat => $subrule:ident!( $($args2:tt)* ))|* ) => (
+  // Internal parser, do not use directly
+  (__impl $i:expr, $submac:ident!( $($args:tt)* ), $($p:pat => $subrule:ident!( $($args2:tt)* ))|* ) => (
     {
       match $submac!($i, $($args)*) {
         $crate::IResult::Error(e)      => $crate::IResult::Error(error_node_position!(
@@ -345,6 +330,16 @@ macro_rules! switch_impl (
           }
         }
       }
+    }
+  );
+  ($i:expr, $submac:ident!( $($args:tt)*), $($rest:tt)*) => (
+    {
+      switch!(__impl $i, $submac!($($args)*), $($rest)*)
+    }
+  );
+  ($i:expr, $e:ident, $($rest:tt)*) => (
+    {
+      switch!(__impl $i, call!($e), $($rest)*)
     }
   );
 );

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -228,37 +228,8 @@ macro_rules! is_a_bytes (
 /// ```
 #[macro_export]
 macro_rules! escaped (
-  ($i:expr, $submac:ident!( $($args:tt)* ), $control_char: expr, $($rest:tt)+) => (
-    {
-      let input: &[u8] = $i;
-
-      escaped1!(input, $submac!($($args)*), $control_char, $($rest)*)
-    }
-  );
-
-  ($i:expr, $f:expr, $control_char: expr, $($rest:tt)+) => (
-    escaped1!($i, call!($f), $control_char, $($rest)*)
-  );
-);
-
-/// Internal parser, do not use directly
-#[doc(hidden)]
-#[macro_export]
-macro_rules! escaped1 (
-  ($i:expr, $submac1:ident!( $($args:tt)* ), $control_char: expr, $submac2:ident!( $($args2:tt)*) ) => (
-    {
-     escaped_impl!($i, $submac1!($($args)*), $control_char,  $submac2!($($args2)*))
-    }
-  );
-  ($i:expr, $submac1:ident!( $($args:tt)* ), $control_char: expr, $g:expr) => (
-     escaped_impl!($i, $submac1!($($args)*), $control_char, call!($g))
-  );
-);
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! escaped_impl (
-  ($i: expr, $normal:ident!(  $($args:tt)* ), $control_char: expr, $escapable:ident!(  $($args2:tt)* )) => (
+  // Internal parser, do not use directly
+  (__impl $i: expr, $normal:ident!(  $($args:tt)* ), $control_char: expr, $escapable:ident!(  $($args2:tt)* )) => (
     {
       use $crate::InputLength;
       let cl = || {
@@ -307,6 +278,27 @@ macro_rules! escaped_impl (
       }
     }
   );
+  // Internal parser, do not use directly
+  (__impl_1 $i:expr, $submac1:ident!( $($args:tt)* ), $control_char: expr, $submac2:ident!( $($args2:tt)*) ) => (
+    {
+     escaped!(__impl $i, $submac1!($($args)*), $control_char,  $submac2!($($args2)*))
+    }
+  );
+  // Internal parser, do not use directly
+  (__impl_1 $i:expr, $submac1:ident!( $($args:tt)* ), $control_char: expr, $g:expr) => (
+     escaped!(__impl $i, $submac1!($($args)*), $control_char, call!($g))
+  );
+  ($i:expr, $submac:ident!( $($args:tt)* ), $control_char: expr, $($rest:tt)+) => (
+    {
+      let input: &[u8] = $i;
+
+      escaped!(__impl_1 input, $submac!($($args)*), $control_char, $($rest)*)
+    }
+  );
+
+  ($i:expr, $f:expr, $control_char: expr, $($rest:tt)+) => (
+    escaped!(__impl_1 $i, call!($f), $control_char, $($rest)*)
+  );
 );
 
 /// `escaped_transform!(&[T] -> IResult<&[T], &[T]>, T, &[T] -> IResult<&[T], &[T]>) => &[T] -> IResult<&[T], Vec<T>>`
@@ -346,37 +338,8 @@ macro_rules! escaped_impl (
 /// ```
 #[macro_export]
 macro_rules! escaped_transform (
-  ($i:expr, $submac:ident!( $($args:tt)* ), $control_char: expr, $($rest:tt)+) => (
-    {
-      let input: &[u8] = $i;
-
-      escaped_transform1!(input, $submac!($($args)*), $control_char, $($rest)*)
-    }
-  );
-
-  ($i:expr, $f:expr, $control_char: expr, $($rest:tt)+) => (
-    escaped_transform1!($i, call!($f), $control_char, $($rest)*)
-  );
-);
-
-/// Internal parser, do not use directly
-#[doc(hidden)]
-#[macro_export]
-macro_rules! escaped_transform1 (
-  ($i:expr, $submac1:ident!( $($args:tt)* ), $control_char: expr, $submac2:ident!( $($args2:tt)*) ) => (
-    {
-     escaped_transform_impl!($i, $submac1!($($args)*), $control_char,  $submac2!($($args2)*))
-    }
-  );
-  ($i:expr, $submac1:ident!( $($args:tt)* ), $control_char: expr, $g:expr) => (
-     escaped_transform_impl!($i, $submac1!($($args)*), $control_char, call!($g))
-  );
-);
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! escaped_transform_impl (
-  ($i: expr, $normal:ident!(  $($args:tt)* ), $control_char: expr, $transform:ident!(  $($args2:tt)* )) => (
+  // Internal parser, do not use directly
+  (__impl $i: expr, $normal:ident!(  $($args:tt)* ), $control_char: expr, $transform:ident!(  $($args2:tt)* )) => (
     {
       use $crate::InputLength;
       let cl = || {
@@ -427,7 +390,28 @@ macro_rules! escaped_transform_impl (
         }
       }
     }
-  )
+  );
+  // Internal parser, do not use directly
+  (__impl_1 $i:expr, $submac1:ident!( $($args:tt)* ), $control_char: expr, $submac2:ident!( $($args2:tt)*) ) => (
+    {
+     escaped_transform!(__impl $i, $submac1!($($args)*), $control_char,  $submac2!($($args2)*))
+    }
+  );
+  // Internal parser, do not use directly
+  (__impl_1 $i:expr, $submac1:ident!( $($args:tt)* ), $control_char: expr, $g:expr) => (
+     escaped_transform_impl!($i, $submac1!($($args)*), $control_char, call!($g))
+  );
+  ($i:expr, $submac:ident!( $($args:tt)* ), $control_char: expr, $($rest:tt)+) => (
+    {
+      let input: &[u8] = $i;
+
+      escaped_transform!(__impl_1 input, $submac!($($args)*), $control_char, $($rest)*)
+    }
+  );
+
+  ($i:expr, $f:expr, $control_char: expr, $($rest:tt)+) => (
+    escaped_transform!(__impl_1 $i, call!($f), $control_char, $($rest)*)
+  );
 );
 
 /// `take_while!(T -> bool) => &[T] -> IResult<&[T], &[T]>`

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -377,25 +377,8 @@ macro_rules! try_parse (
 /// maps a function on the result of a parser
 #[macro_export]
 macro_rules! map(
-  ($i:expr, $submac:ident!( $($args:tt)* ), $g:expr) => (
-    map_impl!($i, $submac!($($args)*), call!($g));
-  );
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
-    map_impl!($i, $submac!($($args)*), $submac2!($($args2)*));
-  );
-  ($i:expr, $f:expr, $g:expr) => (
-    map_impl!($i, call!($f), call!($g));
-  );
-  ($i:expr, $f:expr, $submac:ident!( $($args:tt)* )) => (
-    map_impl!($i, call!($f), $submac!($($args)*));
-  );
-);
-
-/// Internal parser, do not use directly
-#[doc(hidden)]
-#[macro_export]
-macro_rules! map_impl(
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+  // Internal parser, do not use directly
+  (__impl $i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
       match $submac!($i, $($args)*) {
         $crate::IResult::Error(e)                            => $crate::IResult::Error(e),
@@ -405,31 +388,26 @@ macro_rules! map_impl(
       }
     }
   );
+  ($i:expr, $submac:ident!( $($args:tt)* ), $g:expr) => (
+    map!(__impl $i, $submac!($($args)*), call!($g));
+  );
+  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+    map!(__impl $i, $submac!($($args)*), $submac2!($($args2)*));
+  );
+  ($i:expr, $f:expr, $g:expr) => (
+    map!(__impl $i, call!($f), call!($g));
+  );
+  ($i:expr, $f:expr, $submac:ident!( $($args:tt)* )) => (
+    map!(__impl $i, call!($f), $submac!($($args)*));
+  );
 );
 
 /// `map_res!(I -> IResult<I,O>, O -> Result<P>) => I -> IResult<I, P>`
 /// maps a function returning a Result on the output of a parser
 #[macro_export]
 macro_rules! map_res (
-  ($i:expr, $submac:ident!( $($args:tt)* ), $g:expr) => (
-    map_res_impl!($i, $submac!($($args)*), call!($g));
-  );
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
-    map_res_impl!($i, $submac!($($args)*), $submac2!($($args2)*));
-  );
-  ($i:expr, $f:expr, $g:expr) => (
-    map_res_impl!($i, call!($f), call!($g));
-  );
-  ($i:expr, $f:expr, $submac:ident!( $($args:tt)* )) => (
-    map_res_impl!($i, call!($f), $submac!($($args)*));
-  );
-);
-
-/// Internal parser, do not use directly
-#[doc(hidden)]
-#[macro_export]
-macro_rules! map_res_impl (
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+  // Internal parser, do not use directly
+  (__impl $i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
       match $submac!($i, $($args)*) {
         $crate::IResult::Error(e)                            => $crate::IResult::Error(e),
@@ -442,32 +420,26 @@ macro_rules! map_res_impl (
       }
     }
   );
+  ($i:expr, $submac:ident!( $($args:tt)* ), $g:expr) => (
+    map_res!(__impl $i, $submac!($($args)*), call!($g));
+  );
+  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+    map_res!(__impl $i, $submac!($($args)*), $submac2!($($args2)*));
+  );
+  ($i:expr, $f:expr, $g:expr) => (
+    map_res!(__impl $i, call!($f), call!($g));
+  );
+  ($i:expr, $f:expr, $submac:ident!( $($args:tt)* )) => (
+    map_res!(__impl $i, call!($f), $submac!($($args)*));
+  );
 );
-
 
 /// `map_opt!(I -> IResult<I,O>, O -> Option<P>) => I -> IResult<I, P>`
 /// maps a function returning an Option on the output of a parser
 #[macro_export]
 macro_rules! map_opt (
-  ($i:expr, $submac:ident!( $($args:tt)* ), $g:expr) => (
-    map_opt_impl!($i, $submac!($($args)*), call!($g));
-  );
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
-    map_opt_impl!($i, $submac!($($args)*), $submac2!($($args2)*));
-  );
-  ($i:expr, $f:expr, $g:expr) => (
-    map_opt_impl!($i, call!($f), call!($g));
-  );
-  ($i:expr, $f:expr, $submac:ident!( $($args:tt)* )) => (
-    map_opt_impl!($i, call!($f), $submac!($($args)*));
-  );
-);
-
-/// Internal parser, do not use directly
-#[doc(hidden)]
-#[macro_export]
-macro_rules! map_opt_impl (
-  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+  // Internal parser, do not use directly
+  (__impl $i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
       match $submac!($i, $($args)*) {
         $crate::IResult::Error(e)                            => $crate::IResult::Error(e),
@@ -479,6 +451,18 @@ macro_rules! map_opt_impl (
         }
       }
     }
+  );
+  ($i:expr, $submac:ident!( $($args:tt)* ), $g:expr) => (
+    map_opt!(__impl $i, $submac!($($args)*), call!($g));
+  );
+  ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
+    map_opt!(__impl $i, $submac!($($args)*), $submac2!($($args2)*));
+  );
+  ($i:expr, $f:expr, $g:expr) => (
+    map_opt!(__impl $i, call!($f), call!($g));
+  );
+  ($i:expr, $f:expr, $submac:ident!( $($args:tt)* )) => (
+    map_opt!(__impl $i, call!($f), $submac!($($args)*));
   );
 );
 
@@ -841,7 +825,7 @@ macro_rules! peek(
   );
 );
 
-/// `not!(I -> IResult<I,0>) => I -> IResult<I, O>`
+/// `not!(I -> IResult<I,O>) => I -> IResult<I, O>`
 /// returns a result only if the embedded parser returns Error or Incomplete
 /// does not consume the input
 ///


### PR DESCRIPTION
This should remove the need to import implementation macros when using the crate.