### PR TITLE
bytes: typo fixing

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -254,7 +254,7 @@ macro_rules! escaped (
 /// matches a byte string with escaped characters.
 ///
 /// The first argument matches the normal characters (it must not match the control character), the second argument is the control character (like `\` in most languages),
-/// the third argument matches the escaped characters and trnasforms them.
+/// the third argument matches the escaped characters and transforms them.
 ///
 /// As an example, the chain `abc\tdef` could be `abc    def` (it also consumes the control character)
 ///


### PR DESCRIPTION
This fixes a small typo in `escaped_transform!` docstring.