### PR TITLE
Avoid generic lifetime name to avoid collision with external lifetime parameters

### DIFF
--- a/src/methods.rs
+++ b/src/methods.rs
@@ -129,7 +129,7 @@ macro_rules! method (
   );
   ($name:ident<$a:ty,$o:ty>, $self_:ident, $submac:ident!( $($args:tt)* )) => (
       #[allow(unused_variables)]
-      fn $name<'a>( $self_: $a, i: &'a[u8] ) -> ($a, $crate::IResult<&'a [u8], $o, u32>) {
+      fn $name<'a_>( $self_: $a, i: &'a_[u8] ) -> ($a, $crate::IResult<&'a_ [u8], $o, u32>) {
         let result = $submac!(i, $($args)*);
         ($self_, result)
       }
@@ -165,7 +165,7 @@ macro_rules! method (
   );
   (pub $name:ident<$a:ty,$o:ty>, $self_:ident, $submac:ident!( $($args:tt)* )) => (
     #[allow(unused_variables)]
-    pub fn $name<'a>( $self_: $a, i: &'a[u8] ) -> ($a, $crate::IResult<&'a [u8], $o, u32>) {
+    pub fn $name<'a_>( $self_: $a, i: &'a_[u8] ) -> ($a, $crate::IResult<&'a_ [u8], $o, u32>) {
       let result = $submac!(i, $($args)*);
       ($self_, result)
     }
@@ -201,7 +201,7 @@ macro_rules! method (
   );
   ($name:ident<$a:ty,$o:ty>, mut $self_:ident, $submac:ident!( $($args:tt)* )) => (
       #[allow(unused_variables)]
-      fn $name<'a>( mut $self_: $a, i: &'a[u8] ) -> ($a, $crate::IResult<&'a [u8], $o, u32>) {
+      fn $name<'a_>( mut $self_: $a, i: &'a_[u8] ) -> ($a, $crate::IResult<&'a_ [u8], $o, u32>) {
         let result = $submac!(i, $($args)*);
         ($self_, result)
       }
@@ -237,7 +237,7 @@ macro_rules! method (
   );
   (pub $name:ident<$a:ty,$o:ty>, mut $self_:ident, $submac:ident!( $($args:tt)* )) => (
     #[allow(unused_variables)]
-    pub fn $name<'a>( mut $self_: $a, i: &'a[u8] ) -> ($a, $crate::IResult<&'a [u8], $o, u32>) {
+    pub fn $name<'a_>( mut $self_: $a, i: &'a_[u8] ) -> ($a, $crate::IResult<&'a_ [u8], $o, u32>) {
       let result = $submac!(i, $($args)*);
       ($self_, result)
     }

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -129,7 +129,7 @@ macro_rules! method (
   );
   ($name:ident<$a:ty,$o:ty>, $self_:ident, $submac:ident!( $($args:tt)* )) => (
       #[allow(unused_variables)]
-      fn $name<'a_>( $self_: $a, i: &'a_[u8] ) -> ($a, $crate::IResult<&'a_ [u8], $o, u32>) {
+      fn $name( $self_: $a, i: &[u8] ) -> ($a, $crate::IResult<&[u8], $o, u32>) {
         let result = $submac!(i, $($args)*);
         ($self_, result)
       }
@@ -165,7 +165,7 @@ macro_rules! method (
   );
   (pub $name:ident<$a:ty,$o:ty>, $self_:ident, $submac:ident!( $($args:tt)* )) => (
     #[allow(unused_variables)]
-    pub fn $name<'a_>( $self_: $a, i: &'a_[u8] ) -> ($a, $crate::IResult<&'a_ [u8], $o, u32>) {
+    pub fn $name( $self_: $a, i: &[u8] ) -> ($a, $crate::IResult<&[u8], $o, u32>) {
       let result = $submac!(i, $($args)*);
       ($self_, result)
     }
@@ -201,7 +201,7 @@ macro_rules! method (
   );
   ($name:ident<$a:ty,$o:ty>, mut $self_:ident, $submac:ident!( $($args:tt)* )) => (
       #[allow(unused_variables)]
-      fn $name<'a_>( mut $self_: $a, i: &'a_[u8] ) -> ($a, $crate::IResult<&'a_ [u8], $o, u32>) {
+      fn $name( mut $self_: $a, i: &[u8] ) -> ($a, $crate::IResult<&[u8], $o, u32>) {
         let result = $submac!(i, $($args)*);
         ($self_, result)
       }
@@ -237,7 +237,7 @@ macro_rules! method (
   );
   (pub $name:ident<$a:ty,$o:ty>, mut $self_:ident, $submac:ident!( $($args:tt)* )) => (
     #[allow(unused_variables)]
-    pub fn $name<'a_>( mut $self_: $a, i: &'a_[u8] ) -> ($a, $crate::IResult<&'a_ [u8], $o, u32>) {
+    pub fn $name( mut $self_: $a, i: &[u8] ) -> ($a, $crate::IResult<&[u8], $o, u32>) {
       let result = $submac!(i, $($args)*);
       ($self_, result)
     }


### PR DESCRIPTION
In `method!` macro, general lifetime parameter name `'a` is hard-coded. This causes an error when writing a code like below:

```rust
struct Parser<'a> {
  code &'a str,
}

impl<'a> Parser<'a> {
  // Specify output type
  method!(rule<Parser<'a>, &[u8], tag!("foo"));
}
```

Above code causes an error like below:

```
error[E0496]: lifetime name `'a` shadows a lifetime name that is already in scope
   --> src/methods.rs:132:16
    |
132 |       fn $name<'a>( $self_: $a, i: &'a[u8] ) -> ($a, $crate::IResult<&'a[u8], $o, u32>) {
    |                ^^ lifetime 'a already in scope
...
331 |   impl<'a> Parser<'a> {
    |        -- first declared here
...
338 |     method!(tag_cd<Parser<'a>, &'a str>, self, tag_s!("çδ"));
    |     --------------------------------------------------------- in this macro invocation

error: aborting due to previous error

Build failed, waiting for other jobs to finish...
error: Could not compile `nom`.

To learn more, run the command again with --verbose.
```

because `'a` is already used in `impl<'a>`.

I renamed hard-coded names `'a` to `'a_` for avoiding this although I don't know `'a_` is good name for this.