### PR TITLE
Makes Endianness derive from Debug, PartialEq, Eq, Clone and Copy.

### DIFF
--- a/src/nom.rs
+++ b/src/nom.rs
@@ -456,7 +456,7 @@ pub fn le_i64(i:&[u8]) -> IResult<&[u8], i64> {
 }
 
 /// Configurable endianness
-#[derive(PartialEq)]
+#[derive(Debug,PartialEq,Eq,Clone,Copy)]
 pub enum Endianness {
   Big,
   Little,


### PR DESCRIPTION
Enables us to also use `nom` to detect endianness and use it in various ways.
`Debug` allows us to return `Endianness` and compare it in `assert_eq!`.


```rust
named_args!(parse_header_e(e: Endianness, nsec: bool)<(Endianness, Header)>, tuple!(
    value!(e),
    do_parse!(
        major: u16!(e) >>
        minor: u16!(e) >>
        this_zone: i32!(e) >>
        sigfigs: u32!(e) >>
        snaplen: u32!(e) >>
        network: u32!(e) >>
        (Header {
            major: major,
            minor: minor,
            this_zone: this_zone,
            sigfigs: sigfigs,
            snaplen: snaplen,
            network: network,
            nano_sec: nsec
        })
    )
));

named!(parse_header<(Endianness, Header)>, switch!(be_u32,
    0xa1b2c3d4 => call!(parse_header_e, Endianness::Big, false)    | 
    0xd4c3b2a1 => call!(parse_header_e, Endianness::Little, false) 
));


#[cfg(test)]
mod tests {
    use nom;
    use super::*;
    #[test]
    fn parse_header_le_nsec() {
        let i = b"\x4d\x3c\xb2\xa1\x02\x00\x04\x00\xFF\xFF\xFF\xFF\
                  \x01\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x0a";
        let h = Header {
            major: 2,
            minor: 4,
            this_zone: -1,
            sigfigs: 1,
            snaplen: 1,
            network: 1,
            nano_sec: true
        };
        assert_eq!(parse_header(&i[..]), nom::IResult::Done(&[10][..], (Endianness::Little, h)));
    }
}
```
