### PR TITLE
`find_substring` returns `None` if empty substr

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -448,7 +448,13 @@ pub trait FindSubstring<T> {
 
 impl<'a,'b> FindSubstring<&'b [u8]> for &'a[u8] {
   fn find_substring(&self, substr: &'b[u8]) -> Option<usize> {
-    for (index,win) in self.windows(substr.len()).enumerate() {
+    let substr_len = substr.len();
+
+    if substr_len == 0 {
+        return None;
+    }
+
+    for (index,win) in self.windows(substr_len).enumerate() {
       if win == substr {
         return Some(index)
       }


### PR DESCRIPTION
Calling `input.find_substring(b"")` will make the thread to panic with this error:

> thread '…' panicked at 'assertion failed: size != 0', src/libcore/slice/mod.rs:337

This is not possible to create windows of length 0.