### PR TITLE
Rename add_error to add_return_error

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -338,7 +338,7 @@ macro_rules! return_error (
 /// Add an error if the child parser fails
 ///
 /// While error! does an early return and avoids backtracking,
-/// add_error! backtracks normally. It just provides more context
+/// add_return_error! backtracks normally. It just provides more context
 /// for an error
 ///
 /// ```
@@ -349,7 +349,7 @@ macro_rules! return_error (
 /// # use nom::Err::{Position,NodePosition};
 /// # use nom::ErrorKind;
 /// # fn main() {
-///     named!(err_test, add_error!(ErrorKind::Custom(42), tag!("abcd")));
+///     named!(err_test, add_return_error!(ErrorKind::Custom(42), tag!("abcd")));
 ///
 ///     let a = &b"efghblah"[..];
 ///     let res_a = err_test(a);
@@ -358,7 +358,7 @@ macro_rules! return_error (
 /// ```
 ///
 #[macro_export]
-macro_rules! add_error (
+macro_rules! add_return_error (
   ($i:expr, $code:expr, $submac:ident!( $($args:tt)* )) => (
     {
       match $submac!($i, $($args)*) {
@@ -371,7 +371,7 @@ macro_rules! add_error (
     }
   );
   ($i:expr, $code:expr, $f:expr) => (
-    add_error!($i, $code, call!($f));
+    add_return_error!($i, $code, call!($f));
   );
 );
 

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -1015,10 +1015,10 @@ mod tests {
   #[test]
   fn add_err() {
     named!(err_test,
-      preceded!(tag!("efgh"), add_error!(ErrorKind::Custom(42),
+      preceded!(tag!("efgh"), add_return_error!(ErrorKind::Custom(42),
           do_parse!(
                  tag!("ijkl")                                     >>
-            res: add_error!(ErrorKind::Custom(128), tag!("mnop")) >>
+            res: add_return_error!(ErrorKind::Custom(128), tag!("mnop")) >>
             (res)
           )
         )

--- a/src/simple_errors.rs
+++ b/src/simple_errors.rs
@@ -91,9 +91,9 @@ impl<E: fmt::Debug> fmt::Display for Err<E> {
 /// # use nom::ErrorKind;
 /// # fn main() {
 ///     // will add a Custom(42) error to the error chain
-///     named!(err_test, add_error!(ErrorKind::Custom(42), tag!("abcd")));
+///     named!(err_test, add_return_error!(ErrorKind::Custom(42), tag!("abcd")));
 ///     // Convert to IREsult<&[u8], &[u8], &str>
-///     named!(parser<&[u8], &[u8], &str>, add_error!(ErrorKind::Custom("custom error message"), fix_error!(&str, err_test)));
+///     named!(parser<&[u8], &[u8], &str>, add_return_error!(ErrorKind::Custom("custom error message"), fix_error!(&str, err_test)));
 ///
 ///     let a = &b"efghblah"[..];
 ///     let res_a = parser(a);

--- a/src/verbose_errors.rs
+++ b/src/verbose_errors.rs
@@ -125,9 +125,9 @@ impl<P:fmt::Debug,E:fmt::Debug> fmt::Display for Err<P,E> {
 /// # use std::boxed::Box;
 /// # fn main() {
 ///     // will add a Custom(42) error to the error chain
-///     named!(err_test, add_error!(ErrorKind::Custom(42), tag!("abcd")));
+///     named!(err_test, add_return_error!(ErrorKind::Custom(42), tag!("abcd")));
 ///     // Convert to IREsult<&[u8], &[u8], &str>
-///     named!(parser<&[u8], &[u8], &str>, add_error!(ErrorKind::Custom("custom error message"), fix_error!(&str, err_test)));
+///     named!(parser<&[u8], &[u8], &str>, add_return_error!(ErrorKind::Custom("custom error message"), fix_error!(&str, err_test)));
 ///
 ///     let a = &b"efghblah"[..];
 ///     let res_a = parser(a);


### PR DESCRIPTION
I currently get a undefined `add_return_error!` on nom 2.0 and it [appears that it should be defined](https://github.com/Geal/nom/blame/75ad25152040b0e303eb2af7e962453f03fb6a68/doc/upgrading_to_nom_2.md#L140). This PR actually does the rename 😄 

EDIT: This would be a breaking change, not sure how you feel about that, since 2.0 was just released 😕 