### PR TITLE
Including doc comments in named! macro (Not complete)

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -94,52 +94,62 @@ macro_rules! closure (
 /// ```
 #[macro_export]
 macro_rules! named (
-    ($name:ident( $i:ty ) -> $o:ty, $submac:ident!( $($args:tt)* )) => (
+    ($(#[$attr:meta])* $name:ident( $i:ty ) -> $o:ty, $submac:ident!( $($args:tt)* )) => (
+        $(#[$attr])*
         fn $name( i: $i ) -> $crate::IResult<$i,$o,u32> {
             $submac!(i, $($args)*)
         }
     );
-    ($name:ident<$i:ty,$o:ty,$e:ty>, $submac:ident!( $($args:tt)* )) => (
+    ($(#[$attr:meta])* $name:ident<$i:ty,$o:ty,$e:ty>, $submac:ident!( $($args:tt)* )) => (
+        $(#[$attr])*
         fn $name( i: $i ) -> $crate::IResult<$i, $o, $e> {
             $submac!(i, $($args)*)
         }
     );
-    ($name:ident<$i:ty,$o:ty>, $submac:ident!( $($args:tt)* )) => (
+    ($(#[$attr:meta])* $name:ident<$i:ty,$o:ty>, $submac:ident!( $($args:tt)* )) => (
+        $(#[$attr])*
         fn $name( i: $i ) -> $crate::IResult<$i, $o, u32> {
             $submac!(i, $($args)*)
         }
     );
-    ($name:ident<$o:ty>, $submac:ident!( $($args:tt)* )) => (
+    ($(#[$attr:meta])* $name:ident<$o:ty>, $submac:ident!( $($args:tt)* )) => (
+        $(#[$attr])*
         fn $name<'a>( i: &'a[u8] ) -> $crate::IResult<&'a [u8], $o, u32> {
             $submac!(i, $($args)*)
         }
     );
-    ($name:ident, $submac:ident!( $($args:tt)* )) => (
+    ($(#[$attr:meta])* $name:ident, $submac:ident!( $($args:tt)* )) => (
+        $(#[$attr])*
         fn $name( i: &[u8] ) -> $crate::IResult<&[u8], &[u8], u32> {
             $submac!(i, $($args)*)
         }
     );
-    (pub $name:ident( $i:ty ) -> $o:ty, $submac:ident!( $($args:tt)* )) => (
+    ($(#[$attr:meta])* pub $name:ident( $i:ty ) -> $o:ty, $submac:ident!( $($args:tt)* )) => (
+        $(#[$attr])*
         pub fn $name( i: $i ) -> $crate::IResult<$i,$o, u32> {
             $submac!(i, $($args)*)
         }
     );
-    (pub $name:ident<$i:ty,$o:ty,$e:ty>, $submac:ident!( $($args:tt)* )) => (
+    ($(#[$attr:meta])* pub $name:ident<$i:ty,$o:ty,$e:ty>, $submac:ident!( $($args:tt)* )) => (
+        $(#[$attr])*
         pub fn $name( i: $i ) -> $crate::IResult<$i, $o, $e> {
             $submac!(i, $($args)*)
         }
     );
-    (pub $name:ident<$i:ty,$o:ty>, $submac:ident!( $($args:tt)* )) => (
+    ($(#[$attr:meta])* pub $name:ident<$i:ty,$o:ty>, $submac:ident!( $($args:tt)* )) => (
+        $(#[$attr])*
         pub fn $name( i: $i ) -> $crate::IResult<$i, $o, u32> {
             $submac!(i, $($args)*)
         }
     );
-    (pub $name:ident<$o:ty>, $submac:ident!( $($args:tt)* )) => (
+    ($(#[$attr:meta])* pub $name:ident<$o:ty>, $submac:ident!( $($args:tt)* )) => (
+        $(#[$attr])*
         pub fn $name( i: &[u8] ) -> $crate::IResult<&[u8], $o, u32> {
             $submac!(i, $($args)*)
         }
     );
-    (pub $name:ident, $submac:ident!( $($args:tt)* )) => (
+    ($(#[$attr:meta])* pub $name:ident, $submac:ident!( $($args:tt)* )) => (
+        $(#[$attr])*
         pub fn $name<'a>( i: &'a [u8] ) -> $crate::IResult<&[u8], &[u8], u32> {
             $submac!(i, $($args)*)
         }


### PR DESCRIPTION
I am making a bunch of parsers with the `named!` macro and I want to be able to include doc comments for them so I can make doc tests. I tried putting them directly before the macro but they don't seem to be picked up by the compiler. So I decided to try to modify the `named!` macro to support them myself. I knew nothing about macros when I started this little experiment, so please be gentle. Hopefully there is a simple solution that I missed.

After a bit of research I found out that doc comments are actually converted to attributes during compilation, so `/// This is a doc comment` becomes `#[doc = "This is a doc comment"]`. Since we can [match meta attributes](https://doc.rust-lang.org/book/macros.html#syntactic-requirements) in macros, it should be possible to grab them and stick them before the output function. It seems to work with a [simple example](https://play.rust-lang.org/?code=macro_rules!%20test%20%7B%0A%20%20%20%20(%24(%23%5B%24attr%3Ameta%5D)*)%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%24(%23%5B%24attr%5D)*%0A%20%20%20%20%20%20%20%20fn%20print()%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20println!(%22Test!%22)%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20print()%3B%0A%20%20%20%20%7D%0A%7D%0A%0Afn%20main()%20%7B%0A%20%20%20%20test!(%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20Testing%0A%20%20%20%20%20%20%20%20%2F%2F%2F%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20%60%60%60%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20assert_eq!(true%2C%20true)%3B%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20%60%60%60%0A%20%20%20%20)%3B%0A%20%20%20%20println!(%22%7B%7D%22%2C%20%22Hello%20World%22)%3B%0A%7D&version=nightly&backtrace=0)(running `cargo rustc --lib -- -Z unstable-options --pretty=expanded` shows the `#[doc]` attributes directly above the print function). Unfortunately when I tried to modify the `named!` macro(with the changes in the commit in this pull request) to do the same thing, I ran info some ambiguity issues that are a bit above my skill level.

    error: local ambiguity: multiple parsing options: built-in NTs ident ('name') or 1 other option.

I found an [issue](https://github.com/rust-lang/rust/issues/24189) about this exact problem, and it does have a work-around, but it seems like a hack, and I don't really understand it enough to try it. Plus I think it would require some pretty big changes to the implementation of the `named!` macro, which might not be such a good idea.

I am wondering what your thoughts on this are @Geal? Is it even good idea at all. Is the solution worth the changes?