### PR TITLE
Make inner errors in many_till! visible (fix #463)

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -297,7 +297,7 @@ macro_rules! many1(
 ///    let res_b: (Vec<&[u8]>, &[u8]) = (Vec::new(), &b"efgh"[..]);
 ///    assert_eq!(multi(&a[..]), Done(&b"abcd"[..], res_a));
 ///    assert_eq!(multi(&b[..]), Done(&b"abcd"[..], res_b));
-///    assert_eq!(multi(&c[..]), Error(error_position!(ErrorKind::ManyTill,&c[..])));
+///    assert_eq!(multi(&c[..]), Error(error_node_position!(ErrorKind::ManyTill,&c[..],error_position(ErrorKind::Tag,&c[..]))));
 /// # }
 /// ```
 #[macro_export]
@@ -318,8 +318,8 @@ macro_rules! many_till(
           },
           _                           => {
             match $submac1!(input, $($args1)*) {
-              $crate::IResult::Error(_)                            => {
-                ret = $crate::IResult::Error(error_position!($crate::ErrorKind::ManyTill,input));
+              $crate::IResult::Error(err)                            => {
+                ret = $crate::IResult::Error(error_node_position!($crate::ErrorKind::ManyTill,input, err));
                 break;
               },
               $crate::IResult::Incomplete($crate::Needed::Unknown) => {
@@ -1115,7 +1115,7 @@ mod tests {
     let res_b: (Vec<&[u8]>, &[u8]) = (Vec::new(), &b"efgh"[..]);
     assert_eq!(multi(&a[..]), Done(&b"abcd"[..], res_a));
     assert_eq!(multi(&b[..]), Done(&b"abcd"[..], res_b));
-    assert_eq!(multi(&c[..]), Error(error_position!(ErrorKind::ManyTill,&c[..])));
+    assert_eq!(multi(&c[..]), Error(error_node_position!(ErrorKind::ManyTill,&c[..], error_position(ErrorKind::Tag,&c[..]))));
   }
 
   #[test]


### PR DESCRIPTION
Make `many_till!()` return a NodePosition error on failure, so that the inner error that caused it to fail is visible to the caller.