### PR TITLE
Travis CI more improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ env:
     - FEATURES='' # default ones
     - FEATURES='--features "regexp"'
     - FEATURES='--features "regexp regexp_macros"'
-    - FEATURES='--features "stream regexp regexp_macros"'
-    - FEATURES='--features "stream regexp regexp_macros" --no-default-features'
+    - FEATURES='--features "regexp regexp_macros" --no-default-features'
 
 matrix:
   include:
@@ -22,7 +21,7 @@ matrix:
       env: FEATURES='--features "nightly regexp"'
 
     - rust: stable
-      env: DOC_FEATURES='--features "std stream regexp regexp_macros" --no-default-features'
+      env: DOC_FEATURES='--features "std regexp regexp_macros" --no-default-features'
       script: eval cargo doc --verbose $DOC_FEATURES
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ matrix:
   include:
     - rust: nightly
       env: FEATURES='--features "nightly regexp"'
-
     - rust: nightly
       env: FEATURES='--features "regexp regexp_macros" --no-default-features'
-
+    - rust: nightly
+      env: FEATURES='--no-default-features'
     - rust: stable
       env: DOC_FEATURES='--features "std regexp regexp_macros" --no-default-features'
       script: eval cargo doc --verbose $DOC_FEATURES

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,29 @@
 language: rust
-
+sudo: false
+dist: trusty
 cache: cargo
 
 rust:
   - nightly
   - beta
   - stable
-  - 1.2.0
 
 env:
   matrix:
-    - FEATURES=''
+    - FEATURES='' # default ones
+    - FEATURES='--features "regexp"'
     - FEATURES='--features "regexp regexp_macros"'
-    - FEATURES='--features "regexp regexp_macros" --no-default-features'
+    - FEATURES='--features "stream regexp regexp_macros"'
+    - FEATURES='--features "stream regexp regexp_macros" --no-default-features'
 
-before_script:
-  - if [ "$TRAVIS_RUST_VERSION" != "1.2.0" ]; then
-      cargo install cargo-travis --force && export PATH=$HOME/.cargo/bin:$PATH;
-    fi
+matrix:
+  include:
+    - rust: nightly
+      env: FEATURES='--features "nightly regexp"'
 
-script:
-  - '[ $TRAVIS_RUST_VERSION != 1.2.0   ] || cargo test --verbose --features "regexp"'
-  - '[ $TRAVIS_RUST_VERSION != nightly ] || cargo build --verbose --features "nightly regexp"'
-  - '[ $TRAVIS_RUST_VERSION == 1.2.0   ] || eval cargo test --verbose $FEATURES'
-  - '[ $TRAVIS_RUST_VERSION != nightly ] || cargo bench --verbose'
-  - '[ $TRAVIS_RUST_VERSION != stable  ] || cargo doc --verbose --features "std regexp regexp_macros" --no-default-features'
-
-after_success:
-  - '[ $TRAVIS_RUST_VERSION != nightly ] || cargo bench --verbose'
-  - '[ $TRAVIS_RUST_VERSION == 1.2.0   ] || cargo coveralls --verbose'
-  - '[ $TRAVIS_RUST_VERSION != nightly ] || cargo bench --verbose'
-  - if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" != "master" ] && [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
-        cargo install cargo-benchcmp --force;
-        cargo bench > benches-variable;
-        git fetch;
-        git checkout master;
-        cargo bench > benches-control;
-        cargo benchcmp benches-control benches-variable;
-    fi
+    - rust: stable
+      env: DOC_FEATURES='--features "std stream regexp regexp_macros" --no-default-features'
+      script: eval cargo doc --verbose $DOC_FEATURES
 
 notifications:
   webhooks:
@@ -47,8 +33,6 @@ notifications:
     on_failure: always
     on_start: false
 
-dist: trusty
-sudo: false
 
 addons:
   apt:
@@ -60,3 +44,30 @@ addons:
       - cmake
     sources:
       - kalakris-cmake
+
+before_script: |
+  cargo install cargo-travis --force && export PATH=$HOME/.cargo/bin:$PATH
+
+script:
+  - eval cargo build --verbose $FEATURES
+  - eval cargo test --verbose $FEATURES
+
+after_success: |
+  case "$TRAVIS_RUST_VERSION" in
+    nightly)
+      cargo bench --verbose
+      cargo coveralls --verbose
+      cargo bench --verbose
+      if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" != "master" ]; then
+        cargo install cargo-benchcmp --force
+        cargo bench > benches-variable
+        git fetch
+        git checkout master
+        cargo bench > benches-control
+        cargo benchcmp benches-control benches-variable
+      fi
+      ;;
+    *)
+      cargo coveralls --verbose
+      ;;
+  esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,14 @@ env:
     - FEATURES='' # default ones
     - FEATURES='--features "regexp"'
     - FEATURES='--features "regexp regexp_macros"'
-    - FEATURES='--features "regexp regexp_macros" --no-default-features'
 
 matrix:
   include:
     - rust: nightly
       env: FEATURES='--features "nightly regexp"'
+
+    - rust: nightly
+      env: FEATURES='--features "regexp regexp_macros" --no-default-features'
 
     - rust: stable
       env: DOC_FEATURES='--features "std regexp regexp_macros" --no-default-features'


### PR DESCRIPTION
This pull request is a follow up to #573 
In https://github.com/Geal/nom/pull/573#issuecomment-326286088 I showed a rewritten version but didn't make a PR. Please check out this changes.

- The more flexible matrix configuration
- Split of .travis.yml into configuration part and execution script part (graphically it uses two newlines to mark this)
- Dropped Rust 1.2.0, as master doesn't compile on this version anymore. Maybe it is worthwhile to add some minimal version of Rust compiler? Are there branches that you support with 1.2.0?
- Bash's case used to show differences in scripts running on different versions. It looks much clearer this way
- Removed use of stream flag
- Compilation without std flag is now done only on nightly, as on other compiler versions it just won't work. It is OK, as it uses `feature(..)` mechanism. (maybe someday `alloc` will go stable and then we could test against other channels)
- better coverage reports; Coveralls shows percentages per job, which is now per a set of active features

I think this closes #500 