### PR TITLE
src/multi.rs: fix 'type annotations needed' error

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -24,7 +24,7 @@ macro_rules! separated_list(
             res.push(o);
             input = i;
 
-            let ret;
+            let ret: $crate::IResult<_,_,$crate::ErrorKind>;
 
             loop {
               // get the separator first


### PR DESCRIPTION
separated_list!() gives an "error[E0282]: type annotations needed", with
  cannot infer type for `E`
  consider giving `ret` a type

This stops the error.