### PR TITLE
fix incomplete usage of fold_many0

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -800,7 +800,7 @@ macro_rules! fold_many0(
   ($i:expr, $submac:ident!( $($args:tt)* ), $init:expr, $f:expr) => (
     {
       use ::std::result::Result::*;
-      use $crate::Err;
+      use $crate::{Err,AtEof};
 
       let ret;
       let f         = $f;
@@ -820,9 +820,11 @@ macro_rules! fold_many0(
           Ok((i, o)) => {
             // loop trip must always consume (otherwise infinite loops)
             if i == input {
-              ret = Err(Err::Error(
-                error_position!(input, $crate::ErrorKind::Many0)
-              ));
+              if i.at_eof() {
+                ret = Ok((input, res));
+              } else {
+                ret = Err(Err::Error(error_position!(input, $crate::ErrorKind::Many0)));
+              }
               break;
             }
 


### PR DESCRIPTION
I ran into the same issue described in https://github.com/Geal/nom/issues/667 but with `fold_many0`. 

Applying the fix made to `many0` in https://github.com/Geal/nom/commit/968ae9f9b781484337ff26bf4c7eff68293afc6f to `fold_many0` it worked for me.

Please let me know the best place to add tests (issue 667 test? or create a completestr test for fold_many0?) - I'm happy to add one to cover this