### PR TITLE
CI: testing without std, but with alloc feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
         - cargo install cargo-travis   || echo "cargo-travis already installed"
         - cargo install cargo-benchcmp || echo "cargo-benchcmp already installed"
         - cargo install-update -a
+    - rust: nightly
+      env: FEATURES='--no-default-features --features "alloc"'
     - rust: stable
       env: FEATURES=''
     - rust: stable


### PR DESCRIPTION
Related to PR #677

Added a build in the `.travis.yml` so it would test with the `alloc` feature, but without `std`.
`alloc` feature is supported only on nightly channel.