### PR TITLE
optimize compare_no_case for str

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -555,11 +555,9 @@ impl<'a, 'b> Compare<&'b str> for &'a str {
   //FIXME: this version is too simple and does not use the current locale
   #[inline(always)]
   fn compare_no_case(&self, t: &'b str) -> CompareResult {
-    let pos = self
-      .to_lowercase()
-      .chars()
-      .zip(t.to_lowercase().chars())
-      .position(|(a, b)| a != b);
+    let pos = self.chars().zip(t.chars()).position(|(a, b)| {
+      a.to_lowercase().zip(b.to_lowercase()).any(|(a, b)| a != b)
+    });
 
     match pos {
       Some(_) => CompareResult::Error,


### PR DESCRIPTION
This is a performance optimization for `compare_no_case` for `&str`. It avoids allocating `String`s entirely and instead applies `char::to_lowercase()` directly to each compared character. Sample benchmark results are below.

Before:
```
running 4 tests
test tests::long_match     ... bench:     103,406 ns/iter (+/- 2,506)
test tests::long_no_match  ... bench:      98,263 ns/iter (+/- 3,810)
test tests::short_match    ... bench:         541 ns/iter (+/- 12)
test tests::short_no_match ... bench:         517 ns/iter (+/- 3)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out
```
After:
```
running 4 tests
test tests::long_match     ... bench:      79,213 ns/iter (+/- 4,443)
test tests::long_no_match  ... bench:          73 ns/iter (+/- 2)
test tests::short_match    ... bench:         367 ns/iter (+/- 9)
test tests::short_no_match ... bench:          73 ns/iter (+/- 4)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out
```
The most significant improvement is for the case where a match fails close to the beginning of a long string, as there is no longer a need to copy the entire string. Here is the benchmark that was used:
```rust
#![feature(test)]

#[macro_use]
extern crate nom;
extern crate test;

#[cfg(test)]
mod tests {
  use test::Bencher;

  #[bench]
  fn short_match(b: &mut Bencher) {
    named!(parse(&str) -> &str, tag_no_case_s!("aéiou"));

    let s = "aÉiOu";

    b.iter(|| {
      parse(s).unwrap();
    });
  }

  #[bench]
  fn long_match(b: &mut Bencher) {
    named!(parse(&str) -> &str, tag_no_case_s!("oézécévétérérégéjéeéqéjébéaéhéeédédéoéyébérépéméréwéyéeéhépéféuérékéséoézégéqéiéaéwéféyékékéréiéwéjéaéuéaébéhévézégéjévéyéréyéwéiébéréyédéfébégéuéiétésézédéuébélépézéiéléoéiévéeégétéwéjéaéyéiéhéaégéeégézérépéxégéwétékébéhégépéeéaéeébéqéqéaéhéhéséhéhégéséuékédéiébéyéuéuéséméwéléjégépévébévéméiéléléténécébéxétéaézétéxéléjéféméféjézéxérénéréqénéwéiéféaécéwéxéoéwégéaéiésépéléréféyézéeéqémététéaéségégéhéréoévéséiéqéuéaérépéwéwécégébéoéyéxéfévénéxéiéeéhévézénévéiétéqémékéwéyétéwétéiéuéjégéséjénébéuévélégébéiéqéhézésérékéoéxébéiélébéméyétéhéeéxéjéiéléaéqérédéaéhéhéméhérédésésétéiéréjédéréeécétéyéhéréxékéiékéqégébéeégémégérétéiékénéyélévéséféségécévéaégépéyéjéséqéaéxéaéuéféxéwéoétéhéhéyépéqéségédéuéeéxéiécéjéméléuévégéréwéoéjéjétéeéoéwéyéyéjéoéeécépébécépéqéuégéoézéoéhéuénéuéjétéoégéuésétéaéfézéféjéwédékévéyéfététévéoéaéwéjéyéféiéeécéoététénéuépéiéqébésésékéaénéréiéoéyéwéféqéuéiéuéiéwéeéréréyéqéiéhéaéeéféképévégédégéoédérégétébéoépérécédévéléwéiéséyéyébéjéqénéuéuédémébéiécétéqédéaéqéhétévévéjé"));

    let s = "oÉzÉcÉVÉTÉRÉrÉGÉjÉeÉqÉjÉbÉaÉhÉEÉDÉDÉOÉYÉbÉRÉPÉMÉrÉwÉyÉeÉhÉPÉfÉUÉrÉkÉsÉoÉZÉGÉqÉiÉAÉwÉFÉYÉkÉkÉRÉIÉWÉjÉAÉuÉaÉBÉhÉVÉZÉgÉJÉVÉyÉRÉYÉWÉIÉBÉrÉYÉDÉFÉBÉgÉUÉiÉTÉsÉZÉDÉUÉBÉlÉPÉZÉIÉlÉOÉIÉVÉeÉGÉtÉwÉjÉaÉYÉIÉHÉAÉGÉEÉGÉzÉrÉpÉxÉGÉWÉTÉkÉbÉhÉgÉpÉeÉAÉEÉbÉQÉqÉAÉHÉhÉsÉHÉhÉgÉSÉUÉKÉdÉiÉBÉYÉUÉuÉsÉmÉWÉLÉjÉGÉpÉVÉbÉvÉmÉIÉLÉlÉTÉNÉcÉBÉxÉTÉAÉzÉtÉxÉLÉJÉfÉmÉfÉJÉzÉXÉRÉnÉrÉqÉNÉWÉIÉFÉAÉcÉWÉXÉoÉwÉgÉaÉIÉSÉPÉLÉrÉfÉyÉzÉeÉQÉmÉTÉtÉaÉSÉGÉgÉHÉRÉoÉVÉSÉiÉQÉUÉaÉrÉpÉWÉwÉCÉGÉBÉOÉYÉxÉFÉvÉNÉxÉiÉeÉHÉVÉZÉnÉvÉIÉTÉqÉmÉkÉWÉYÉtÉWÉTÉiÉuÉJÉGÉsÉJÉnÉBÉUÉVÉlÉGÉbÉiÉQÉhÉZÉSÉrÉKÉOÉxÉBÉiÉlÉBÉmÉYÉTÉHÉeÉXÉJÉiÉLÉaÉqÉrÉDÉaÉHÉhÉmÉHÉRÉDÉsÉsÉTÉIÉRÉjÉDÉRÉEÉcÉtÉyÉHÉRÉxÉkÉiÉKÉqÉGÉbÉEÉgÉMÉGÉRÉTÉIÉKÉnÉyÉLÉvÉsÉfÉsÉGÉcÉvÉAÉgÉPÉyÉjÉSÉQÉaÉxÉaÉuÉFÉxÉWÉoÉtÉHÉHÉyÉPÉqÉsÉGÉDÉuÉEÉxÉiÉCÉJÉMÉLÉuÉVÉgÉrÉWÉoÉJÉjÉTÉEÉOÉwÉyÉYÉJÉoÉEÉCÉpÉBÉCÉpÉqÉUÉGÉOÉZÉoÉHÉuÉnÉUÉjÉTÉoÉGÉUÉsÉtÉaÉfÉZÉFÉjÉWÉDÉkÉVÉyÉfÉTÉtÉVÉOÉAÉWÉJÉYÉFÉIÉEÉCÉoÉtÉTÉnÉuÉpÉiÉQÉBÉSÉSÉkÉAÉnÉRÉIÉoÉyÉWÉfÉqÉUÉiÉUÉIÉWÉEÉRÉRÉyÉqÉiÉHÉaÉEÉfÉkÉPÉVÉgÉDÉGÉOÉDÉRÉGÉtÉBÉoÉpÉRÉCÉdÉVÉLÉWÉiÉSÉYÉYÉBÉJÉqÉnÉUÉUÉDÉmÉbÉiÉCÉTÉqÉdÉaÉQÉhÉTÉVÉVÉjÉ";

    b.iter(|| {
      parse(s).unwrap();
    });
  }

  #[bench]
  fn short_no_match(b: &mut Bencher) {
    named!(parse(&str) -> &str, tag_no_case_s!("aéiou"));

    let s = "zÉiOu";

    b.iter(|| {
      parse(s).unwrap_err();
    });
  }

  #[bench]
  fn long_no_match(b: &mut Bencher) {
    named!(parse(&str) -> &str, tag_no_case_s!("oézécévétérérégéjéeéqéjébéaéhéeédédéoéyébérépéméréwéyéeéhépéféuérékéséoézégéqéiéaéwéféyékékéréiéwéjéaéuéaébéhévézégéjévéyéréyéwéiébéréyédéfébégéuéiétésézédéuébélépézéiéléoéiévéeégétéwéjéaéyéiéhéaégéeégézérépéxégéwétékébéhégépéeéaéeébéqéqéaéhéhéséhéhégéséuékédéiébéyéuéuéséméwéléjégépévébévéméiéléléténécébéxétéaézétéxéléjéféméféjézéxérénéréqénéwéiéféaécéwéxéoéwégéaéiésépéléréféyézéeéqémététéaéségégéhéréoévéséiéqéuéaérépéwéwécégébéoéyéxéfévénéxéiéeéhévézénévéiétéqémékéwéyétéwétéiéuéjégéséjénébéuévélégébéiéqéhézésérékéoéxébéiélébéméyétéhéeéxéjéiéléaéqérédéaéhéhéméhérédésésétéiéréjédéréeécétéyéhéréxékéiékéqégébéeégémégérétéiékénéyélévéséféségécévéaégépéyéjéséqéaéxéaéuéféxéwéoétéhéhéyépéqéségédéuéeéxéiécéjéméléuévégéréwéoéjéjétéeéoéwéyéyéjéoéeécépébécépéqéuégéoézéoéhéuénéuéjétéoégéuésétéaéfézéféjéwédékévéyéfététévéoéaéwéjéyéféiéeécéoététénéuépéiéqébésésékéaénéréiéoéyéwéféqéuéiéuéiéwéeéréréyéqéiéhéaéeéféképévégédégéoédérégétébéoépérécédévéléwéiéséyéyébéjéqénéuéuédémébéiécétéqédéaéqéhétévévéjé"));

    let s = "zÉzÉcÉVÉTÉRÉrÉGÉjÉeÉqÉjÉbÉaÉhÉEÉDÉDÉOÉYÉbÉRÉPÉMÉrÉwÉyÉeÉhÉPÉfÉUÉrÉkÉsÉoÉZÉGÉqÉiÉAÉwÉFÉYÉkÉkÉRÉIÉWÉjÉAÉuÉaÉBÉhÉVÉZÉgÉJÉVÉyÉRÉYÉWÉIÉBÉrÉYÉDÉFÉBÉgÉUÉiÉTÉsÉZÉDÉUÉBÉlÉPÉZÉIÉlÉOÉIÉVÉeÉGÉtÉwÉjÉaÉYÉIÉHÉAÉGÉEÉGÉzÉrÉpÉxÉGÉWÉTÉkÉbÉhÉgÉpÉeÉAÉEÉbÉQÉqÉAÉHÉhÉsÉHÉhÉgÉSÉUÉKÉdÉiÉBÉYÉUÉuÉsÉmÉWÉLÉjÉGÉpÉVÉbÉvÉmÉIÉLÉlÉTÉNÉcÉBÉxÉTÉAÉzÉtÉxÉLÉJÉfÉmÉfÉJÉzÉXÉRÉnÉrÉqÉNÉWÉIÉFÉAÉcÉWÉXÉoÉwÉgÉaÉIÉSÉPÉLÉrÉfÉyÉzÉeÉQÉmÉTÉtÉaÉSÉGÉgÉHÉRÉoÉVÉSÉiÉQÉUÉaÉrÉpÉWÉwÉCÉGÉBÉOÉYÉxÉFÉvÉNÉxÉiÉeÉHÉVÉZÉnÉvÉIÉTÉqÉmÉkÉWÉYÉtÉWÉTÉiÉuÉJÉGÉsÉJÉnÉBÉUÉVÉlÉGÉbÉiÉQÉhÉZÉSÉrÉKÉOÉxÉBÉiÉlÉBÉmÉYÉTÉHÉeÉXÉJÉiÉLÉaÉqÉrÉDÉaÉHÉhÉmÉHÉRÉDÉsÉsÉTÉIÉRÉjÉDÉRÉEÉcÉtÉyÉHÉRÉxÉkÉiÉKÉqÉGÉbÉEÉgÉMÉGÉRÉTÉIÉKÉnÉyÉLÉvÉsÉfÉsÉGÉcÉvÉAÉgÉPÉyÉjÉSÉQÉaÉxÉaÉuÉFÉxÉWÉoÉtÉHÉHÉyÉPÉqÉsÉGÉDÉuÉEÉxÉiÉCÉJÉMÉLÉuÉVÉgÉrÉWÉoÉJÉjÉTÉEÉOÉwÉyÉYÉJÉoÉEÉCÉpÉBÉCÉpÉqÉUÉGÉOÉZÉoÉHÉuÉnÉUÉjÉTÉoÉGÉUÉsÉtÉaÉfÉZÉFÉjÉWÉDÉkÉVÉyÉfÉTÉtÉVÉOÉAÉWÉJÉYÉFÉIÉEÉCÉoÉtÉTÉnÉuÉpÉiÉQÉBÉSÉSÉkÉAÉnÉRÉIÉoÉyÉWÉfÉqÉUÉiÉUÉIÉWÉEÉRÉRÉyÉqÉiÉHÉaÉEÉfÉkÉPÉVÉgÉDÉGÉOÉDÉRÉGÉtÉBÉoÉpÉRÉCÉdÉVÉLÉWÉiÉSÉYÉYÉBÉJÉqÉnÉUÉUÉDÉmÉbÉiÉCÉTÉqÉdÉaÉQÉhÉTÉVÉVÉjÉ";

    b.iter(|| {
      parse(s).unwrap_err();
    });
  }
}
```