### PR TITLE
Reduce CI times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ matrix:
       env: FEATURES='--features "nightly"'
     - rust: nightly
       env: FEATURES='--no-default-features'
-      before_script:
-        - export PATH=$HOME/.cargo/bin:$PATH
-        - which cargo-coveralls || cargo install cargo-travis
-        - which cargo-benchcmp  || cargo install cargo-benchcmp
     - rust: stable
       env: FEATURES=''
     - rust: stable
@@ -53,6 +49,11 @@ addons:
       - cmake
     sources:
       - kalakris-cmake
+
+before_script:
+  - export PATH=$HOME/.cargo/bin:$PATH
+  - which cargo-coveralls || cargo install cargo-travis
+  - which cargo-benchcmp  || cargo install cargo-benchcmp
 
 script:
   - eval cargo build --verbose $FEATURES

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ matrix:
       env: FEATURES='--no-default-features'
     - rust: stable
       env: FEATURES=''
-    - rust: stable
+    - rust: nightly
       env: DOC_FEATURES='--features "std regexp regexp_macros" --no-default-features'
       before_script:
         - export PATH=$HOME/.cargo/bin:$PATH
-        - which rustfmt || cargo install rustfmt
+        - which rustfmt || cargo install rustfmt-nightly
       script:
-        - eval cargo fmt -- --write-mode=diff
+        - cargo fmt -- --write-mode=diff
         - eval cargo doc --verbose $DOC_FEATURES
       after_success:
         - echo 'No need to send Coveralls'

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
       script:
         - eval cargo fmt -- --write-mode=diff
         - eval cargo doc --verbose $DOC_FEATURES
+      after_success:
+        - echo 'No need to send Coveralls'
 
 notifications:
   webhooks:


### PR DESCRIPTION
Not forcing `cargo install` on every build can save CI a lot of time. Cargo, unfortunately, doesn't have some CI flag that would install or update the tools if needed. I applied the workaround described in issue https://github.com/roblabla/cargo-travis/issues/17

Latest master: https://travis-ci.org/Geal/nom/builds/314349125
Ran for 32 min 21 sec
Total time 2 hrs 10 min 14 sec

This PR: https://travis-ci.org/Geal/nom/builds/314369454
Ran for 13 min 4 sec
Total time 56 min 48 sec

These speedups come with some downside. If one of the tools stop working, you may need to clear Travis cache manually to install updates.