### PR TITLE
Add str version of one_of

### DIFF
--- a/src/str.rs
+++ b/src/str.rs
@@ -224,6 +224,38 @@ macro_rules! take_until_s (
   );
 );
 
+/// Matches one of the characters in a string
+///
+/// # Example
+/// ```
+/// # #[macro_use] extern crate nom;
+/// # use nom::IResult;
+/// # fn main() {
+/// let test = one_of_s!("汉 some more input", "汉012");
+/// assert_eq!(test, IResult::Done(" some more input", '汉'));
+/// # }
+/// ```
+#[macro_export]
+macro_rules! one_of_s (
+  ($i:expr, $inp:expr) => (
+    {
+      let mut iter = $i.chars();
+      let first_op = iter.next();
+      if let Some(first) = first_op {
+        if let Some(_) = $inp.chars().find(|&ch| ch == first) {
+          let rest = iter.as_str();
+          $crate::IResult::Done(rest, first)
+        } else {
+          $crate::IResult::Error(error_position!($crate::ErrorKind::OneOf, $i))
+        }
+      } else {
+        $crate::IResult::Incomplete::<_, _>($crate::Needed::Size(1))
+      }
+    }
+  );
+);
+
+
 #[cfg(test)]
 mod test {
     use ::IResult;


### PR DESCRIPTION
Adds a string slice version of `one_of` called `one_of_s`. Slight difference to `one_of`, in that it returns a `char` rather than a `&str` (`one_of` returns a `&[u8]` with a single element).

Handles multibyte chars, as seen in doc_test.