### PR TITLE
err cast to errorkind robust against verbose-error feature state

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -431,7 +431,7 @@ macro_rules! many1(
 ///    let res_b: (Vec<&[u8]>, &[u8]) = (Vec::new(), &b"efgh"[..]);
 ///    assert_eq!(multi(&a[..]), Done(&b"abcd"[..], res_a));
 ///    assert_eq!(multi(&b[..]), Done(&b"abcd"[..], res_b));
-///    assert_eq!(multi(&c[..]), Error(error_node_position!(ErrorKind::ManyTill,&c[..],error_position(ErrorKind::Tag,&c[..]))));
+///    assert_eq!(multi(&c[..]), Error(error_node_position!(ErrorKind::ManyTill,&c[..],error_position!(ErrorKind::Tag,&c[..]))));
 /// # }
 /// ```
 #[macro_export]
@@ -1351,7 +1351,7 @@ mod tests {
     let res_b: (Vec<&[u8]>, &[u8]) = (Vec::new(), &b"efgh"[..]);
     assert_eq!(multi(&a[..]), Done(&b"abcd"[..], res_a));
     assert_eq!(multi(&b[..]), Done(&b"abcd"[..], res_b));
-    assert_eq!(multi(&c[..]), Error(error_node_position!(ErrorKind::ManyTill,&c[..], error_position(ErrorKind::Tag,&c[..]))));
+    assert_eq!(multi(&c[..]), Error(error_node_position!(ErrorKind::ManyTill,&c[..], error_position!(ErrorKind::Tag,&c[..]))));
   }
 
   #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -243,7 +243,6 @@ pub fn slice_to_offsets(input: &[u8], s: &[u8]) -> (usize, usize) {
 pub fn prepare_errors<O,E: Clone>(input: &[u8], res: IResult<&[u8],O,E>) -> Option<Vec<(ErrorKind<E>, usize, usize)> > {
   if let IResult::Error(e) = res {
     let mut v:Vec<(ErrorKind<E>, usize, usize)> = Vec::new();
-    let mut err = e.clone();
 
     match e {
        Err::Code(_) => {},

--- a/src/util.rs
+++ b/src/util.rs
@@ -701,6 +701,12 @@ pub fn error_to_u32<E>(e: &ErrorKind<E>) -> u32 {
       }
 
     }
+    /// Convert Err into an ErrorKind.
+    ///
+    /// This allows application code to use ErrorKind and stay independent from the `verbose-errors` features activation.
+    pub fn into_error_kind(self) -> ErrorKind<E> {
+      self
+    }
   }
 
 #[cfg(test)]

--- a/src/verbose_errors.rs
+++ b/src/verbose_errors.rs
@@ -39,6 +39,20 @@ pub enum Err<P,E=u32>{
   NodePosition(ErrorKind<E>, P, Vec<Err<P,E>>)
 }
 
+impl<P,E> Err<P,E> {
+  /// Convert Err into ErrorKind.
+  ///
+  /// This allows application code to use ErrorKind and stay independent from the verbose-errors features activation.
+  pub fn into_error_kind(self) -> ErrorKind<E> {
+    match self {
+      Err::Code(kind) => kind,
+      Err::Node(kind, _) => kind,
+      Err::Position(kind, _) => kind,
+      Err::NodePosition(kind, _, _) => kind,
+    }
+  }
+}
+
 impl<I,O,E> IResult<I,O,E> {
   /// Maps a `IResult<I, O, E>` to `IResult<I, O, N>` by appling a function
   /// to a contained `Error` value, leaving `Done` and `Incomplete` value


### PR DESCRIPTION
This creates a `Err::into_error_kind()` that will work the same whether or not verbose error are activated.