### PR TITLE
Don't use chain! in arithmetic tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,65 +12,57 @@
 //! extern crate nom;
 //!
 //! use nom::{IResult,digit};
-//! use nom::IResult::*;
 //!
 //! // Parser definition
 //!
 //! use std::str;
 //! use std::str::FromStr;
 //!
-//! named!(parens<i64>, delimited!(
-//!     char!('('),
-//!     expr,
-//!     char!(')')
-//!   )
-//! );
+//! // We parse any expr surrounded by parens, ignoring all whitespaces around those
+//! named!(parens<i64>, ws!(delimited!( tag!("("), expr, tag!(")") )) );
 //!
-//! named!(i64_digit<i64>,
-//!   map_res!(
+//! // We transform an integer string into a i64, ignoring surrounding whitespaces
+//! // We look for a digit suite, and try to convert it.
+//! // If either str::from_utf8 or FromStr::from_str fail,
+//! // we fallback to the parens parser defined above
+//! named!(factor<i64>, alt!(
 //!     map_res!(
-//!       digit,
-//!       str::from_utf8
-//!     ),
-//!     FromStr::from_str
-//!   )
-//! );
-//!
-//! // We transform an integer string into a i64
-//! // we look for a digit suite, and try to convert it.
-//! // if either str::from_utf8 or FromStr::from_str fail,
-//! // the parser will fail
-//! named!(factor<i64>,
-//!   alt!(
-//!     i64_digit
+//!       map_res!(
+//!         ws!(digit),
+//!         str::from_utf8
+//!       ),
+//!       FromStr::from_str
+//!     )
 //!   | parens
 //!   )
 //! );
 //!
-//! // we define acc as mutable to update its value whenever a new term is found
-//! named!(term <i64>,
-//!   chain!(
-//!     mut acc: factor  ~
-//!              many0!(
-//!                alt!(
-//!                  tap!(mul: preceded!(tag!("*"), factor) => acc = acc * mul) |
-//!                  tap!(div: preceded!(tag!("/"), factor) => acc = acc / div)
-//!                )
-//!              ),
-//!     || { return acc }
+//! // We read an initial factor and for each time we find
+//! // a * or / operator followed by another factor, we do
+//! // the math by folding everything
+//! named!(term <i64>, do_parse!(
+//!     init: factor >>
+//!     res:  fold_many0!(
+//!         pair!(alt!(tag!("*") | tag!("/")), factor),
+//!         init,
+//!         |acc, (op, val): (&[u8], i64)| {
+//!             if (op[0] as char) == '*' { acc * val } else { acc / val }
+//!         }
+//!     ) >>
+//!     (res)
 //!   )
 //! );
 //!
-//! named!(expr <i64>,
-//!   chain!(
-//!     mut acc: term  ~
-//!              many0!(
-//!                alt!(
-//!                  tap!(add: preceded!(tag!("+"), term) => acc = acc + add) |
-//!                  tap!(sub: preceded!(tag!("-"), term) => acc = acc - sub)
-//!                )
-//!              ),
-//!     || { return acc }
+//! named!(expr <i64>, do_parse!(
+//!     init: term >>
+//!     res:  fold_many0!(
+//!         pair!(alt!(tag!("+") | tag!("-")), term),
+//!         init,
+//!         |acc, (op, val): (&[u8], i64)| {
+//!             if (op[0] as char) == '+' { acc + val } else { acc - val }
+//!         }
+//!     ) >>
+//!     (res)
 //!   )
 //! );
 //!

--- a/tests/arithmetic.rs
+++ b/tests/arithmetic.rs
@@ -20,27 +20,29 @@ named!(factor<i64>, alt!(
   )
 );
 
-named!(term <i64>, chain!(
-    mut acc: factor  ~
-             many0!(
-               alt!(
-                 tap!(mul: preceded!(tag!("*"), factor) => acc = acc * mul) |
-                 tap!(div: preceded!(tag!("/"), factor) => acc = acc / div)
-               )
-             ),
-    || { return acc }
+named!(term <i64>, do_parse!(
+    init: factor >>
+    res:  fold_many0!(
+        pair!(alt!(tag!("*") | tag!("/")), factor),
+        init,
+        |acc, (op, val): (&[u8], i64)| {
+            if (op[0] as char) == '*' { acc * val } else { acc / val }
+        }
+    ) >>
+    (res)
   )
 );
 
-named!(expr <i64>, chain!(
-    mut acc: term  ~
-             many0!(
-               alt!(
-                 tap!(add: preceded!(tag!("+"), term) => acc = acc + add) |
-                 tap!(sub: preceded!(tag!("-"), term) => acc = acc - sub)
-               )
-             ),
-    || { return acc }
+named!(expr <i64>, do_parse!(
+    init: term >>
+    res:  fold_many0!(
+        pair!(alt!(tag!("+") | tag!("-")), term),
+        init,
+        |acc, (op, val): (&[u8], i64)| {
+            if (op[0] as char) == '+' { acc + val } else { acc - val }
+        }
+    ) >>
+    (res)
   )
 );
 

--- a/tests/arithmetic.rs
+++ b/tests/arithmetic.rs
@@ -3,11 +3,18 @@ extern crate nom;
 
 use nom::{IResult,digit};
 
+// Parser definition
+
 use std::str;
 use std::str::FromStr;
 
+// We parse any expr surrounded by parens, ignoring all whitespaces around those
 named!(parens<i64>, ws!(delimited!( tag!("("), expr, tag!(")") )) );
 
+// We transform an integer string into a i64, ignoring surrounding whitespaces
+// We look for a digit suite, and try to convert it.
+// If either str::from_utf8 or FromStr::from_str fail,
+// we fallback to the parens parser defined above
 named!(factor<i64>, alt!(
     map_res!(
       map_res!(
@@ -20,6 +27,9 @@ named!(factor<i64>, alt!(
   )
 );
 
+// We read an initial factor and for each time we find
+// a * or / operator followed by another factor, we do
+// the math by folding everything
 named!(term <i64>, do_parse!(
     init: factor >>
     res:  fold_many0!(


### PR DESCRIPTION
Fixes part of #328

This one is a little trickier, in order to drop the mut usage, I used fold_many which might be less intuitive.
I think it's a good start though, until we rewrite it another way maybe at some point.
