### PR TITLE
Change eol to test for newline first

### DIFF
--- a/src/character.rs
+++ b/src/character.rs
@@ -133,7 +133,7 @@ pub fn crlf(input:&[u8]) -> IResult<&[u8], char> {
   }
 }
 
-named!(pub eol<char>, alt!(crlf | newline));
+named!(pub eol<char>, alt!(newline | crlf));
 named!(pub tab<char>, char!('\t'));
 
 pub fn anychar(input:&[u8]) -> IResult<&[u8], char> {


### PR DESCRIPTION
If crlf is the first one to match, a single character will always return incomplete, even if it's a single '\n'. Change so that newline is the first test, so inputs of a single character are parsed correctly.