### PR TITLE
Add explicit lifetimes for named! and named_attr!

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -99,19 +99,19 @@ macro_rules! named (
     );
     ($name:ident( $i:ty ) -> $o:ty, $submac:ident!( $($args:tt)* )) => (
         #[allow(unused_variables)]
-        fn $name( i: $i ) -> $crate::IResult<$i,$o,u32> {
+        fn $name<'a>( i: $i ) -> $crate::IResult<$i,$o,u32> {
             $submac!(i, $($args)*)
         }
     );
     ($name:ident<$i:ty,$o:ty,$e:ty>, $submac:ident!( $($args:tt)* )) => (
         #[allow(unused_variables)]
-        fn $name( i: $i ) -> $crate::IResult<$i, $o, $e> {
+        fn $name<'a>( i: $i ) -> $crate::IResult<$i, $o, $e> {
             $submac!(i, $($args)*)
         }
     );
     ($name:ident<$i:ty,$o:ty>, $submac:ident!( $($args:tt)* )) => (
         #[allow(unused_variables)]
-        fn $name( i: $i ) -> $crate::IResult<$i, $o, u32> {
+        fn $name<'a>( i: $i ) -> $crate::IResult<$i, $o, u32> {
             $submac!(i, $($args)*)
         }
     );
@@ -129,31 +129,31 @@ macro_rules! named (
     );
     (pub $name:ident( $i:ty ) -> $o:ty, $submac:ident!( $($args:tt)* )) => (
         #[allow(unused_variables)]
-        pub fn $name( i: $i ) -> $crate::IResult<$i,$o, u32> {
+        pub fn $name<'a>( i: $i ) -> $crate::IResult<$i,$o, u32> {
             $submac!(i, $($args)*)
         }
     );
     (pub $name:ident<$i:ty,$o:ty,$e:ty>, $submac:ident!( $($args:tt)* )) => (
         #[allow(unused_variables)]
-        pub fn $name( i: $i ) -> $crate::IResult<$i, $o, $e> {
+        pub fn $name<'a>( i: $i ) -> $crate::IResult<$i, $o, $e> {
             $submac!(i, $($args)*)
         }
     );
     (pub $name:ident<$i:ty,$o:ty>, $submac:ident!( $($args:tt)* )) => (
         #[allow(unused_variables)]
-        pub fn $name( i: $i ) -> $crate::IResult<$i, $o, u32> {
+        pub fn $name<'a>( i: $i ) -> $crate::IResult<$i, $o, u32> {
             $submac!(i, $($args)*)
         }
     );
     (pub $name:ident<$o:ty>, $submac:ident!( $($args:tt)* )) => (
         #[allow(unused_variables)]
-        pub fn $name( i: &[u8] ) -> $crate::IResult<&[u8], $o, u32> {
+        pub fn $name<'a>( i: &'a [u8] ) -> $crate::IResult<&'a [u8], $o, u32> {
             $submac!(i, $($args)*)
         }
     );
     (pub $name:ident, $submac:ident!( $($args:tt)* )) => (
         #[allow(unused_variables)]
-        pub fn $name<'a>( i: &'a [u8] ) -> $crate::IResult<&[u8], &[u8], u32> {
+        pub fn $name( i: &[u8] ) -> $crate::IResult<&[u8], &[u8], u32> {
             $submac!(i, $($args)*)
         }
     );
@@ -177,19 +177,19 @@ macro_rules! named (
 macro_rules! named_attr (
     ($(#[$attr:meta])*, $name:ident( $i:ty ) -> $o:ty, $submac:ident!( $($args:tt)* )) => (
         $(#[$attr])*
-        fn $name( i: $i ) -> $crate::IResult<$i,$o,u32> {
+        fn $name<'a>( i: $i ) -> $crate::IResult<$i,$o,u32> {
             $submac!(i, $($args)*)
         }
     );
     ($(#[$attr:meta])*, $name:ident<$i:ty,$o:ty,$e:ty>, $submac:ident!( $($args:tt)* )) => (
         $(#[$attr])*
-        fn $name( i: $i ) -> $crate::IResult<$i, $o, $e> {
+        fn $name<'a>( i: $i ) -> $crate::IResult<$i, $o, $e> {
             $submac!(i, $($args)*)
         }
     );
     ($(#[$attr:meta])*, $name:ident<$i:ty,$o:ty>, $submac:ident!( $($args:tt)* )) => (
         $(#[$attr])*
-        fn $name( i: $i ) -> $crate::IResult<$i, $o, u32> {
+        fn $name<'a>( i: $i ) -> $crate::IResult<$i, $o, u32> {
             $submac!(i, $($args)*)
         }
     );
@@ -207,31 +207,31 @@ macro_rules! named_attr (
     );
     ($(#[$attr:meta])*, pub $name:ident( $i:ty ) -> $o:ty, $submac:ident!( $($args:tt)* )) => (
         $(#[$attr])*
-        pub fn $name( i: $i ) -> $crate::IResult<$i,$o, u32> {
+        pub fn $name<'a>( i: $i ) -> $crate::IResult<$i,$o, u32> {
             $submac!(i, $($args)*)
         }
     );
     ($(#[$attr:meta])*, pub $name:ident<$i:ty,$o:ty,$e:ty>, $submac:ident!( $($args:tt)* )) => (
         $(#[$attr])*
-        pub fn $name( i: $i ) -> $crate::IResult<$i, $o, $e> {
+        pub fn $name<'a>( i: $i ) -> $crate::IResult<$i, $o, $e> {
             $submac!(i, $($args)*)
         }
     );
     ($(#[$attr:meta])*, pub $name:ident<$i:ty,$o:ty>, $submac:ident!( $($args:tt)* )) => (
         $(#[$attr])*
-        pub fn $name( i: $i ) -> $crate::IResult<$i, $o, u32> {
+        pub fn $name<'a>( i: $i ) -> $crate::IResult<$i, $o, u32> {
             $submac!(i, $($args)*)
         }
     );
     ($(#[$attr:meta])*, pub $name:ident<$o:ty>, $submac:ident!( $($args:tt)* )) => (
         $(#[$attr])*
-        pub fn $name( i: &[u8] ) -> $crate::IResult<&[u8], $o, u32> {
+        pub fn $name<'a>( i: &'a [u8] ) -> $crate::IResult<&'a [u8], $o, u32> {
             $submac!(i, $($args)*)
         }
     );
     ($(#[$attr:meta])*, pub $name:ident, $submac:ident!( $($args:tt)* )) => (
         $(#[$attr])*
-        pub fn $name<'a>( i: &'a [u8] ) -> $crate::IResult<&[u8], &[u8], u32> {
+        pub fn $name( i: &[u8] ) -> $crate::IResult<&[u8], &[u8], u32> {
             $submac!(i, $($args)*)
         }
     );


### PR DESCRIPTION
Also normalizes pub and non-pub expansions. Previously only usable in
the private output-specified variation.