### PR TITLE
Use stdlib compile_error! in compiler_error! macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+## Unreleased
+
+### Changed
+
+- the `compiler_error` macro now uses the stdlib `compile_error` macro on nightly.
+
 ## 3.2.0 - 2017-07-24
 
 ### Thanks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 
 [features]
 std = ["memchr/use_std"]
-nightly = ["compiler_error"]
+nightly = []
 default = ["std", "stream"]
 regexp = ["regex"]
 regexp_macros = ["regexp", "lazy_static"]
@@ -45,10 +45,6 @@ default-features = false
 #[dev-dependencies.bytes]
 #git = "https://github.com/carllerche/bytes"
 #rev = "a7d38e29"
-
-[dependencies.compiler_error]
-version = "0.1.1"
-optional = true
 
 [badges]
 travis-ci = { repository = "Geal/nom" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,7 +394,6 @@
 #![cfg_attr(feature = "nightly", feature(test))]
 #![cfg_attr(feature = "nightly", feature(const_fn))]
 #![cfg_attr(feature = "nightly", feature(plugin))]
-#![cfg_attr(feature = "nightly", plugin(compiler_error))]
 //#![warn(missing_docs)]
 
 #[cfg(not(feature = "std"))]
@@ -413,6 +412,15 @@ extern crate test;
 macro_rules! compiler_error {
     ($e:expr) => {
       INVALID_NOM_SYNTAX_PLEASE_SEE_FAQ //https://github.com/Geal/nom/blob/master/doc/FAQ.md#using-nightly-to-get-better-error-messages
+    }
+}
+
+#[cfg(feature = "nightly")]
+#[allow(unused_macros)]
+#[macro_export]
+macro_rules! compiler_error {
+    ($e:expr) => {
+        compile_error!($e)
     }
 }
 


### PR DESCRIPTION
Removes the dependency on `compiler_error!`, which didn't work on my version of nightly for whatever reason (it complains that it can't find the `compiler_error!` macro).

`compile_error!` is stable and will land in 1.20: https://github.com/matthewhammer/rust/commit/87483f93cea2a2b7b7649f3c2e88ce7d2ce9801f

Macro docs : https://doc.rust-lang.org/nightly/std/macro.compile_error.html