### PR TITLE
Add basic calculator language parser example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Here is a list of known projects using nom:
   * [torrc configuration file](https://github.com/dhuseby/torrc-rs)
   * [Web archive](https://github.com/sbeckeriv/warc_nom_parser)
 - Programming languages:
+  * [Basic Calculator](https://github.com/balajisivaraman/basic_calculator_rs)
   * [GLSL](https://github.com/phaazon/glsl)
   * [Lua](https://github.com/doomrobo/nom-lua53)
   * [SQL](https://github.com/ms705/nom-sql)
@@ -375,7 +376,7 @@ Here is a list of known projects using nom:
   * [TLS](https://github.com/rusticata/tls-parser)
   * [IPFIX / Netflow v10](https://github.com/dominotree/rs-ipfix)
 - Language specifications:
-  * [BNF](https://github.com/snewt/bnf)  
+  * [BNF](https://github.com/snewt/bnf)
 - [using nom as lexer and parser](https://github.com/Rydgel/monkey-rust)
 
 Want to create a new parser using `nom`? A list of not yet implemented formats is available [here](https://github.com/Geal/nom/issues/14).


### PR DESCRIPTION
I created a very simple parser/evaluator for a basic calculator language using Nom. The goal was to learn the idioms Rust and Nom using a relatively simple example, something that is larger than just math operations, but smaller than a full fledged language or text file format.

It demonstrates the use of most of the fundamental Nom idioms (the primitive parser macros - `alpha!`, `digit!`, `ws!`, `char!` , `tag!`, and a bunch of other combinators; `do_parse!`; and combining smaller parsers into bigger ones). It also includes an example of parsing from a file using the older streaming API (`FileProducer` and a custom `Consumer`). I plan to keep this repository updated with Nom's API changes. So once the new generators API is finalised and released, I'll update that example as well.

My hope is that others new to both Rust and Nom can use this repository as a place to get started with both. (I put it under the Programming Languages category in the example because I couldn't find a better place for it.)

Thank you for the great library.