### PR TITLE
Fix documentation for take_while1.

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -405,7 +405,7 @@ macro_rules! take_while (
   );
 );
 
-/// `take_while1!(&[T] -> bool) => &[T] -> IResult<&[T], &[T]>`
+/// `take_while1!(T -> bool) => &[T] -> IResult<&[T], &[T]>`
 /// returns the longest (non empty) list of bytes until the provided function fails.
 ///
 /// The argument is either a function `&[T] -> bool` or a macro returning a `bool


### PR DESCRIPTION
Documentation says the predicate takes a `&[T]` when in actuality it takes a `T` (as one would expect).