### PR TITLE
Add nom-sql to list of parsers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Here is a list of known projects using nom:
 - Programming languages:
   * [GLSL](https://github.com/phaazon/glsl)
   * [Lua](https://github.com/doomrobo/nom-lua53)
+  * [SQL](https://github.com/ms705/nom-sql)
 - Interface definition formats:
   * [Thrift](https://github.com/thehydroimpulse/thrust)
 - Audio, video and image formats:


### PR DESCRIPTION
[nom-sql](https://github.com/ms705/nom-sql) is an incomplete, but already useable SQL parser (e.g., used in [distributary](https://github.com/mit-pdos/distributary)).

It's currently written using very much outdated nom 1.x APIs, but will upgrade in the future.