### PR TITLE
Request to add bnf to list of projects using nom

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ Here is a list of known projects using nom:
   * [DER](https://github.com/rusticata/der-parser)
   * [TLS](https://github.com/rusticata/tls-parser)
   * [IPFIX / Netflow v10](https://github.com/dominotree/rs-ipfix)
+- Language specifications:
+  * [BNF](https://github.com/snewt/bnf)  
 - [using nom as lexer and parser](https://github.com/Rydgel/monkey-rust)
 
 Want to create a new parser using `nom`? A list of not yet implemented formats is available [here](https://github.com/Geal/nom/issues/14).


### PR DESCRIPTION
This commit represents an addition to the list of known projects
using nom. I wrote a tool to parse BNF grammars using nom called bnf
available on Github [here](https://github.com/snewt/bnf) with the
corresponding crate documentation [here](https://crates.io/crates/bnf).
I really enjoyed learning to use nom! Thanks for making and maintaining
it! The project's documentation was awesome and it really helped me
through the process.