### PR TITLE
allow non primitive bits encoded integers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ extern crate test;
 #[cfg(not(feature = "std"))]
 mod std {
 #[macro_use]
-  pub use core::{fmt, cmp, iter, option, result, ops, slice, str, mem};
+  pub use core::{fmt, cmp, iter, option, result, ops, slice, str, mem, convert};
   pub use collections::{boxed, vec, string};
   pub mod prelude {
     pub use core::prelude as v1;


### PR DESCRIPTION
`take_bits!` returns a bits encoded value of the type passed to the macro by argument. This type must implement some operator traits (Shr, Shl, AddAssign) and a conversion from `u8`. Only rust integer and float primitive types can do this conversion according to numeric cast rules.

These changes make the conversion explicit in order to allow non primitive types. It is then possible to parse `num::bigint::BigInt` integers with `take_bits!`.