### PR TITLE
Fix typo in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
 ### Thanks
 
 - Chris Pick for some `Incomplete` related refactors
-- @drbgn for documentation fixes
+- @dbrgn for documentation fixes
 - @valarauca for adding `be_u24`
 - @ithinuel for usability fixes
 - @evuez for README readability fixes and improvements to `IResult`


### PR DESCRIPTION
I hope this change doesn't end up in the changelog, because if you accidentally mistype it again we'll end up IN AN ENDLESS RECURSIVE LOOP OF MISSPELLING, PULL REQUESTS, DEATH AND DEVASTATION 😱 

(As requested on Reddit, this fixes the typo in my hard-to-type username 🙃)