### PR TITLE
Missing imports while testing

### DIFF
--- a/src/branch.rs
+++ b/src/branch.rs
@@ -705,6 +705,7 @@ macro_rules! permutation_iterator (
 
 #[cfg(test)]
 mod tests {
+  use ::std::string::{String, ToString};
   use internal::{Err,Needed,IResult};
   use util::ErrorKind;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,7 +400,7 @@
 //#![warn(missing_docs)]
 
 #[cfg(not(feature = "std"))]
-extern crate alloc;
+#[macro_use] extern crate alloc;
 #[cfg(feature = "regexp")]
 extern crate regex;
 #[cfg(feature = "regexp_macros")]

--- a/src/regexp.rs
+++ b/src/regexp.rs
@@ -556,6 +556,7 @@ macro_rules! re_bytes_captures_static (
 );
 #[cfg(test)]
 mod tests {
+  use ::std::vec::Vec;
   use util::ErrorKind;
   use internal::Err;
 

--- a/src/regexp.rs
+++ b/src/regexp.rs
@@ -606,7 +606,7 @@ mod tests {
   fn re_matches_static() {
     named!(rm< &str,Vec<&str> >, re_matches_static!(r"\d{4}-\d{2}-\d{2}"));
     assert_eq!(rm("2015-09-07"),Ok(("", vec!["2015-09-07"])));
-    assert_eq!(rm("blah"), Err(Err::Error(error_position!(&"blah"[..], ErrorKind::RegexpMatch::<u32>))));
+    assert_eq!(rm("blah"), Err(Err::Error(error_position!(&"blah"[..], ErrorKind::RegexpMatches::<u32>))));
     assert_eq!(rm("aaa2015-09-07blah2015-09-09pouet"),Ok(("pouet", vec!["2015-09-07", "2015-09-09"])));
   }
 
@@ -697,7 +697,7 @@ mod tests {
   fn re_bytes_matches_static() {
     named!(rm<Vec<&[u8]> >, re_bytes_matches_static!(r"\d{4}-\d{2}-\d{2}"));
     assert_eq!(rm(&b"2015-09-07"[..]),Ok((&b""[..], vec![&b"2015-09-07"[..]])));
-    assert_eq!(rm(&b"blah"[..]), Err(Err::Error(error_position!(&b"blah"[..], ErrorKind::RegexpMatch::<u32>))));
+    assert_eq!(rm(&b"blah"[..]), Err(Err::Error(error_position!(&b"blah"[..], ErrorKind::RegexpMatches::<u32>))));
     assert_eq!(rm(&b"aaa2015-09-07blah2015-09-09pouet"[..]),Ok((&b"pouet"[..], vec![&b"2015-09-07"[..], &b"2015-09-09"[..]])));
   }
 

--- a/src/whitespace.rs
+++ b/src/whitespace.rs
@@ -869,6 +869,7 @@ macro_rules! ws (
 #[cfg(test)]
 #[allow(dead_code)]
 mod tests {
+  use ::std::string::{String, ToString};
   use internal::{Err,IResult,Needed};
   use super::sp;
   use util::ErrorKind;


### PR DESCRIPTION
Fix missing imports for `cargo test --no-default-features` on latest nightly.