### PR TITLE
Fix dead links in doc/home.md

### DIFF
--- a/doc/home.md
+++ b/doc/home.md
@@ -9,7 +9,7 @@ To get started using nom, you can include it in your Rust projects from
 * [Gitter chat room](https://gitter.im/Geal/nom). You can also go to the #nom IRC
 channel on irc.mozilla.org, or ping 'geal' on Mozilla, Freenode, Geeknode or oftc IRC
 * [Tutorial about parsing ISO8601 dates](https://fnordig.de/2015/07/16/omnomnom-parsing-iso8601-dates-using-nom/)
-* [Making a new parser from scratch](making_a_new_parser_from_scratch.html)
+* [Making a new parser from scratch](making_a_new_parser_from_scratch.md)
 (general tips on writing a parser and code architecture)
-* [How to handle parser errors](error_management.html)
-* [How nom's macro combinators work](how_nom_macros_work.html)
+* [How to handle parser errors](error_management.md)
+* [How nom's macro combinators work](how_nom_macros_work.md)


### PR DESCRIPTION
Modify links from the erroneous ".html" extension to the correct ".md" extension