### PR TITLE
Improve documentation for `alt!` and `alt_complete!`

### DIFF
--- a/src/branch.rs
+++ b/src/branch.rs
@@ -5,7 +5,7 @@
 /// ```
 /// All the parsers must have the same return type.
 ///
-/// If one of the parser returns `Incomplete`, `alt!` will return `Incomplete`, to retry
+/// If one of the parsers returns `Incomplete`, `alt!` will return `Incomplete`, to retry
 /// once you get more input. Note that it is better for performance to know the
 /// minimum size of data you need before you get into `alt!`.
 ///
@@ -242,11 +242,26 @@ macro_rules! alt (
   );
 );
 
-/// This is a combination of the `alt!` and `complete!` combinators. Rather
-/// than returning `Incomplete` on partial input, `alt_complete!` will try the
-/// next alternative in the chain. You should use this only if you know you
+/// Is equivalent to the `alt!` combinator, except that it will not return `Incomplete`
+/// when one of the constituting parsers returns `Incomplete`. Instead, it will try the
+/// next alternative in the chain.
+///
+/// You should use this combinator only if you know you
 /// will not receive partial input for the rules you're trying to match (this
 /// is almost always the case for parsing programming languages).
+///
+/// ```rust,ignore
+/// alt_complete!(I -> IResult<I,O> | I -> IResult<I,O> | ... | I -> IResult<I,O> ) => I -> IResult<I, O>
+/// ```
+/// All the parsers must have the same return type.
+///
+/// If one of the parsers return `Incomplete`, `alt_complete!` will try the next alternative.
+/// If there is no other parser left to try, an `Error` will be returned.
+///
+/// ```rust,ignore
+/// alt_complete!(parser_1 | parser_2 | ... | parser_n)
+/// ```
+/// **For more in depth examples, refer to the documentation of `alt!`**
 #[macro_export]
 macro_rules! alt_complete (
   // Recursive rules (must include `complete!` around the head)

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -1,47 +1,97 @@
-/// `alt!(I -> IResult<I,O> | I -> IResult<I,O> | ... | I -> IResult<I,O> ) => I -> IResult<I, O>`
-/// try a list of parsers, return the result of the first successful one
+/// Try a list of parsers and return the result of the first successful one
 ///
-/// If one of the parser returns Incomplete, alt will return Incomplete, to retry
+/// ```rust,ignore
+/// alt!(I -> IResult<I,O> | I -> IResult<I,O> | ... | I -> IResult<I,O> ) => I -> IResult<I, O>
+/// ```
+/// All the parsers must have the same return type.
+///
+/// If one of the parser returns `Incomplete`, `alt!` will return `Incomplete`, to retry
 /// once you get more input. Note that it is better for performance to know the
-/// minimum size of data you need before you get into alt.
+/// minimum size of data you need before you get into `alt!`.
+///
+/// The `alt!` combinator is used in the following way:
+///
+/// ```rust,ignore
+/// alt!(parser_1 | parser_2 | ... | parser_n)
+/// ```
+///
+/// # Basic example
 ///
 /// ```
 /// # #[macro_use] extern crate nom;
-/// # use nom::IResult::Done;
 /// # fn main() {
-///  named!( test, alt!( tag!( "abcd" ) | tag!( "efgh" ) ) );
-///  let r1 = test(b"abcdefgh");
-///  assert_eq!(r1, Done(&b"efgh"[..], &b"abcd"[..]));
-///  let r2 = test(&b"efghijkl"[..]);
-///  assert_eq!(r2, Done(&b"ijkl"[..], &b"efgh"[..]));
+///  // Create a parser that will match either "dragon" or "beast"
+///  named!( dragon_or_beast, alt!( tag!( "dragon" ) | tag!( "beast" ) ) );
+///
+///  // Given the input "dragon slayer", the parser will match "dragon"
+///  // and the rest will be " slayer"
+///  let (rest, result) = dragon_or_beast(b"dragon slayer").unwrap();
+///  assert_eq!(result, b"dragon");
+///  assert_eq!(rest, b" slayer");
+///
+///  // Given the input "beast of Gevaudan", the parser will match "beast"
+///  // and the rest will be " of Gevaudan"
+///  let (rest, result) = dragon_or_beast(&b"beast of Gevaudan"[..]).unwrap();
+///  assert_eq!(result, b"beast");
+///  assert_eq!(rest, b" of Gevaudan");
 ///  # }
 /// ```
 ///
-/// There is another syntax for alt allowing a block to manipulate the result:
+/// # Manipulate results
+///
+/// There exists another syntax for `alt!` that gives you the ability to
+/// manipulate the result from each parser:
 ///
 /// ```
 /// # #[macro_use] extern crate nom;
 /// # use nom::IResult::Done;
 /// # fn main() {
-///     #[derive(Debug,PartialEq,Eq)]
-///     enum Tagged {
-///       Abcd,
-///       Efgh,
-///       Took(usize)
-///     }
-///     named!(test<Tagged>, alt!(
-///         tag!("abcd") => { |_|          Tagged::Abcd }
-///       | tag!("efgh") => { |_|          Tagged::Efgh }
-///       | take!(5)     => { |res: &[u8]| Tagged::Took(res.len()) } // the closure takes the result as argument if the parser is successful
-///     ));
-///     let r1 = test(b"abcdefgh");
-///     assert_eq!(r1, Done(&b"efgh"[..], Tagged::Abcd));
-///     let r2 = test(&b"efghijkl"[..]);
-///     assert_eq!(r2, Done(&b"ijkl"[..], Tagged::Efgh));
-///     let r3 = test(&b"mnopqrst"[..]);
-///     assert_eq!(r3, Done(&b"rst"[..],  Tagged::Took(5)));
+/// #
+/// // We create an enum to represent our creatures
+/// #[derive(Debug,PartialEq,Eq)]
+/// enum Creature {
+///     Dragon,
+///     Beast,
+///     Unknown(usize)
+/// }
+///
+/// // Let's make a helper function that returns true when not a space
+/// // we are required to do this because the `take_while!` macro is limited
+/// // to idents, so we can't negate `ìs_space` at the call site
+/// fn is_not_space(c: u8) -> bool { ! nom::is_space(c) }
+///
+/// // Our parser will return the `Dragon` variant when matching "dragon",
+/// // the `Beast` variant when matching "beast" and otherwise it will consume
+/// // the input until a space is found and return an `Unknown` creature with
+/// // the size of it's name.
+/// named!(creature<Creature>, alt!(
+///     tag!("dragon")            => { |_| Creature::Dragon } |
+///     tag!("beast")             => { |_| Creature::Beast }  |
+///     take_while!(is_not_space) => { |r: &[u8]| Creature::Unknown(r.len()) }
+///     // the closure takes the result as argument if the parser is successful
+/// ));
+///
+/// // Given the input "dragon slayer" the parser will return `Creature::Dragon`
+/// // and the rest will be " slayer"
+/// let (rest, result) = creature(b"dragon slayer").unwrap();
+/// assert_eq!(result, Creature::Dragon);
+/// assert_eq!(rest, b" slayer");
+///
+/// // Given the input "beast of Gevaudan" the parser will return `Creature::Beast`
+/// // and the rest will be " of Gevaudan"
+/// let (rest, result) = creature(b"beast of Gevaudan").unwrap();
+/// assert_eq!(result, Creature::Beast);
+/// assert_eq!(rest, b" of Gevaudan");
+///
+/// // Given the input "demon hunter" the parser will return `Creature::Unkown(5)`
+/// // and the rest will be " hunter"
+/// let (rest, result) = creature(b"demon hunter").unwrap();
+/// assert_eq!(result, Creature::Unknown(5));
+/// assert_eq!(rest, b" hunter");
 /// # }
 /// ```
+///
+/// # Behaviour of `alt!`
 ///
 /// **BE CAREFUL** there is a case where the behaviour of `alt!` can be confusing:
 ///


### PR DESCRIPTION
I'm trying to improve the documentation a little and started with the `alt!` and `alt_complete!` combinators. Here is what I changed:

- Made the short description, shorter and easier to read.
  In my opinion, things like `alt!(I -> IResult<I,O> | I -> IResult<I,O> | ... | I -> IResult<I,O> ) => I -> IResult<I, O>` are too long to be in the short description. When all the combinators are listed on the front page of the docs it's easier to have a one line overview of what that combinator does, instead of a full type description.
- Added titles to differentiate between different sections of the page (e.g. example, manipulate results, ...).
- Changed the examples to be a little more readable by adding spaces, comments and making it a little more realistic.

I am not sure if you will like the changes, if not, feel free to close this PR. :smiley: 

