### PR TITLE
Add a simple benchmark to both ini and ini_str parsers.

### DIFF
--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -1,3 +1,7 @@
+#![cfg_attr(feature = "nightly", feature(test))]
+
+#[cfg(feature = "nightly")]
+extern crate test;
 
 #[macro_use]
 extern crate nom;
@@ -221,4 +225,21 @@ key4 = value4
   expected_h.insert("abcd",     expected_1);
   expected_h.insert("category", expected_2);
   assert_eq!(res, IResult::Done(ini_after_parser, expected_h));
+}
+
+#[cfg(feature = "nightly")]
+#[bench]
+fn bench_ini(b: &mut test::Bencher) {
+  let str = "[owner]
+name=John Doe
+organization=Acme Widgets Inc.
+
+[database]
+server=192.0.2.62
+port=143
+file=payroll.dat
+";
+
+  b.iter(|| categories(str.as_bytes()).unwrap());
+  b.bytes = str.len() as u64;
 }

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -1,3 +1,7 @@
+#![cfg_attr(feature = "nightly", feature(test))]
+
+#[cfg(feature = "nightly")]
+extern crate test;
 
 #[macro_use]
 extern crate nom;
@@ -238,4 +242,21 @@ key4 = value4
   expected_h.insert("abcd",     expected_1);
   expected_h.insert("category", expected_2);
   assert_eq!(res, IResult::Done("", expected_h));
+}
+
+#[cfg(feature = "nightly")]
+#[bench]
+fn bench_ini(b: &mut test::Bencher) {
+  let str = "[owner]
+name=John Doe
+organization=Acme Widgets Inc.
+
+[database]
+server=192.0.2.62
+port=143
+file=payroll.dat
+";
+
+  b.iter(|| categories(str).unwrap());
+  b.bytes = str.len() as u64;
 }


### PR DESCRIPTION
These can be run on Rust Nightly using:

    cargo bench --features nightly --test ini

and

    cargo bench --features nightly --test ini_str

On my machine, these currently run at around 99 MB/s and 101 MB/s
respectively (best of many runs).

<hr>

Just for reference, a similar benchmark in munch.rs [[1]] [[2]] runs at 140 MB/s on the same machine as of the current HEAD (149 MB/s with an optimization I'm testing right now and will push soon) as mentioned in the original PR: https://github.com/Geal/nom/pull/461#issuecomment-287717125.

<hr>

@Geal let me know if I got the `cfg`s right!

[1]: https://github.com/utkarshkukreti/munch.rs/blob/62907a57d0d598bd5570c4726bbd0251bd66152f/benches/ini.rs
[2]: https://github.com/utkarshkukreti/munch.rs/blob/62907a57d0d598bd5570c4726bbd0251bd66152f/examples/ini.rs