### PR TITLE
IResult: implement or() similar to Option.or()

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -120,6 +120,14 @@ impl<I,O,E> IResult<I,O,E> {
     }
   }
 
+  pub fn or(self, other: IResult<I, O, E>) -> IResult<I, O, E> {
+    if self.is_done() {
+      self
+    } else {
+      other
+    }
+  }
+
   /// Maps a `IResult<I, O, E>` to `IResult<I, N, E>` by appling a function
   /// to a contained `Done` value, leaving `Error` and `Incomplete` value
   /// untouched.
@@ -316,6 +324,13 @@ mod tests {
   const DONE: IResult<&'static [u8], u32> = IResult::Done(&REST, 5);
   const ERROR: IResult<&'static [u8], u32> = IResult::Error(error_code!(ErrorKind::Tag));
   const INCOMPLETE: IResult<&'static [u8], u32> = IResult::Incomplete(Needed::Unknown);
+
+  #[test]
+  fn iresult_or() {
+    assert_eq!(DONE.or(ERROR), DONE);
+    assert_eq!(ERROR.or(DONE), DONE);
+    assert_eq!(INCOMPLETE.or(ERROR), ERROR);
+  }
 
   #[test]
   fn needed_map() {


### PR DESCRIPTION
For now, implementing some alternative "whitespace" logic can be tricky as functions like take_until & co give you an error when i[0] doesn't satisfy the condition, and sep! then bubbles-up the error. opt! is not acceptable here as sep! doesn't like Option either.
With this, it's simple enough to implement a new alternative with stuff like:

pub fn skip_non_vowels (i: &[u8]) -> IResult<&[u8], &[u8]> {
is_not!(i, b"aeiouy").or(IResult::Done(i, &i[0..0]))
}

and then

sep!(i, skip_non_vowels, blah)