### PR TITLE
Document is_* tests for character types

### DIFF
--- a/src/nom.rs
+++ b/src/nom.rs
@@ -62,16 +62,19 @@ pub fn line_ending(input:&[u8]) -> IResult<&[u8], &[u8]> {
   tag_ln(input)
 }
 
+/// Tests if byte is ASCII alphabetic: A-Z, a-z
 #[inline]
 pub fn is_alphabetic(chr:u8) -> bool {
   (chr >= 0x41 && chr <= 0x5A) || (chr >= 0x61 && chr <= 0x7A)
 }
 
+/// Tests if byte is ASCII digit: 0-9
 #[inline]
 pub fn is_digit(chr: u8) -> bool {
   chr >= 0x30 && chr <= 0x39
 }
 
+/// Tests if byte is ASCII hex digit: 0-9, A-F, a-f
 #[inline]
 pub fn is_hex_digit(chr: u8) -> bool {
   (chr >= 0x30 && chr <= 0x39) ||
@@ -79,16 +82,19 @@ pub fn is_hex_digit(chr: u8) -> bool {
   (chr >= 0x61 && chr <= 0x66)
 }
 
+/// Tests if byte is ASCII octal digit: 0-7
 #[inline]
 pub fn is_oct_digit(chr: u8) -> bool {
   chr >= 0x30 && chr <= 0x37
 }
 
+/// Tests if byte is ASCII alphanumeric: A-Z, a-z, 0-9
 #[inline]
 pub fn is_alphanumeric(chr: u8) -> bool {
   is_alphabetic(chr) || is_digit(chr)
 }
 
+/// Tests if byte is ASCII space or tab
 #[inline]
 pub fn is_space(chr:u8) -> bool {
   chr == ' ' as u8 || chr == '\t' as u8


### PR DESCRIPTION
These tests are especially important to document because the equivalent tests on Rust's `char` type account for Unicode, while these only check ASCII bytes.