### PR TITLE
Indent parser implementations wrt the category

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,35 +337,35 @@ More examples of chain and tuple usage can be found in the [INI file parser exam
 Here is a list of known projects using nom:
 
 - Text file formats:
- * [Ceph Crush](https://github.com/cholcombe973/crushtool)
- * [XFS Runtime Stats](https://github.com/ChrisMacNaughton/xfs-rs)
- * [CSV](https://github.com/GuillaumeGomez/csv-parser)
- * [FASTQ](https://github.com/elij/fastq.rs)
- * [INI](https://github.com/Geal/nom/blob/master/tests/ini.rs)
- * [ISO 8601 dates](https://github.com/badboy/iso8601)
- * [libconfig-like configuration file format](https://github.com/filipegoncalves/rust-config)
- * [torrc configuration file](https://github.com/dhuseby/torrc-rs)
- * [Web archive](https://github.com/sbeckeriv/warc_nom_parser)
+  * [Ceph Crush](https://github.com/cholcombe973/crushtool)
+  * [XFS Runtime Stats](https://github.com/ChrisMacNaughton/xfs-rs)
+  * [CSV](https://github.com/GuillaumeGomez/csv-parser)
+  * [FASTQ](https://github.com/elij/fastq.rs)
+  * [INI](https://github.com/Geal/nom/blob/master/tests/ini.rs)
+  * [ISO 8601 dates](https://github.com/badboy/iso8601)
+  * [libconfig-like configuration file format](https://github.com/filipegoncalves/rust-config)
+  * [torrc configuration file](https://github.com/dhuseby/torrc-rs)
+  * [Web archive](https://github.com/sbeckeriv/warc_nom_parser)
 - Interface definition formats:
- * [Thrift](https://github.com/thehydroimpulse/thrust)
+  * [Thrift](https://github.com/thehydroimpulse/thrust)
 - Audio, video and image formats:
- * [GIF](https://github.com/Geal/gif.rs)
- * [MagicaVoxel .vox](https://github.com/davidedmonds/dot_vox)
- * [midi](https://github.com/derekdreery/nom-midi-rs)
+  * [GIF](https://github.com/Geal/gif.rs)
+  * [MagicaVoxel .vox](https://github.com/davidedmonds/dot_vox)
+  * [midi](https://github.com/derekdreery/nom-midi-rs)
 - Document formats:
- * [TAR](https://github.com/Keruspe/tar-parser.rs)
- * [torrent files](https://github.com/jag426/bittorrent)
+  * [TAR](https://github.com/Keruspe/tar-parser.rs)
+  * [torrent files](https://github.com/jag426/bittorrent)
 - Database formats:
- * [Redis database files](https://github.com/badboy/rdb-rs)
+  * [Redis database files](https://github.com/badboy/rdb-rs)
 - Network protocol formats:
- * [Bencode](https://github.com/jbaum98/bencode.rs)
- * [IRC](https://github.com/Detegr/RBot-parser)
- * [Pcap-NG](https://github.com/richo/pcapng-rs)
- * [NTP](https://github.com/rusticata/ntp-parser)
- * [SNMP](https://github.com/rusticata/snmp-parser)
- * [DER](https://github.com/rusticata/der-parser)
- * [TLS](https://github.com/rusticata/tls-parser)
- * [IPFIX / Netflow v10](https://github.com/dominotree/rs-ipfix)
+  * [Bencode](https://github.com/jbaum98/bencode.rs)
+  * [IRC](https://github.com/Detegr/RBot-parser)
+  * [Pcap-NG](https://github.com/richo/pcapng-rs)
+  * [NTP](https://github.com/rusticata/ntp-parser)
+  * [SNMP](https://github.com/rusticata/snmp-parser)
+  * [DER](https://github.com/rusticata/der-parser)
+  * [TLS](https://github.com/rusticata/tls-parser)
+  * [IPFIX / Netflow v10](https://github.com/dominotree/rs-ipfix)
 
 Want to create a new parser using `nom`? A list of not yet implemented formats is available [here](https://github.com/Geal/nom/issues/14).
 


### PR DESCRIPTION
The list of examples in the "Parsers written with nom" section is not properly indented, so the libraries appear in the same level as their categories. Increase the indent of the libraries to appear as sublists of the respective categories.