### PR TITLE
Fix take_until_and_consume1!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## [Unreleased][unreleased]
 
-### Changed
+### Fixed
+
+- `take_until_and_consume1!` no longer results in "no method named \`find_substring\`" and "no method named \`slice\`" compilation errors
+- `take_until_and_consume1!` returns the correct Incomplete(Needed) amount
+
+### Added
+
+- `ErrorKind::TakeUntilAndConsume1`
 
 ## 3.2.1 - 2017-10-27
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -726,16 +726,23 @@ macro_rules! take_until_and_consume1 (
       use $crate::{Err,Needed,IResult,ErrorKind,need_more};
 
       use $crate::InputLength;
+      use $crate::FindSubstring;
+      use $crate::Slice;
 
       let res: IResult<_,_> = if 1 + $substr.input_len() > $i.input_len() {
-        need_more(Needed::Size($substr.input_len()))
+        need_more($i, Needed::Size(1+$substr.input_len()))
       } else {
-        match ($i).find_substring($substr) {
+        // To guarantee returning a non-empty subsequence, look for the substring
+        // starting from index 1. We know that there is at least one byte available
+        // because of the previous check.
+        match ($i.slice(1..)).find_substring($substr) {
           None => {
-            let e = ErrorKind::TakeUntilAndConsume::<u32>;
+            let e = ErrorKind::TakeUntilAndConsume1::<u32>;
             Err(Err::Error(error_position!(e,$i)))
           },
           Some(index) => {
+            // convert the index within $i.slice(1..) to the index within $i
+            let index = index + 1;
             Ok(($i.slice(index+$substr.input_len()..), $i.slice(0..index)))
           },
         }
@@ -1126,25 +1133,56 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
-  fn take_until_test() {
+  fn take_until_and_consume() {
     named!(x, take_until_and_consume!("efgh"));
     let r = x(&b"abcdabcdefghijkl"[..]);
     assert_eq!(r, Ok((&b"ijkl"[..], &b"abcdabcd"[..])));
-
     println!("Done 1\n");
 
     let r2 = x(&b"abcdabcdefgh"[..]);
     assert_eq!(r2, Ok((&b""[..], &b"abcdabcd"[..])));
-
     println!("Done 2\n");
+
     let r3 = x(&b"abcefg"[..]);
     assert_eq!(r3,  Err(Err::Error(error_position!(ErrorKind::TakeUntilAndConsume, &b"abcefg"[..]))));
+    println!("Done 3\n");
 
     assert_eq!(
       x(&b"ab"[..]),
       Err(Err::Incomplete(Needed::Size(4)))
     );
+  }
+
+  #[test]
+  fn take_until_and_consume1() {
+    named!(x, take_until_and_consume1!("efgh"));
+    let r = x(&b"abcdabcdefghijkl"[..]);
+    assert_eq!(r, Ok((&b"ijkl"[..], &b"abcdabcd"[..])));
+    println!("Done 1\n");
+
+    let r2 = x(&b"abcdabcdefgh"[..]);
+    assert_eq!(r2, Ok((&b""[..], &b"abcdabcd"[..])));
+    println!("Done 2\n");
+
+    let r3 = x(&b"abcefg"[..]);
+    assert_eq!(r3, Err(Err::Error(error_position!(ErrorKind::TakeUntilAndConsume1, &b"abcefg"[..]))));
+    println!("Done 3\n");
+
+    let r4 = x(&b"efgh"[..]);
+    assert_eq!(r4, Err(Err::Incomplete(Needed::Size(5))));
+    println!("Done 4\n");
+
+    named!(x2, take_until_and_consume1!(""));
+    let r5 = x2(&b""[..]);
+    assert_eq!(r5, Err(Err::Incomplete(Needed::Size(1))));
+    println!("Done 5\n");
+
+    let r6 = x2(&b"a"[..]);
+    assert_eq!(r6, Ok((&b""[..], &b"a"[..])));
+    println!("Done 6\n");
+
+    let r7 = x(&b"efghi"[..]);
+    assert_eq!(r7, Err(Err::Error(error_position!(ErrorKind::TakeUntilAndConsume1, &b"efghi"[..]))));
   }
 
   #[test]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -469,7 +469,9 @@ impl<'a,'b> FindSubstring<&'b [u8]> for &'a[u8] {
     let substr_len = substr.len();
 
     if substr_len == 0 {
-      None
+      // an empty substring is found at position 0
+      // This matches the behavior of str.find("").
+      Some(0)
     } else if substr_len == 1 {
       memchr::memchr(substr[0], self)
     } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -546,6 +546,7 @@ pub enum ErrorKind<E=u32> {
   Permutation,
   Verify,
   TakeTill1,
+  TakeUntilAndConsume1,
 }
 
 pub fn error_to_u32<E>(e: &ErrorKind<E>) -> u32 {
@@ -609,6 +610,7 @@ pub fn error_to_u32<E>(e: &ErrorKind<E>) -> u32 {
     ErrorKind::ManyTill                  => 65,
     ErrorKind::Verify                    => 66,
     ErrorKind::TakeTill1                 => 67,
+    ErrorKind::TakeUntilAndConsume1      => 68,
   }
 }
 
@@ -674,6 +676,7 @@ pub fn error_to_u32<E>(e: &ErrorKind<E>) -> u32 {
         ErrorKind::ManyTill                  => "ManyTill",
         ErrorKind::Verify                    => "predicate verification",
         ErrorKind::TakeTill1                 => "TakeTill1",
+        ErrorKind::TakeUntilAndConsume1      => "Take at least 1 until and consume",
       }
 
     }
@@ -753,6 +756,7 @@ impl<F, E: From<F>> Convert<ErrorKind<F>> for ErrorKind<E> {
       ErrorKind::ManyTill                  => ErrorKind::ManyTill,
       ErrorKind::Verify                    => ErrorKind::Verify,
       ErrorKind::TakeTill1                 => ErrorKind::TakeTill1,
+      ErrorKind::TakeUntilAndConsume1      => ErrorKind::TakeUntilAndConsume1,
     }
   }
 }


### PR DESCRIPTION
- Using the macro would cause compilation errors.
- The generated parser combinator would return the incorrect needed amount.
- ErrorKind was missing a variant for take_until_and_consume1!.
- Ensure that the returned sequence is non-empty.