### PR TITLE
Use `memchr` in `FindToken` and `FindSubstring` implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ optional = true
 version = "^0.2.2"
 optional = true
 
+[dependencies.memchr]
+version = "^1.0.1"
+
 #[dev-dependencies.bytes]
 #git = "https://github.com/carllerche/bytes"
 #rev = "a7d38e29"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ extern crate collections;
 extern crate regex;
 #[cfg(feature = "regexp_macros")]
 #[macro_use] extern crate lazy_static;
+extern crate memchr;
 #[cfg(feature = "nightly")]
 extern crate test;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -9,6 +9,8 @@ use std::str::CharIndices;
 use std::str::FromStr;
 use std::str::from_utf8;
 
+use memchr::memchr;
+
 
 /// abstract method to calculate the input length
 pub trait InputLength {
@@ -404,10 +406,7 @@ pub trait FindToken<T> {
 
 impl<'a> FindToken<&'a[u8]> for u8 {
   fn find_token(&self, input: &[u8]) -> bool {
-    for &i in input.iter() {
-      if *self == i { return true }
-    }
-    false
+    memchr(*self, input).is_some()
   }
 }
 
@@ -419,10 +418,7 @@ impl<'a> FindToken<&'a str> for u8 {
 
 impl<'a,'b> FindToken<&'a[u8]> for &'b u8 {
   fn find_token(&self, input: &[u8]) -> bool {
-    for &i in input.iter() {
-      if **self == i { return true }
-    }
-    false
+    memchr(**self, input).is_some()
   }
 }
 


### PR DESCRIPTION
As said on Gitter, this is the first step for a `memchr` usage in the `FindToken` implementation. So far, no performance boost has been observed. Maybe benchmarks are not designed to show this kind of performance change yet.

This is a WIP.