### PR TITLE
switch: wrap cases in a Some()

### DIFF
--- a/src/branch.rs
+++ b/src/branch.rs
@@ -307,14 +307,14 @@ macro_rules! alt_complete (
 macro_rules! switch (
   (__impl $i:expr, $submac:ident!( $($args:tt)* ), $($p:pat => $subrule:ident!( $($args2:tt)* ))|* ) => (
     {
-      match $submac!($i, $($args)*) {
+      match map!($i, $submac!($($args)*), |o| Some(o)) {
         $crate::IResult::Error(e)      => $crate::IResult::Error(error_node_position!(
             $crate::ErrorKind::Switch, $i, e
         )),
         $crate::IResult::Incomplete(i) => $crate::IResult::Incomplete(i),
         $crate::IResult::Done(i, o)    => {
           match o {
-            $($p => match $subrule!(i, $($args2)*) {
+            $(Some($p) => match $subrule!(i, $($args2)*) {
               $crate::IResult::Error(e) => $crate::IResult::Error(error_node_position!(
                   $crate::ErrorKind::Switch, $i, e
               )),


### PR DESCRIPTION
This changes basically nothing except that _ becomes a valid case even with an exhaustive listing as it would match None (even if that case can never happen)

Fixes #460

Signed-off-by: Marc-Antoine Perennou <Marc-Antoine@Perennou.com>