### PR TITLE
Don't use chain! in nom internals

### DIFF
--- a/docs/error_management.md
+++ b/docs/error_management.md
@@ -91,10 +91,10 @@ Sometimes, you want to provide an error code at a specific point in the parser t
 ```rust
     named!(err_test,
       preceded!(tag!("efgh"), add_error!(ErrorKind::Custom(42),
-          chain!(
-                 tag!("ijkl")              ~    
-            res: add_error!(ErrorKind::Custom(128), tag!("mnop")) ,
-            || { res }
+          do_parse!(
+                 tag!("ijkl")                                     >>
+            res: add_error!(ErrorKind::Custom(128), tag!("mnop")) >>
+            (res)
           )    
         )    
     ));  
@@ -124,10 +124,10 @@ named!(err_test, alt!(
     tag!("efgh"),
     error!(
       42,
-      chain!(
-             tag!("ijkl")              ~
-        res: error!(128, tag!("mnop")) ,
-        || { res }
+      do_parse!(
+             tag!("ijkl")              >>
+        res: error!(128, tag!("mnop")) >>
+        (res)
       )
     )
   )
@@ -267,10 +267,10 @@ named!(err_test, alt!(
   tag!("abcd") |
   error!(12,
     preceded!(tag!("efgh"), error!(42,
-        chain!(
-               tag!("ijk")              ~
-          res: error!(128, tag!("mnop")) ,
-          || { res }
+        do_parse!(
+               tag!("ijk")               >>
+          res: error!(128, tag!("mnop")) >>
+          (res)
         )
       )
     )

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -220,11 +220,11 @@ mod tests {
   }
 
   named!(ch<(&[u8],usize),(u8,u8)>,
-    chain!(
-      tag_bits!(u8, 3, 0b101) ~
-      x: take_bits!(u8, 4)    ~
-      y: take_bits!(u8, 5)    ,
-      || { (x,y) }
+    do_parse!(
+      tag_bits!(u8, 3, 0b101) >>
+      x: take_bits!(u8, 4)    >>
+      y: take_bits!(u8, 5)    >>
+      (x,y)
     )
   );
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -935,7 +935,7 @@ mod tests {
     assert_eq!(x(b"\x02."), Incomplete(Needed::Size(3)));
     assert_eq!(x(b"\x02"), Incomplete(Needed::Size(3)));
 
-    named!(y, chain!(tag!("magic") ~ b: length_bytes!(le_u8), || b));
+    named!(y, do_parse!(tag!("magic") >> b: length_bytes!(le_u8) >> (b)));
     assert_eq!(y(b"magic\x02..>>"), Done(&b">>"[..], &b".."[..]));
     assert_eq!(y(b"magic\x02.."), Done(&[][..], &b".."[..]));
     assert_eq!(y(b"magic\x02."), Incomplete(Needed::Size(8)));

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -208,10 +208,10 @@ macro_rules! apply (
 ///     named!(err_test, alt!(
 ///       tag!("abcd") |
 ///       preceded!(tag!("efgh"), return_error!(ErrorKind::Custom(42),
-///           chain!(
-///                  tag!("ijkl")              ~
-///             res: return_error!(ErrorKind::Custom(128), tag!("mnop")) ,
-///             || { res }
+///           do_parse!(
+///                  tag!("ijkl")                                        >>
+///             res: return_error!(ErrorKind::Custom(128), tag!("mnop")) >>
+///             (res)
 ///           )
 ///         )
 ///       )
@@ -333,7 +333,7 @@ macro_rules! complete (
 
 /// A bit like `std::try!`, this macro will return the remaining input and parsed value if the child parser returned `Done`,
 /// and will do an early return for `Error` and `Incomplete`
-/// this can provide more flexibility than `chain!` if needed
+/// this can provide more flexibility than `do_parse!` if needed
 ///
 /// ```
 /// # #[macro_use] extern crate nom;
@@ -536,11 +536,11 @@ macro_rules! expr_res (
 /// # use nom::{be_u8,ErrorKind};
 ///
 ///  fn take_add(input:&[u8], size: u8) -> IResult<&[u8],&[u8]> {
-///    chain!(input,
-///      sz:     be_u8                             ~
-///      length: expr_opt!(size.checked_add(sz))   ~ // checking for integer overflow (returns an Option)
-///      data:   take!(length)                     ,
-///      ||{ data }
+///    do_parse!(input,
+///      sz:     be_u8                             >>
+///      length: expr_opt!(size.checked_add(sz))   >> // checking for integer overflow (returns an Option)
+///      data:   take!(length)                     >>
+///      (data)
 ///    )
 ///  }
 /// # fn main() {
@@ -645,8 +645,8 @@ macro_rules! opt_res (
 /// parser.
 ///
 /// This is especially useful if a parser depends
-/// on the value return by a preceding parser in
-/// a `chain!`.
+/// on the value returned by a preceding parser in
+/// a `do_parse!`.
 ///
 /// ```
 /// # #[macro_use] extern crate nom;
@@ -698,8 +698,8 @@ macro_rules! cond_with_error(
 /// parser.
 ///
 /// This is especially useful if a parser depends
-/// on the value return by a preceding parser in
-/// a `chain!`.
+/// on the value returned by a preceding parser in
+/// a `do_parse!`.
 ///
 /// ```
 /// # #[macro_use] extern crate nom;
@@ -750,8 +750,8 @@ macro_rules! cond(
 /// an error if the condition is false
 ///
 /// This is especially useful if a parser depends
-/// on the value return by a preceding parser in
-/// a `chain!`.
+/// on the value returned by a preceding parser in
+/// a `do_parse!`.
 ///
 /// ```
 /// # #[macro_use] extern crate nom;
@@ -836,10 +836,11 @@ macro_rules! peek(
 /// # use nom::Err::Position;
 /// # use nom::ErrorKind;
 /// # fn main() {
-/// named!(not_e, chain!(
-///     res: tag!("abc") ~
-///          not!(char!('e')),
-///     || { res }));
+/// named!(not_e, do_parse!(
+///     res: tag!("abc")      >>
+///          not!(char!('e')) >>
+///     (res)
+/// ));
 ///
 /// let r = not_e(&b"abcd"[..]);
 /// assert_eq!(r, Done(&b"d"[..], &b"abc"[..]));

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -77,12 +77,12 @@
 //! counterparts:
 //! ```ignore
 //!    method!(pub simple_chain<&mut Parser<'a>, &'a str, &'a str>, self,
-//!      chain!(
-//!             call_m!(self.tag_abc)      ~
-//!             call_m!(self.tag_def)      ~
-//!             call_m!(self.tag_ghi)      ~
-//!       last: call_m!(self.simple_peek)  ,
-//!        ||{sb.parsed = last; last}
+//!      do_parse!(
+//!             call_m!(self.tag_abc)                                        >>
+//!             call_m!(self.tag_def)                                        >>
+//!             call_m!(self.tag_ghi)                                        >>
+//!       last: map!(call_m!(self.simple_peek), |parsed| sb.parsed = parsed) >>
+//!       (last)
 //!      )
 //!    );
 //! ```
@@ -325,10 +325,10 @@ mod tests {
       peek!(call_m!(self.take3))
     );
     method!(pub simple_chain<Parser<'a>, &'a str, &'a str>, mut self,
-      chain!(
-         bcd:  call_m!(self.tag_bcd)      ~
-         last: call_m!(self.simple_peek)  ,
-         ||{self.bcd = bcd; last}
+      do_parse!(
+         map!(call_m!(self.tag_bcd), |bcd| self.bcd = bcd) >>
+         last: call_m!(self.simple_peek)                   >>
+         (last)
       )
     );
     fn tag_stuff(mut self: Parser<'a>, input: &'a str, something: &'a str) -> (Parser<'a>, ::IResult<&'a str, &'a str>) {

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -1047,11 +1047,11 @@ mod tests {
 
   #[allow(dead_code)]
   pub fn compile_count_fixed(input: &[u8]) -> IResult<&[u8], ()> {
-    chain!(input,
-      tag!("abcd")                   ~
-      count_fixed!( u16, le_u16, 4 ) ~
-      eof!()                         ,
-      || { () }
+    do_parse!(input,
+      tag!("abcd")                   >>
+      count_fixed!( u16, le_u16, 4 ) >>
+      eof!()                         >>
+      ()
     )
   }
 

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -961,10 +961,10 @@ mod tests {
     named!(err_test, alt!(
       tag!("abcd") |
       preceded!(tag!("efgh"), return_error!(ErrorKind::Custom(42),
-          chain!(
-                 tag!("ijkl")              ~
-            res: return_error!(ErrorKind::Custom(128), tag!("mnop")) ,
-            || { res }
+          do_parse!(
+                 tag!("ijkl")                                        >>
+            res: return_error!(ErrorKind::Custom(128), tag!("mnop")) >>
+            (res)
           )
         )
       )
@@ -1016,10 +1016,10 @@ mod tests {
   fn add_err() {
     named!(err_test,
       preceded!(tag!("efgh"), add_error!(ErrorKind::Custom(42),
-          chain!(
-                 tag!("ijkl")              ~
-            res: add_error!(ErrorKind::Custom(128), tag!("mnop")) ,
-            || { res }
+          do_parse!(
+                 tag!("ijkl")                                     >>
+            res: add_error!(ErrorKind::Custom(128), tag!("mnop")) >>
+            (res)
           )
         )
     ));
@@ -1040,10 +1040,10 @@ mod tests {
   #[test]
   fn complete() {
     named!(err_test,
-      chain!(
-             tag!("ijkl")              ~
-        res: complete!(tag!("mnop")) ,
-        || { res }
+      do_parse!(
+             tag!("ijkl")            >>
+        res: complete!(tag!("mnop")) >>
+        (res)
       )
     );
     let a = &b"ijklmn"[..];

--- a/tests/arithmetic_ast.rs
+++ b/tests/arithmetic_ast.rs
@@ -86,27 +86,27 @@ fn fold_exprs(initial: Expr, remainder: Vec<(Oper, Expr)>) -> Expr {
     })
 }
 
-named!(term< Expr >, chain!(
-    initial: factor ~
+named!(term< Expr >, do_parse!(
+    initial: factor >>
     remainder: many0!(
            alt!(
-             chain!(tag!("*") ~ mul: factor, || { (Oper::Mul, mul) }) |
-             chain!(tag!("/") ~ div: factor, || { (Oper::Div, div) })
+             do_parse!(tag!("*") >> mul: factor >> (Oper::Mul, mul)) |
+             do_parse!(tag!("/") >> div: factor >> (Oper::Div, div))
            )
-         ),
-    || fold_exprs(initial, remainder))
-);
+         ) >>
+    (fold_exprs(initial, remainder))
+));
 
-named!(expr< Expr >, chain!(
-    initial: term ~
+named!(expr< Expr >, do_parse!(
+    initial: term >>
     remainder: many0!(
            alt!(
-             chain!(tag!("+") ~ add: term, || { (Oper::Add, add) }) |
-             chain!(tag!("-") ~ sub: term, || { (Oper::Sub, sub) })
+             do_parse!(tag!("+") >> add: term >> (Oper::Add, add)) |
+             do_parse!(tag!("-") >> sub: term >> (Oper::Sub, sub))
            )
-         ),
-    || fold_exprs(initial, remainder))
-);
+         ) >>
+    (fold_exprs(initial, remainder))
+));
 
 #[test]
 fn factor_test() {

--- a/tests/cross_function_backtracking.rs
+++ b/tests/cross_function_backtracking.rs
@@ -102,10 +102,10 @@ macro_rules! c (
 
 #[cfg(feature = "verbose_errors")]
 n!(pub foo< bool >,
-    chain!(
-        tag!("a") ~
-        cut!(nom::ErrorKind::Custom(42),dbg_dmp!(tag!("b"))) ,
-        || { true }
+    do_parse!(
+        tag!("a") >>
+        cut!(nom::ErrorKind::Custom(42),dbg_dmp!(tag!("b"))) >>
+        (true)
     )
 );
 

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -16,23 +16,23 @@ named!(category<&str>, map_res!(
 ));
 
 named!(key_value    <&[u8],(&str,&str)>,
-  chain!(
-    key: map_res!(alphanumeric, std::str::from_utf8) ~
-         space?                            ~
-         tag!("=")                         ~
-         space?                            ~
+  do_parse!(
+    key: map_res!(alphanumeric, std::str::from_utf8) >>
+         opt!(space)                                 >>
+         tag!("=")                                   >>
+         opt!(space)                                 >>
     val: map_res!(
            take_until_either!("\n;"),
            str::from_utf8
-         )                                 ~
-         space?                            ~
-         chain!(
-           tag!(";")        ~
-           not_line_ending  ,
-           ||{}
-         ) ?                               ~
-         multispace?                       ,
-    ||{(key, val)}
+         )                                           >>
+         opt!(space)                                 >>
+         opt!(do_parse!(
+           tag!(";")                                 >>
+           not_line_ending                           >>
+           ()
+         ))                                          >>
+         opt!(multispace)                            >>
+    (key, val)
   )
 );
 
@@ -55,10 +55,10 @@ fn keys_and_values(input:&[u8]) -> IResult<&[u8], HashMap<&str, &str> > {
 }
 
 named!(category_and_keys<&[u8],(&str,HashMap<&str,&str>)>,
-  chain!(
-    category: category    ~
-    keys: keys_and_values ,
-    move ||{(category, keys)}
+  do_parse!(
+    category: category    >>
+    keys: keys_and_values >>
+    (category, keys)
   )
 );
 

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -36,26 +36,26 @@ fn right_bracket(c:char) -> bool {
 }
 
 named!(category     <&str, &str>,
-  chain!(
-          tag_s!("[")                 ~
-    name: take_till_s!(right_bracket) ~
-          tag_s!("]")                 ~
-          space_or_line_ending?       ,
-    ||{ name }
+  do_parse!(
+          tag_s!("[")                 >>
+    name: take_till_s!(right_bracket) >>
+          tag_s!("]")                 >>
+          opt!(space_or_line_ending)  >>
+    (name)
   )
 );
 
 named!(key_value    <&str,(&str,&str)>,
-  chain!(
-    key: alphanumeric                            ~
-         space?                                  ~
-         tag_s!("=")                             ~
-         space?                                  ~
-    val: take_till_s!(is_line_ending_or_comment) ~
-         space?                                  ~
-         pair!(tag_s!(";"), not_line_ending)?    ~
-         space_or_line_ending?                   ,
-    ||{(key, val)}
+  do_parse!(
+    key: alphanumeric                              >>
+         opt!(space)                               >>
+         tag_s!("=")                               >>
+         opt!(space)                               >>
+    val: take_till_s!(is_line_ending_or_comment)   >>
+         opt!(space)                               >>
+         opt!(pair!(tag_s!(";"), not_line_ending)) >>
+         opt!(space_or_line_ending)                >>
+    (key, val)
   )
 );
 

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -24,23 +24,21 @@ pub fn take_char(input: &[u8]) -> IResult<&[u8], char> {
 #[allow(dead_code)]
 named!(range<&[u8], Range>,
     alt!(
-        chain!(
-            start: take_char ~
-            tag!("-") ~
-            end: take_char,
-            || {
-                Range {
-                    start: start,
-                    end: end,
-                }
-            }
+        do_parse!(
+            start: take_char >>
+            tag!("-")        >>
+            end: take_char   >>
+            (Range {
+                start: start,
+                end:   end,
+            })
         ) |
         map!(
             take_char,
             |c| {
                 Range {
                     start: c,
-                    end: c,
+                    end:   c,
                 }
             }
         )
@@ -70,10 +68,10 @@ named!(parse_ints< Vec<i32> >, many0!(spaces_or_int));
 
 fn spaces_or_int(input: &[u8]) -> IResult<&[u8], i32>{
   println!("{}", input.to_hex(8));
-  chain!(input,
-    opt!(complete!(space)) ~
-    x:   complete!(digit),
-    || {
+  do_parse!(input,
+    opt!(complete!(space)) >>
+    res: map!(complete!(digit),
+    |x| {
       println!("x: {:?}", x);
       let result = str::from_utf8(x).unwrap();
       println!("Result: {}", result);
@@ -82,7 +80,8 @@ fn spaces_or_int(input: &[u8]) -> IResult<&[u8], i32>{
         Ok(i) => i,
         Err(_) =>  panic!("UH OH! NOT A DIGIT!")
       }
-    }
+    }) >>
+    (res)
   )
 }
 

--- a/tests/mp4.rs
+++ b/tests/mp4.rs
@@ -93,30 +93,30 @@ pub struct Mvhd64 {
 
 #[allow(non_snake_case)]
 named!(mvhd32 <&[u8], MvhdBox>,
-  chain!(
-  version_flags: be_u32 ~
-  created_date:  be_u32 ~
-  modified_date: be_u32 ~
-  scale:         be_u32 ~
-  duration:      be_u32 ~
-  speed:         be_f32 ~
-  volume:        be_u16 ~ // actually a 2 bytes decimal
-              take!(10) ~
-  scale_a:       be_f32 ~
-  rotate_b:      be_f32 ~
-  angle_u:       be_f32 ~
-  rotate_c:      be_f32 ~
-  scale_d:       be_f32 ~
-  angle_v:       be_f32 ~
-  position_x:    be_f32 ~
-  position_y:    be_f32 ~
-  scale_w:       be_f32 ~
-  preview:       be_u64 ~
-  poster:        be_u32 ~
-  selection:     be_u64 ~
-  current_time:  be_u32 ~
-  track_id:      be_u32,
-  ||{
+  do_parse!(
+  version_flags: be_u32 >>
+  created_date:  be_u32 >>
+  modified_date: be_u32 >>
+  scale:         be_u32 >>
+  duration:      be_u32 >>
+  speed:         be_f32 >>
+  volume:        be_u16 >> // actually a 2 bytes decimal
+              take!(10) >>
+  scale_a:       be_f32 >>
+  rotate_b:      be_f32 >>
+  angle_u:       be_f32 >>
+  rotate_c:      be_f32 >>
+  scale_d:       be_f32 >>
+  angle_v:       be_f32 >>
+  position_x:    be_f32 >>
+  position_y:    be_f32 >>
+  scale_w:       be_f32 >>
+  preview:       be_u64 >>
+  poster:        be_u32 >>
+  selection:     be_u64 >>
+  current_time:  be_u32 >>
+  track_id:      be_u32 >>
+  (
     MvhdBox::M32(Mvhd32 {
       version_flags: version_flags,
       created_date:  created_date,
@@ -140,36 +140,35 @@ named!(mvhd32 <&[u8], MvhdBox>,
       current_time:  current_time,
       track_id:      track_id
     })
-  }
-  )
+  ))
 );
 
 #[allow(non_snake_case)]
 named!(mvhd64 <&[u8], MvhdBox>,
-  chain!(
-  version_flags: be_u32 ~
-  created_date:  be_u64 ~
-  modified_date: be_u64 ~
-  scale:         be_u32 ~
-  duration:      be_u64 ~
-  speed:         be_f32 ~
-  volume:        be_u16 ~ // actually a 2 bytes decimal
-              take!(10) ~
-  scale_a:       be_f32 ~
-  rotate_b:      be_f32 ~
-  angle_u:       be_f32 ~
-  rotate_c:      be_f32 ~
-  scale_d:       be_f32 ~
-  angle_v:       be_f32 ~
-  position_x:    be_f32 ~
-  position_y:    be_f32 ~
-  scale_w:       be_f32 ~
-  preview:       be_u64 ~
-  poster:        be_u32 ~
-  selection:     be_u64 ~
-  current_time:  be_u32 ~
-  track_id:      be_u32,
-  ||{
+  do_parse!(
+  version_flags: be_u32 >>
+  created_date:  be_u64 >>
+  modified_date: be_u64 >>
+  scale:         be_u32 >>
+  duration:      be_u64 >>
+  speed:         be_f32 >>
+  volume:        be_u16 >> // actually a 2 bytes decimal
+              take!(10) >>
+  scale_a:       be_f32 >>
+  rotate_b:      be_f32 >>
+  angle_u:       be_f32 >>
+  rotate_c:      be_f32 >>
+  scale_d:       be_f32 >>
+  angle_v:       be_f32 >>
+  position_x:    be_f32 >>
+  position_y:    be_f32 >>
+  scale_w:       be_f32 >>
+  preview:       be_u64 >>
+  poster:        be_u32 >>
+  selection:     be_u64 >>
+  current_time:  be_u32 >>
+  track_id:      be_u32 >>
+  (
     MvhdBox::M64(Mvhd64 {
       version_flags: version_flags,
       created_date:  created_date,
@@ -193,8 +192,7 @@ named!(mvhd64 <&[u8], MvhdBox>,
       current_time:  current_time,
       track_id:      track_id
     })
-  }
-  )
+  ))
 );
 
 #[derive(Debug,Clone)]
@@ -245,11 +243,11 @@ struct MP4BoxHeader {
 named!(brand_name<&[u8],&str>, map_res!(take!(4), str::from_utf8));
 
 named!(filetype_parser<&[u8], FileType>,
-  chain!(
-    m: brand_name          ~
-    v: take!(4)            ~
-    c: many0!(brand_name)  ,
-    ||{ FileType{ major_brand: m, major_brand_version:v, compatible_brands: c } }
+  do_parse!(
+    m: brand_name          >>
+    v: take!(4)            >>
+    c: many0!(brand_name)  >>
+    (FileType{ major_brand: m, major_brand_version:v, compatible_brands: c })
   )
 );
 
@@ -302,18 +300,18 @@ named!(moov_type<&[u8], MP4BoxType>,
 );
 
 named!(box_header<&[u8],MP4BoxHeader>,
-  chain!(
-    length: be_u32 ~
-    tag: box_type  ,
-    || { MP4BoxHeader{ length: length, tag: tag} }
+  do_parse!(
+    length: be_u32 >>
+    tag: box_type  >>
+    (MP4BoxHeader{ length: length, tag: tag})
   )
 );
 
 named!(moov_header<&[u8],MP4BoxHeader>,
-  chain!(
-    length: be_u32 ~
-    tag: moov_type  ,
-    || { MP4BoxHeader{ length: length, tag: tag} }
+  do_parse!(
+    length: be_u32 >>
+    tag: moov_type >>
+    (MP4BoxHeader{ length: length, tag: tag})
   )
 );
 


### PR DESCRIPTION
Fixes part of #328

The only places where chain! is still listed/used are the Changelog, the nom-1.0 porting guide, the chain! documentation, the chain! unit tests, tsome arithmetic tests and the README.

Two other pull requests address the two latters, all the others should stay as is I guess.
