### PR TITLE
Lift some restrictions in the floating-point number parser

### DIFF
--- a/src/nom.rs
+++ b/src/nom.rs
@@ -679,8 +679,8 @@ pub fn float(input: &[u8]) -> IResult<&[u8], f32> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          delimited!(digit, tag!("."), opt!(complete!(digit)))
-          | delimited!(opt!(digit), tag!("."), digit)
+          value!((), tuple!(digit, opt!(complete!(tag!("."))), opt!(complete!(digit))))
+          | value!((), tuple!(tag!("."), digit))
         ),
         opt!(complete!(tuple!(
           alt!(tag!("e") | tag!("E")),
@@ -703,8 +703,8 @@ pub fn float_s(input: &str) -> IResult<&str, f32> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          delimited!(digit, tag!("."), opt!(complete!(digit)))
-          | delimited!(opt!(digit), tag!("."), digit)
+          value!((), tuple!(digit, opt!(complete!(tag!("."))), opt!(complete!(digit))))
+          | value!((), tuple!(tag!("."), digit))
         ),
         opt!(complete!(tuple!(
           alt!(tag!("e") | tag!("E")),
@@ -727,8 +727,8 @@ pub fn double(input: &[u8]) -> IResult<&[u8], f64> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          delimited!(digit, tag!("."), opt!(complete!(digit)))
-          | delimited!(opt!(digit), tag!("."), digit)
+          value!((), tuple!(digit, opt!(complete!(tag!("."))), opt!(complete!(digit))))
+          | value!((), tuple!(tag!("."), digit))
         ),
         opt!(complete!(tuple!(
           alt!(tag!("e") | tag!("E")),
@@ -751,8 +751,8 @@ pub fn double_s(input: &str) -> IResult<&str, f64> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          delimited!(digit, tag!("."), opt!(complete!(digit)))
-          | delimited!(opt!(digit), tag!("."), digit)
+          value!((), tuple!(digit, opt!(complete!(tag!("."))), opt!(complete!(digit))))
+          | value!((), tuple!(tag!("."), digit))
         ),
         opt!(complete!(tuple!(
           alt!(tag!("e") | tag!("E")),

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -679,8 +679,8 @@ pub fn float(input: &[u8]) -> IResult<&[u8], f32> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          value!((), tuple!(digit, opt!(tuple!(tag!("."), opt!(digit)))))
-          | value!((), tuple!(tag!("."), digit))
+          value!((), pair!(digit, opt!(pair!(tag!("."), opt!(digit)))))
+          | value!((), pair!(tag!("."), digit))
         ),
         opt!(tuple!(
           alt!(tag!("e") | tag!("E")),
@@ -702,8 +702,8 @@ pub fn float_s(input: &str) -> IResult<&str, f32> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          value!((), tuple!(digit, opt!(tuple!(tag!("."), opt!(digit)))))
-          | value!((), tuple!(tag!("."), digit))
+          value!((), pair!(digit, opt!(pair!(tag!("."), opt!(digit)))))
+          | value!((), pair!(tag!("."), digit))
         ),
         opt!(tuple!(
           alt!(tag!("e") | tag!("E")),
@@ -725,8 +725,8 @@ pub fn double(input: &[u8]) -> IResult<&[u8], f64> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          value!((), tuple!(digit, opt!(tuple!(tag!("."), opt!(digit)))))
-          | value!((), tuple!(tag!("."), digit))
+          value!((), pair!(digit, opt!(pair!(tag!("."), opt!(digit)))))
+          | value!((), pair!(tag!("."), digit))
         ),
         opt!(tuple!(
           alt!(tag!("e") | tag!("E")),
@@ -748,8 +748,8 @@ pub fn double_s(input: &str) -> IResult<&str, f64> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          value!((), tuple!(digit, opt!(tuple!(tag!("."), opt!(digit)))))
-          | value!((), tuple!(tag!("."), digit))
+          value!((), pair!(digit, opt!(pair!(tag!("."), opt!(digit)))))
+          | value!((), pair!(tag!("."), digit))
         ),
         opt!(tuple!(
           alt!(tag!("e") | tag!("E")),

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -1400,15 +1400,32 @@ mod tests {
   #[test]
   #[cfg(feature = "std")]
   fn float_test() {
-    assert_eq!(float(&b"+3.14"[..]),   Ok((&b""[..], 3.14)));
-    assert_eq!(float_s(&"3.14"[..]),   Ok((&""[..], 3.14)));
-    assert_eq!(double(&b"3.14"[..]),   Ok((&b""[..], 3.14)));
-    assert_eq!(double_s(&"3.14"[..]),   Ok((&""[..], 3.14)));
-
-    assert_eq!(float(&b"-1.234E-12"[..]),   Ok((&b""[..], -1.234E-12)));
-    assert_eq!(float_s(&"-1.234E-12"[..]),   Ok((&""[..], -1.234E-12)));
-    assert_eq!(double(&b"-1.234E-12"[..]),   Ok((&b""[..], -1.234E-12)));
-    assert_eq!(double_s(&"-1.234E-12"[..]),   Ok((&""[..], -1.234E-12)));
+    let cases = vec![
+      "3.1415",
+      "+3.1415",
+      "-3.1415",
+      "4141.5e-3",
+      "0.51415e1",
+      "0.51415e+1",
+      "6.1415e0",
+      "7.",
+      "+7.",
+      "-7.",
+      "8e5",
+      "8e+5",
+      "8e-5",
+      "9",
+      "+9",
+      "-9",
+    ];
+    for s in cases.into_iter() {
+      let d = str::parse::<f64>(s).unwrap();
+      assert_eq!(double(s.as_bytes()), Ok((&[][..], d)), "checking double({:?}) -> {}", s, d);
+      assert_eq!(double_s(s), Ok((&""[..], d)), "checking double_s({:?}) -> {}", s, d);
+      let f = str::parse::<f32>(s).unwrap();
+      assert_eq!(float(s.as_bytes()), Ok((&[][..], f)), "checking float({:?}) -> {}", s, f);
+      assert_eq!(float_s(s), Ok((&""[..], f)), "checking float_s({:?}) -> {}", s, f);
+    }
   }
 
   use types::CompleteStr;

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -679,7 +679,7 @@ pub fn float(input: &[u8]) -> IResult<&[u8], f32> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          delimited!(digit, tag!("."), opt!(digit))
+          delimited!(digit, tag!("."), opt!(complete!(digit)))
           | delimited!(opt!(digit), tag!("."), digit)
         ),
         opt!(complete!(tuple!(
@@ -703,7 +703,7 @@ pub fn float_s(input: &str) -> IResult<&str, f32> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          delimited!(digit, tag!("."), opt!(digit))
+          delimited!(digit, tag!("."), opt!(complete!(digit)))
           | delimited!(opt!(digit), tag!("."), digit)
         ),
         opt!(complete!(tuple!(
@@ -727,7 +727,7 @@ pub fn double(input: &[u8]) -> IResult<&[u8], f64> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          delimited!(digit, tag!("."), opt!(digit))
+          delimited!(digit, tag!("."), opt!(complete!(digit)))
           | delimited!(opt!(digit), tag!("."), digit)
         ),
         opt!(complete!(tuple!(
@@ -751,7 +751,7 @@ pub fn double_s(input: &str) -> IResult<&str, f64> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          delimited!(digit, tag!("."), opt!(digit))
+          delimited!(digit, tag!("."), opt!(complete!(digit)))
           | delimited!(opt!(digit), tag!("."), digit)
         ),
         opt!(complete!(tuple!(

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -679,7 +679,7 @@ pub fn float(input: &[u8]) -> IResult<&[u8], f32> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          value!((), tuple!(digit, opt!(tag!(".")), opt!(digit)))
+          value!((), tuple!(digit, opt!(tuple!(tag!("."), opt!(digit)))))
           | value!((), tuple!(tag!("."), digit))
         ),
         opt!(tuple!(
@@ -702,7 +702,7 @@ pub fn float_s(input: &str) -> IResult<&str, f32> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          value!((), tuple!(digit, opt!(tag!(".")), opt!(digit)))
+          value!((), tuple!(digit, opt!(tuple!(tag!("."), opt!(digit)))))
           | value!((), tuple!(tag!("."), digit))
         ),
         opt!(tuple!(
@@ -725,7 +725,7 @@ pub fn double(input: &[u8]) -> IResult<&[u8], f64> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          value!((), tuple!(digit, opt!(tag!(".")), opt!(digit)))
+          value!((), tuple!(digit, opt!(tuple!(tag!("."), opt!(digit)))))
           | value!((), tuple!(tag!("."), digit))
         ),
         opt!(tuple!(
@@ -748,7 +748,7 @@ pub fn double_s(input: &str) -> IResult<&str, f64> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          value!((), tuple!(digit, opt!(tag!(".")), opt!(digit)))
+          value!((), tuple!(digit, opt!(tuple!(tag!("."), opt!(digit)))))
           | value!((), tuple!(tag!("."), digit))
         ),
         opt!(tuple!(

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -686,8 +686,7 @@ pub fn float(input: &[u8]) -> IResult<&[u8], f32> {
           alt!(tag!("e") | tag!("E")),
           opt!(alt!(tag!("+") | tag!("-"))),
           digit
-          )
-        )
+        ))
       )
     ),
     parse_to!(f32)
@@ -710,8 +709,7 @@ pub fn float_s(input: &str) -> IResult<&str, f32> {
           alt!(tag!("e") | tag!("E")),
           opt!(alt!(tag!("+") | tag!("-"))),
           digit
-          )
-        )
+        ))
       )
     ),
     parse_to!(f32)
@@ -734,8 +732,7 @@ pub fn double(input: &[u8]) -> IResult<&[u8], f64> {
           alt!(tag!("e") | tag!("E")),
           opt!(alt!(tag!("+") | tag!("-"))),
           digit
-          )
-        )
+        ))
       )
     ),
     parse_to!(f64)
@@ -758,8 +755,7 @@ pub fn double_s(input: &str) -> IResult<&str, f64> {
           alt!(tag!("e") | tag!("E")),
           opt!(alt!(tag!("+") | tag!("-"))),
           digit
-          )
-        )
+        ))
       )
     ),
     parse_to!(f64)

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -679,15 +679,15 @@ pub fn float(input: &[u8]) -> IResult<&[u8], f32> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          value!((), tuple!(digit, opt!(complete!(tag!("."))), opt!(complete!(digit))))
+          value!((), tuple!(digit, opt!(tag!(".")), opt!(digit)))
           | value!((), tuple!(tag!("."), digit))
         ),
-        opt!(complete!(tuple!(
+        opt!(tuple!(
           alt!(tag!("e") | tag!("E")),
           opt!(alt!(tag!("+") | tag!("-"))),
           digit
           )
-        ))
+        )
       )
     ),
     parse_to!(f32)
@@ -703,15 +703,15 @@ pub fn float_s(input: &str) -> IResult<&str, f32> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          value!((), tuple!(digit, opt!(complete!(tag!("."))), opt!(complete!(digit))))
+          value!((), tuple!(digit, opt!(tag!(".")), opt!(digit)))
           | value!((), tuple!(tag!("."), digit))
         ),
-        opt!(complete!(tuple!(
+        opt!(tuple!(
           alt!(tag!("e") | tag!("E")),
           opt!(alt!(tag!("+") | tag!("-"))),
           digit
           )
-        ))
+        )
       )
     ),
     parse_to!(f32)
@@ -727,15 +727,15 @@ pub fn double(input: &[u8]) -> IResult<&[u8], f64> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          value!((), tuple!(digit, opt!(complete!(tag!("."))), opt!(complete!(digit))))
+          value!((), tuple!(digit, opt!(tag!(".")), opt!(digit)))
           | value!((), tuple!(tag!("."), digit))
         ),
-        opt!(complete!(tuple!(
+        opt!(tuple!(
           alt!(tag!("e") | tag!("E")),
           opt!(alt!(tag!("+") | tag!("-"))),
           digit
           )
-        ))
+        )
       )
     ),
     parse_to!(f64)
@@ -751,15 +751,15 @@ pub fn double_s(input: &str) -> IResult<&str, f64> {
       tuple!(
         opt!(alt!(tag!("+") | tag!("-"))),
         alt!(
-          value!((), tuple!(digit, opt!(complete!(tag!("."))), opt!(complete!(digit))))
+          value!((), tuple!(digit, opt!(tag!(".")), opt!(digit)))
           | value!((), tuple!(tag!("."), digit))
         ),
-        opt!(complete!(tuple!(
+        opt!(tuple!(
           alt!(tag!("e") | tag!("E")),
           opt!(alt!(tag!("+") | tag!("-"))),
           digit
           )
-        ))
+        )
       )
     ),
     parse_to!(f64)
@@ -1401,30 +1401,30 @@ mod tests {
   #[cfg(feature = "std")]
   fn float_test() {
     let cases = vec![
-      "3.1415",
-      "+3.1415",
-      "-3.1415",
-      "4141.5e-3",
-      "0.51415e1",
-      "0.51415e+1",
-      "6.1415e0",
-      "7.",
-      "+7.",
-      "-7.",
-      "8e5",
-      "8e+5",
-      "8e-5",
-      "9",
-      "+9",
-      "-9",
+      "3.1415 ",
+      "+3.1415 ",
+      "-3.1415 ",
+      "4141.5e-3 ",
+      "0.51415e1 ",
+      "0.51415e+1 ",
+      "6.1415e0 ",
+      "7. ",
+      "+7. ",
+      "-7. ",
+      "8e5 ",
+      "8e+5 ",
+      "8e-5 ",
+      "9 ",
+      "+9 ",
+      "-9 ",
     ];
     for s in cases.into_iter() {
-      let d = str::parse::<f64>(s).unwrap();
-      assert_eq!(double(s.as_bytes()), Ok((&[][..], d)), "checking double({:?}) -> {}", s, d);
-      assert_eq!(double_s(s), Ok((&""[..], d)), "checking double_s({:?}) -> {}", s, d);
-      let f = str::parse::<f32>(s).unwrap();
-      assert_eq!(float(s.as_bytes()), Ok((&[][..], f)), "checking float({:?}) -> {}", s, f);
-      assert_eq!(float_s(s), Ok((&""[..], f)), "checking float_s({:?}) -> {}", s, f);
+      let d = str::parse::<f64>(&s[..s.len() - 1]).unwrap();
+      assert_eq!(double(s.as_bytes()), Ok((&b" "[..], d)), "checking double({:?}) -> {}", s, d);
+      assert_eq!(double_s(s), Ok((&" "[..], d)), "checking double_s({:?}) -> {}", s, d);
+      let f = str::parse::<f32>(&s[..s.len() - 1]).unwrap();
+      assert_eq!(float(s.as_bytes()), Ok((&b" "[..], f)), "checking float({:?}) -> {}", s, f);
+      assert_eq!(float_s(s), Ok((&" "[..], f)), "checking float_s({:?}) -> {}", s, f);
     }
   }
 


### PR DESCRIPTION
Currently, the ```double``` parser will reject a floating point number presented as ```1243e5```.
Other examples of a rejected formats are ```1234.``` and ```.1234```, which are not a valid Rust floating-point literals [1], but they are widely used in text formats and are accepted by parser from the standard library.

I also drop ```complete!``` wrappers from the parsers. ```Nom``` claims to support streaming, but current parser with ```complete!``` may fail if exponent falls on the boundary of the input buffer. At the same time, it seems that, in most practical situations, we don't need to parse floats in the end of the output, so it should be fine to leave that case out of the scope. Overall, I don't have a strong opinion here, but I think that if ```complete!``` is to stay in any place, there should be a notice in the documentation.

[1] https://doc.rust-lang.org/reference/tokens.html#floating-point-literals

Fixes #437