### PR TITLE
Check if requested length would overflow in do_parse, chain and tuple

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -725,7 +725,11 @@ macro_rules! length_bytes(
           let nb = nb as usize;
           if i1.input_len() < nb {
             use $crate::Offset;
-            $crate::IResult::Incomplete($crate::Needed::Size($i.offset(i1) + nb))
+            let (size,overflowed) = $i.offset(i1).overflowing_add(nb);
+            match overflowed {
+                true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+                false => $crate::IResult::Incomplete($crate::Needed::Size(size)),
+            }
           } else {
             $crate::IResult::Done(i1.slice(nb..), i1.slice(..nb))
           }

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -509,9 +509,13 @@ macro_rules! count(
             break;
           }
           $crate::IResult::Incomplete($crate::Needed::Size(sz)) => {
-            ret = $crate::IResult::Incomplete($crate::Needed::Size(
-              sz + $crate::InputLength::input_len(&($i)) - $crate::InputLength::input_len(&input)
-            ));
+            let (size,overflowed) = sz.overflowing_add(
+              $crate::InputLength::input_len(&($i)) - $crate::InputLength::input_len(&input)
+            );
+            ret = match overflowed {
+                true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+                false => $crate::IResult::Incomplete($crate::Needed::Size(size)),
+            };
             break;
           }
         }
@@ -579,9 +583,13 @@ macro_rules! count_fixed (
             break;
           }
           $crate::IResult::Incomplete($crate::Needed::Size(sz)) => {
-            ret = $crate::IResult::Incomplete($crate::Needed::Size(
-              sz + $crate::InputLength::input_len(&($i)) - $crate::InputLength::input_len(&input)
-            ));
+            let (size,overflowed) = sz.overflowing_add(
+              $crate::InputLength::input_len(&($i)) - $crate::InputLength::input_len(&input)
+            );
+            ret = match overflowed {
+                true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+                false => $crate::IResult::Incomplete($crate::Needed::Size(size)),
+            };
             break;
           }
         }
@@ -609,9 +617,13 @@ macro_rules! length_count(
             $crate::IResult::Error(e)                            => $crate::IResult::Error(e),
             $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
             $crate::IResult::Incomplete($crate::Needed::Size(n)) => {
-              $crate::IResult::Incomplete($crate::Needed::Size(
-                n + $crate::InputLength::input_len(&($i)) - $crate::InputLength::input_len(&i)
-              ))
+              let (size,overflowed) = n.overflowing_add(
+                $crate::InputLength::input_len(&($i)) - $crate::InputLength::input_len(&i)
+              );
+              match overflowed {
+                  true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+                  false => $crate::IResult::Incomplete($crate::Needed::Size(size)),
+              }
             },
             $crate::IResult::Done(i2, o2)  =>  $crate::IResult::Done(i2, o2)
           }
@@ -648,9 +660,13 @@ macro_rules! length_data(
           $crate::IResult::Error(e)                            => $crate::IResult::Error(e),
           $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
           $crate::IResult::Incomplete($crate::Needed::Size(n)) => {
-            $crate::IResult::Incomplete($crate::Needed::Size(
-              n +$crate::InputLength::input_len(&($i)) - $crate::InputLength::input_len(&i)
-            ))
+            let (size,overflowed) = n.overflowing_add(
+              $crate::InputLength::input_len(&($i)) - $crate::InputLength::input_len(&i)
+            );
+            match overflowed {
+                true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+                false => $crate::IResult::Incomplete($crate::Needed::Size(size)),
+            }
           },
           $crate::IResult::Done(i2, o2)  =>  $crate::IResult::Done(i2, o2)
         }

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -165,8 +165,11 @@ macro_rules! many0(
             break;
           },
           $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
-            let size = i + ($i).input_len() - input.input_len();
-            ret = $crate::IResult::Incomplete($crate::Needed::Size(size));
+            let (size,overflowed) = i.overflowing_add(($i).input_len() - input.input_len());
+            ret = match overflowed {
+                true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+                false => $crate::IResult::Incomplete($crate::Needed::Size(size)),
+            };
             break;
           },
           $crate::IResult::Done(i, o)                          => {
@@ -245,8 +248,12 @@ macro_rules! many1(
                   break;
                 },
                 $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+                  let (size,overflowed) = i.overflowing_add(($i).input_len() - input.input_len());
                   incomplete = ::std::option::Option::Some(
-                    $crate::Needed::Size(i + ($i).input_len() - input.input_len())
+                    match overflowed {
+                        true  => $crate::Needed::Unknown,
+                        false => $crate::Needed::Size(size),
+                    }
                   );
                   break;
                 },
@@ -327,8 +334,11 @@ macro_rules! many_till(
                 break;
               },
               $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
-                let size = i + ($i).input_len() - input.input_len();
-                ret = $crate::IResult::Incomplete($crate::Needed::Size(size));
+                let (size,overflowed) = i.overflowing_add(($i).input_len() - input.input_len());
+                ret = match overflowed {
+                    true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+                    false => $crate::IResult::Incomplete($crate::Needed::Size(size)),
+                };
                 break;
               },
               $crate::IResult::Done(i, o)                          => {
@@ -411,8 +421,12 @@ macro_rules! many_m_n(
             break;
           },
           $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+            let (size,overflowed) = i.overflowing_add(($i).input_len() - input.input_len());
             incomplete = ::std::option::Option::Some(
-              $crate::Needed::Size(i + ($i).input_len() - input.input_len())
+              match overflowed {
+                  true  => $crate::Needed::Unknown,
+                  false => $crate::Needed::Size(size),
+              }
             );
             break;
           },

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -700,8 +700,13 @@ macro_rules! do_parse (
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) =>
           $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) =>
-          $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+          let (needed,overflowed) = $consumed.overflowing_add(i);
+          match overflowed {
+              true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+              false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+          }
+        },
         $crate::IResult::Done(i,_)     => {
           do_parse!(__impl i,
             $consumed + ($crate::InputLength::input_len(&($i)) -
@@ -721,8 +726,13 @@ macro_rules! do_parse (
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) =>
           $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) =>
-          $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+          let (needed,overflowed) = $consumed.overflowing_add(i);
+          match overflowed {
+              true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+              false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+          }
+        },
         $crate::IResult::Done(i,o)     => {
           let $field = o;
           do_parse!(__impl i,

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -85,8 +85,13 @@ macro_rules! chaining_parser (
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) =>
           $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) =>
-          $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+          let (needed,overflowed) = $consumed.overflowing_add(i);
+          match overflowed {
+              true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+              false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+          }
+        },
         $crate::IResult::Done(i,_)     => {
           chaining_parser!(i,
             $consumed + ($crate::InputLength::input_len(&($i)) -
@@ -107,8 +112,13 @@ macro_rules! chaining_parser (
         match inc {
           $crate::Needed::Unknown =>
             $crate::IResult::Incomplete($crate::Needed::Unknown),
-          $crate::Needed::Size(i) =>
-            $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+          $crate::Needed::Size(i) => {
+            let (needed,overflowed) = $consumed.overflowing_add(i);
+            match overflowed {
+                true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+                false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+            }
+          },
         }
       } else {
         let input = if let $crate::IResult::Done(i,_) = res {
@@ -133,8 +143,13 @@ macro_rules! chaining_parser (
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) =>
           $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) =>
-          $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+          let (needed,overflowed) = $consumed.overflowing_add(i);
+          match overflowed {
+              true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+              false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+          }
+        },
         $crate::IResult::Done(i,o)     => {
           let $field = o;
           chaining_parser!(i,
@@ -155,8 +170,13 @@ macro_rules! chaining_parser (
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) =>
           $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) =>
-          $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+          let (needed,overflowed) = $consumed.overflowing_add(i);
+          match overflowed {
+              true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+              false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+          }
+        },
         $crate::IResult::Done(i,o)     => {
           let mut $field = o;
           chaining_parser!(i,
@@ -178,8 +198,13 @@ macro_rules! chaining_parser (
         match inc {
           $crate::Needed::Unknown =>
             $crate::IResult::Incomplete($crate::Needed::Unknown),
-          $crate::Needed::Size(i) =>
-            $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+          $crate::Needed::Size(i) => {
+            let (needed,overflowed) = $consumed.overflowing_add(i);
+            match overflowed {
+                true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+                false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+            }
+          },
         }
       } else {
         let ($field,input) = if let $crate::IResult::Done(i,o) = res {
@@ -205,8 +230,13 @@ macro_rules! chaining_parser (
         match inc {
           $crate::Needed::Unknown =>
             $crate::IResult::Incomplete($crate::Needed::Unknown),
-          $crate::Needed::Size(i) =>
-            $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+          $crate::Needed::Size(i) => {
+            let (needed,overflowed) = $consumed.overflowing_add(i);
+            match overflowed {
+                true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+                false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+            }
+          },
         }
       } else {
         let (mut $field,input) = if let $crate::IResult::Done(i,o) = res {
@@ -231,8 +261,13 @@ macro_rules! chaining_parser (
       $crate::IResult::Error(e)      => $crate::IResult::Error(e),
       $crate::IResult::Incomplete($crate::Needed::Unknown) =>
         $crate::IResult::Incomplete($crate::Needed::Unknown),
-      $crate::IResult::Incomplete($crate::Needed::Size(i)) =>
-        $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+      $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+        let (needed,overflowed) = $consumed.overflowing_add(i);
+        match overflowed {
+            true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+            false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+        }
+      },
       $crate::IResult::Done(i,_)     => {
         $crate::IResult::Done(i, $assemble())
       }
@@ -249,8 +284,13 @@ macro_rules! chaining_parser (
       match inc {
         $crate::Needed::Unknown =>
           $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::Needed::Size(i) =>
-          $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::Needed::Size(i) => {
+          let (needed,overflowed) = $consumed.overflowing_add(i);
+          match overflowed {
+              true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+              false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+          }
+        },
       }
     } else {
       let input = if let $crate::IResult::Done(i,_) = res {
@@ -271,8 +311,13 @@ macro_rules! chaining_parser (
       $crate::IResult::Error(e)      => $crate::IResult::Error(e),
       $crate::IResult::Incomplete($crate::Needed::Unknown) =>
         $crate::IResult::Incomplete($crate::Needed::Unknown),
-      $crate::IResult::Incomplete($crate::Needed::Size(i)) =>
-        $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+      $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+        let (needed,overflowed) = $consumed.overflowing_add(i);
+        match overflowed {
+            true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+            false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+        }
+      },
       $crate::IResult::Done(i,o)     => {
         let $field = o;
         $crate::IResult::Done(i, $assemble())
@@ -289,8 +334,13 @@ macro_rules! chaining_parser (
       $crate::IResult::Error(e)      => $crate::IResult::Error(e),
       $crate::IResult::Incomplete($crate::Needed::Unknown) =>
         $crate::IResult::Incomplete($crate::Needed::Unknown),
-      $crate::IResult::Incomplete($crate::Needed::Size(i)) =>
-        $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+      $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+        let (needed,overflowed) = $consumed.overflowing_add(i);
+        match overflowed {
+            true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+            false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+        }
+      },
       $crate::IResult::Done(i,o)     => {
         let mut $field = o;
         $crate::IResult::Done(i, $assemble())
@@ -308,8 +358,13 @@ macro_rules! chaining_parser (
       match inc {
         $crate::Needed::Unknown =>
           $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::Needed::Size(i) =>
-          $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::Needed::Size(i) => {
+          let (needed,overflowed) = $consumed.overflowing_add(i);
+          match overflowed {
+              true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+              false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+          }
+        },
       }
     } else {
       let ($field,input) = if let $crate::IResult::Done(i,o) = res {
@@ -331,8 +386,13 @@ macro_rules! chaining_parser (
       match inc {
         $crate::Needed::Unknown =>
           $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::Needed::Size(i) =>
-          $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::Needed::Size(i) => {
+          let (needed,overflowed) = $consumed.overflowing_add(i);
+          match overflowed {
+              true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+              false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+          }
+        },
       }
     } else {
       let (mut $field,input) = if let $crate::IResult::Done(i,o) = res {
@@ -407,8 +467,13 @@ macro_rules! tuple_parser (
           $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) =>
           $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) =>
-          $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+          let (needed,overflowed) = $consumed.overflowing_add(i);
+          match overflowed {
+              true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+              false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+          }
+        },
         $crate::IResult::Done(i,o)     => {
           tuple_parser!(i,
             $consumed + ($crate::InputLength::input_len(&($i)) -
@@ -424,8 +489,13 @@ macro_rules! tuple_parser (
           $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) =>
           $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) =>
-          $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+          let (needed,overflowed) = $consumed.overflowing_add(i);
+          match overflowed {
+              true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+              false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+          }
+        },
         $crate::IResult::Done(i,o)     => {
           tuple_parser!(i,
             $consumed + ($crate::InputLength::input_len(&($i)) -
@@ -444,8 +514,13 @@ macro_rules! tuple_parser (
           $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) =>
           $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) =>
-          $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+          let (needed,overflowed) = $consumed.overflowing_add(i);
+          match overflowed {
+              true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+              false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+          }
+        },
         $crate::IResult::Done(i,o)     => {
           $crate::IResult::Done(i, (o))
         }
@@ -459,8 +534,13 @@ macro_rules! tuple_parser (
           $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) =>
           $crate::IResult::Incomplete($crate::Needed::Unknown),
-        $crate::IResult::Incomplete($crate::Needed::Size(i)) =>
-          $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+        $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+          let (needed,overflowed) = $consumed.overflowing_add(i);
+          match overflowed {
+              true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+              false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+          }
+        },
         $crate::IResult::Done(i,o)     => {
           $crate::IResult::Done(i, ($($parsed),* , o))
         }
@@ -753,8 +833,13 @@ macro_rules! do_parse (
       $crate::IResult::Error(e)      => $crate::IResult::Error(e),
       $crate::IResult::Incomplete($crate::Needed::Unknown) =>
         $crate::IResult::Incomplete($crate::Needed::Unknown),
-      $crate::IResult::Incomplete($crate::Needed::Size(i)) =>
-        $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+      $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+        let (needed,overflowed) = $consumed.overflowing_add(i);
+        match overflowed {
+            true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+            false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+        }
+      },
       $crate::IResult::Done(i,_)     => {
         $crate::IResult::Done(i, ( $($rest)* ))
       },
@@ -770,8 +855,13 @@ macro_rules! do_parse (
       $crate::IResult::Error(e)      => $crate::IResult::Error(e),
       $crate::IResult::Incomplete($crate::Needed::Unknown) =>
         $crate::IResult::Incomplete($crate::Needed::Unknown),
-      $crate::IResult::Incomplete($crate::Needed::Size(i)) =>
-        $crate::IResult::Incomplete($crate::Needed::Size($consumed + i)),
+      $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
+        let (needed,overflowed) = $consumed.overflowing_add(i);
+        match overflowed {
+            true  => $crate::IResult::Incomplete($crate::Needed::Unknown),
+            false =>  $crate::IResult::Incomplete($crate::Needed::Size(needed)),
+        }
+      },
       $crate::IResult::Done(i,o)     => {
         let $field = o;
         $crate::IResult::Done(i, ( $($rest)* ))

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -14,8 +14,32 @@ named!(parser01<&[u8],()>,
     )
 );
 
+// We request a length that would trigger an overflow if computing consumed + requested
+named!(parser02<&[u8],()>,
+    chain!(
+        hdr: take!(1) ~
+        data: take!(18446744073709551615),
+        || ()
+    )
+);
+
+// We request a length that would trigger an overflow if computing consumed + requested
+named!(parser03<&[u8],(&[u8],&[u8])>,
+    tuple!(take!(1),take!(18446744073709551615))
+);
+
 #[test]
-fn overflow_incomplete_test() {
+fn overflow_incomplete_test01() {
   assert_eq!(parser01(&b"3"[..]), IResult::Incomplete(Needed::Unknown));
+}
+
+#[test]
+fn overflow_incomplete_test02() {
+  assert_eq!(parser02(&b"3"[..]), IResult::Incomplete(Needed::Unknown));
+}
+
+#[test]
+fn overflow_incomplete_test03() {
+  assert_eq!(parser03(&b"3"[..]), IResult::Incomplete(Needed::Unknown));
 }
 

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate nom;
 
-use nom::{IResult,Needed};
+use nom::{IResult,Needed,be_u64};
 
 // Parser definition
 
@@ -29,17 +29,56 @@ named!(parser03<&[u8],(&[u8],&[u8])>,
 );
 
 #[test]
-fn overflow_incomplete_test01() {
+fn overflow_incomplete_do_parse() {
   assert_eq!(parser01(&b"3"[..]), IResult::Incomplete(Needed::Unknown));
 }
 
 #[test]
-fn overflow_incomplete_test02() {
+fn overflow_incomplete_chain() {
   assert_eq!(parser02(&b"3"[..]), IResult::Incomplete(Needed::Unknown));
 }
 
 #[test]
-fn overflow_incomplete_test03() {
+fn overflow_incomplete_tuple() {
   assert_eq!(parser03(&b"3"[..]), IResult::Incomplete(Needed::Unknown));
 }
 
+#[test]
+fn overflow_incomplete_length_bytes() {
+ named!(multi<&[u8], Vec<&[u8]> >, many0!( length_bytes!(be_u64) ) );
+
+ // Trigger an overflow in length_bytes
+ assert_eq!(multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff\xaa"[..]), IResult::Incomplete(Needed::Unknown));
+}
+
+#[test]
+fn overflow_incomplete_many0() {
+ named!(multi<&[u8], Vec<&[u8]> >, many0!( length_bytes!(be_u64) ) );
+
+ // Trigger an overflow in many0
+ assert_eq!(multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef\xaa"[..]), IResult::Incomplete(Needed::Unknown));
+}
+
+#[test]
+fn overflow_incomplete_many1() {
+ named!(multi<&[u8], Vec<&[u8]> >, many1!( length_bytes!(be_u64) ) );
+
+ // Trigger an overflow in many1
+ assert_eq!(multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef\xaa"[..]), IResult::Incomplete(Needed::Unknown));
+}
+
+#[test]
+fn overflow_incomplete_many_till() {
+ named!(multi<&[u8], (Vec<&[u8]>, &[u8]) >, many_till!( length_bytes!(be_u64), tag!("abc") ) );
+
+ // Trigger an overflow in many_till
+ assert_eq!(multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef\xaa"[..]), IResult::Incomplete(Needed::Unknown));
+}
+
+#[test]
+fn overflow_incomplete_many_m_n() {
+ named!(multi<&[u8], Vec<&[u8]> >, many_m_n!(2, 4, length_bytes!(be_u64) ) );
+
+ // Trigger an overflow in many_m_n
+ assert_eq!(multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef\xaa"[..]), IResult::Incomplete(Needed::Unknown));
+}

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate nom;
 
-use nom::{IResult,Needed,be_u64};
+use nom::{IResult,Needed,be_u8,be_u64};
 
 // Parser definition
 
@@ -81,4 +81,32 @@ fn overflow_incomplete_many_m_n() {
 
  // Trigger an overflow in many_m_n
  assert_eq!(multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef\xaa"[..]), IResult::Incomplete(Needed::Unknown));
+}
+
+#[test]
+fn overflow_incomplete_count() {
+ named!(counter<&[u8], Vec<&[u8]> >, count!( length_bytes!(be_u64), 2 ) );
+
+ assert_eq!(counter(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef\xaa"[..]), IResult::Incomplete(Needed::Unknown));
+}
+
+#[test]
+fn overflow_incomplete_count_fixed() {
+ named!(counter< [&[u8]; 2] >, count_fixed!( &[u8], length_bytes!(be_u64), 2 ) );
+
+ assert_eq!(counter(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef\xaa"[..]), IResult::Incomplete(Needed::Unknown));
+}
+
+#[test]
+fn overflow_incomplete_length_count() {
+ named!(multi<&[u8], Vec<&[u8]> >, length_count!( be_u8, length_bytes!(be_u64) ) );
+
+ assert_eq!(multi(&b"\x04\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xee\xaa"[..]), IResult::Incomplete(Needed::Unknown));
+}
+
+#[test]
+fn overflow_incomplete_length_data() {
+ named!(multi<&[u8], Vec<&[u8]> >, many0!( length_data!(be_u64) ) );
+
+ assert_eq!(multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff\xaa"[..]), IResult::Incomplete(Needed::Unknown));
 }

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -1,0 +1,21 @@
+#[macro_use]
+extern crate nom;
+
+use nom::{IResult,Needed};
+
+// Parser definition
+
+// We request a length that would trigger an overflow if computing consumed + requested
+named!(parser01<&[u8],()>,
+    do_parse!(
+        hdr: take!(1) >>
+        data: take!(18446744073709551615) >>
+        ( () )
+    )
+);
+
+#[test]
+fn overflow_incomplete_test() {
+  assert_eq!(parser01(&b"3"[..]), IResult::Incomplete(Needed::Unknown));
+}
+


### PR DESCRIPTION
This fixes #481 by using `overflowing_add`, in case the requested value would overflow when computing `Needed(consumed + needed)`.