### PR TITLE
Added be_u24 method

### DIFF
--- a/src/nom.rs
+++ b/src/nom.rs
@@ -340,6 +340,17 @@ pub fn be_u16(i: &[u8]) -> IResult<&[u8], u16> {
   }
 }
 
+/// Recognizes big endian unsigned 3 byte integer
+#[inline]
+pub fn be_u24(i: &[u8]) -> IResult<&[u8], usize> {
+  if i.len() < 3 {
+    Incomplete(Needed::Size(3))
+  } else {
+    let res = ((i[0] as usize) << 16) + ((i[1] as usize) << 8) + (i[2] as usize);
+    Done(&i[3..], res)
+  }
+}
+
 /// Recognizes big endian unsigned 4 bytes integer
 #[inline]
 pub fn be_u32(i: &[u8]) -> IResult<&[u8], u32> {

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -342,14 +342,18 @@ pub fn be_u16(i: &[u8]) -> IResult<&[u8], u16> {
 
 /// Recognizes big endian unsigned 3 byte integer
 #[inline]
-pub fn be_u24(i: &[u8]) -> IResult<&[u8], usize> {
+pub fn be_u24(i: &[u8]) -> IResult<&[u8], u32> {
   if i.len() < 3 {
     Incomplete(Needed::Size(3))
   } else {
-    let res = ((i[0] as usize) << 16) + ((i[1] as usize) << 8) + (i[2] as usize);
+    let res = ((i[0] as u32) << 16) + ((i[1] as u32) << 8) + (i[2] as u32);
     Done(&i[3..], res)
   }
 }
+
+
+
+
 
 /// Recognizes big endian unsigned 4 bytes integer
 #[inline]
@@ -416,6 +420,17 @@ pub fn le_u16(i: &[u8]) -> IResult<&[u8], u16> {
   } else {
     let res = ((i[1] as u16) << 8) + i[0] as u16;
     Done(&i[2..], res)
+  }
+}
+
+/// Recongnizes little endan unsigned 3 byte integer
+#[inline]
+pub fn le_u24(i: &[u8]) -> IResult<&[u8], u32> {
+  if i.len() < 3 {
+    Incomplete(Needed::Size(3))
+  } else {
+    let res = (i[0] as u32) + ((i[3] as u32) << 8) + ((i[2] as u32) << 16);
+    Done(&i[3..], res)
   }
 }
 

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -817,6 +817,13 @@ mod tests {
     assert_eq!(be_i16(&[0xff, 0xff]), Done(&b""[..], -1));
     assert_eq!(be_i16(&[0x80, 0x00]), Done(&b""[..], -32768_i16));
   }
+  
+  #[test]
+  fn u24_tests() {
+    assert_eq!(be_u24(&[0x00, 0x00, 0x00]), Done(&b""[..], 0));
+    assert_eq!(be_u24(&[0x00, 0xFF, 0xFF]), Done(&b""[..], 65535_u32));
+    assert_eq!(be_u24(&[0x12, 0x34, 0x56]), Done(&b""[..], 1193046_u32));
+  }
 
   #[test]
   fn i32_tests() {


### PR DESCRIPTION
In TLS1.0+ there are payload fields who's length is set via a 24bit unsigned integer value.

Kind of a strange method I agree. I'm not sure if you prefer `usize` or `u32`