### PR TITLE
perf(tests/ini{,_str}): remove unnecessary cloning and refactor

### DIFF
--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -40,14 +40,9 @@ named!(key_value    <&[u8],(&str,&str)>,
 named!(keys_and_values_aggregator<&[u8], Vec<(&str,&str)> >, many0!(key_value));
 
 fn keys_and_values(input:&[u8]) -> IResult<&[u8], HashMap<&str, &str> > {
-  let mut h: HashMap<&str, &str> = HashMap::new();
-
   match keys_and_values_aggregator(input) {
     IResult::Done(i,tuple_vec) => {
-      for &(k,v) in &tuple_vec {
-        h.insert(k, v);
-      }
-      IResult::Done(i, h)
+      IResult::Done(i, tuple_vec.into_iter().collect())
     },
     IResult::Incomplete(a)     => IResult::Incomplete(a),
     IResult::Error(a)          => IResult::Error(a)
@@ -65,14 +60,9 @@ named!(category_and_keys<&[u8],(&str,HashMap<&str,&str>)>,
 named!(categories_aggregator<&[u8], Vec<(&str, HashMap<&str,&str>)> >, many0!(category_and_keys));
 
 fn categories(input: &[u8]) -> IResult<&[u8], HashMap<&str, HashMap<&str, &str> > > {
-  let mut h: HashMap<&str, HashMap<&str, &str>> = HashMap::new();
-
   match categories_aggregator(input) {
     IResult::Done(i,tuple_vec) => {
-      for &(k,ref v) in &tuple_vec {
-        h.insert(k, v.clone());
-      }
-      IResult::Done(i, h)
+      IResult::Done(i, tuple_vec.into_iter().collect())
     },
     IResult::Incomplete(a)     => IResult::Incomplete(a),
     IResult::Error(a)          => IResult::Error(a)

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -62,14 +62,9 @@ named!(key_value    <&str,(&str,&str)>,
 named!(keys_and_values_aggregator<&str, Vec<(&str,&str)> >, many0!(key_value));
 
 fn keys_and_values(input:&str) -> IResult<&str, HashMap<&str, &str> > {
-  let mut h: HashMap<&str, &str> = HashMap::new();
-
   match keys_and_values_aggregator(input) {
     IResult::Done(i,tuple_vec) => {
-      for &(k,v) in &tuple_vec {
-        h.insert(k, v);
-      }
-      IResult::Done(i, h)
+      IResult::Done(i, tuple_vec.into_iter().collect())
     },
     IResult::Incomplete(a)     => IResult::Incomplete(a),
     IResult::Error(a)          => IResult::Error(a)
@@ -84,14 +79,9 @@ named!(category_and_keys<&str,(&str,HashMap<&str,&str>)>,
 named!(categories_aggregator<&str, Vec<(&str, HashMap<&str,&str>)> >, many0!(category_and_keys));
 
 fn categories(input: &str) -> IResult<&str, HashMap<&str, HashMap<&str, &str> > > {
-  let mut h: HashMap<&str, HashMap<&str, &str>> = HashMap::new();
-
   match categories_aggregator(input) {
     IResult::Done(i,tuple_vec) => {
-      for &(k,ref v) in &tuple_vec {
-        h.insert(k, v.clone());
-      }
-      IResult::Done(i, h)
+      IResult::Done(i, tuple_vec.into_iter().collect())
     },
     IResult::Incomplete(a)     => IResult::Incomplete(a),
     IResult::Error(a)          => IResult::Error(a)


### PR DESCRIPTION
I was benchmarking this parser against one [I wrote in munch.rs](https://github.com/utkarshkukreti/munch.rs/compare/dcc1f29a1d858d684c61e116169bf1f2f610e073...84356c91d5974249b84c4149f46989dd85a3e46b) and found some low hanging fruits to speed up this one, specifically removing the unnecessary cloning of the `HashMap` returned by `keys_and_values`.

(If you want, I can also add the benches to these examples. I [already have them written](https://github.com/utkarshkukreti/nom/commit/5c3376daa2e1f8409590ea1cac55d4bc3d0e4436) but I didn't know whether you want benches for these in the repo.)