### PR TITLE
Removed leading Zeros in Ranges

### DIFF
--- a/src/branch.rs
+++ b/src/branch.rs
@@ -718,7 +718,7 @@ mod tests {
         let res:$crate::IResult<&[u8],&[u8]> = if $i.len() < cnt {
           $crate::IResult::Incomplete($crate::Needed::Size(cnt))
         } else {
-          $crate::IResult::Done(&$i[cnt..],&$i[0..cnt])
+          $crate::IResult::Done(&$i[cnt..],&$i[..cnt])
         };
         res
       }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -557,7 +557,7 @@ macro_rules! take_until_and_consume (
             $crate::IResult::Error(error_position!($crate::ErrorKind::TakeUntilAndConsume,$i))
           },
           Some(index) => {
-            $crate::IResult::Done($i.slice(index+$substr.input_len()..), $i.slice(0..index))
+            $crate::IResult::Done($i.slice(index+$substr.input_len()..), $i.slice(..index))
           },
         }
       };
@@ -582,7 +582,7 @@ macro_rules! take_until_and_consume1 (
             $crate::IResult::Error(error_position!($crate::ErrorKind::TakeUntilAndConsume,$i))
           },
           Some(index) => {
-            $crate::IResult::Done($i.slice(index+$substr.input_len()..), $i.slice(0..index))
+            $crate::IResult::Done($i.slice(index+$substr.input_len()..), $i.slice(..index))
           },
         }
       };
@@ -609,7 +609,7 @@ macro_rules! take_until (
             $crate::IResult::Error(error_position!($crate::ErrorKind::TakeUntil,$i))
           },
           Some(index) => {
-            $crate::IResult::Done($i.slice(index..), $i.slice(0..index))
+            $crate::IResult::Done($i.slice(index..), $i.slice(..index))
           },
         }
       };
@@ -636,7 +636,7 @@ macro_rules! take_until1 (
             $crate::IResult::Error(error_position!($crate::ErrorKind::TakeUntil,$i))
           },
           Some(index) => {
-            $crate::IResult::Done($i.slice(index..), $i.slice(0..index))
+            $crate::IResult::Done($i.slice(index..), $i.slice(..index))
           },
         }
       };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1211,7 +1211,7 @@ mod tests {
         let res:$crate::IResult<&[u8],&[u8]> = if $i.len() < cnt {
           $crate::IResult::Incomplete($crate::Needed::Size(cnt))
         } else {
-          $crate::IResult::Done(&$i[cnt..],&$i[0..cnt])
+          $crate::IResult::Done(&$i[cnt..],&$i[..cnt])
         };
         res
       }

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -36,7 +36,7 @@
 //!   );
 //! );
 //! ```
-//! 
+//!
 //! The `method!` macro is similar to the `named!` macro in the macros module.
 //! While `named!` will create a parser function, `method!` will create a parser
 //! method on the struct it is defined in.
@@ -61,7 +61,7 @@
 //! will cause self to be moved for the rest of the method.To get around this
 //! restriction all self is moved into the called method and then the called
 //! method will return self to the caller.
-//! 
+//!
 //! To call a method on self you need to use the `call_m!` macro. For example:
 //! ```ignore
 //! struct<'a> Parser<'a> {
@@ -290,9 +290,9 @@ mod tests {
       {
         let res: $crate::IResult<_,_> = if $tag.len() > $i.len() {
           $crate::IResult::Incomplete($crate::Needed::Size($tag.len()))
-        //} else if &$i[0..$tag.len()] == $tag {
+        //} else if &$i[..$tag.len()] == $tag {
         } else if ($i).starts_with($tag) {
-          $crate::IResult::Done(&$i[$tag.len()..], &$i[0..$tag.len()])
+          $crate::IResult::Done(&$i[$tag.len()..], &$i[..$tag.len()])
         } else {
           $crate::IResult::Error(error_position!($crate::ErrorKind::TagStr, $i))
         };
@@ -461,7 +461,7 @@ mod tests {
       other => panic!("`Parser.use_apply` didn't succeed when it should have. \
                              Got `{:?}`.", other),
     }
-  } 
+  }
 
   #[test]
   fn test_method_call_peek() {

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -1142,7 +1142,7 @@ mod tests {
         let res:$crate::IResult<&[u8],&[u8]> = if $i.len() < cnt {
           $crate::IResult::Incomplete($crate::Needed::Size(cnt))
         } else {
-          $crate::IResult::Done(&$i[cnt..],&$i[0..cnt])
+          $crate::IResult::Done(&$i[cnt..],&$i[..cnt])
         };
         res
       }

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -529,7 +529,7 @@ mod tests {
         let res:$crate::IResult<&[u8],&[u8]> = if $i.len() < cnt {
           $crate::IResult::Incomplete($crate::Needed::Size(cnt))
         } else {
-          $crate::IResult::Done(&$i[cnt..],&$i[0..cnt])
+          $crate::IResult::Done(&$i[cnt..],&$i[..cnt])
         };
         res
       }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -211,7 +211,7 @@ impl InputTake for [u8] {
     #[inline]
     fn take<P>(&self, count: usize) -> Option<&Self> {
       if self.len() >= count {
-        Some(&self[0..count])
+        Some(&self[..count])
       } else {
         None
       }

--- a/src/whitespace.rs
+++ b/src/whitespace.rs
@@ -659,7 +659,7 @@ macro_rules! eat_separator (
     {
       use $crate::{AsChar,InputLength,InputIter,Slice};
       if ($i).input_len() == 0 {
-        $crate::IResult::Done(($i).slice(0..), ($i).slice(0..0))
+        $crate::IResult::Done(($i).slice(..), ($i).slice(..0))
       } else {
         match ($i).iter_indices().position(|(_, item)| {
           let i = item.as_char();
@@ -784,11 +784,11 @@ macro_rules! sep (
   };
 );
 
-use std::ops::{Range,RangeFrom,RangeTo};
+use std::ops::{RangeFull,RangeFrom,RangeTo};
 use internal::IResult;
 #[allow(unused_imports)]
 pub fn sp<'a,T>(input:T) -> IResult<T, T> where
-  T: ::traits::Slice<Range<usize>>+::traits::Slice<RangeFrom<usize>>+::traits::Slice<RangeTo<usize>>,
+  T: ::traits::Slice<RangeFull>+::traits::Slice<RangeFrom<usize>>+::traits::Slice<RangeTo<usize>>,
     T: ::traits::InputIter+::traits::InputLength,
     <T as ::traits::InputIter>::Item: ::traits::AsChar {
     eat_separator!(input, &b" \t\r\n"[..])


### PR DESCRIPTION
Hope this is something you`re (mildly) interested in:

Removing leading zeroes in ranges helped making the code a bit
more intuitive. Also this made Range<usize> as a trait
superflous in some cases.

ATTENTION: This also ment in two case to switch from RangeFrom to
RangeFull. This might break some code which does not rely on `str`
ot `[T]` for which the Slice trait is implemented for all kinds of
Ranges by nom.