### PR TITLE
Fix problem with IterIndices for str

### DIFF
--- a/src/str.rs
+++ b/src/str.rs
@@ -64,6 +64,10 @@ macro_rules! tag_no_case_s (
 ///  let a = "abcdefgh";
 ///
 ///  assert_eq!(take5(a), Done("fgh", "abcde"));
+///
+///  let b = "12345";
+///
+///  assert_eq!(take5(b), Done("", "12345"));
 /// # }
 /// ```
 #[macro_export]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -211,6 +211,9 @@ impl<'a> IterIndices for &'a str {
         }
         cnt += 1;
       }
+      if cnt == count {
+        return Some(self.len())
+      }
       None
     }
 }


### PR DESCRIPTION
The implementation of `IterIndices::index` for `&str` didn't correctly handle the case when the slice is exactly the right length.  Add a fix by checking for the right length if we get to the end of `char_indices()`.