### PR TITLE
mark *_s macros as deprecated

### DIFF
--- a/src/methods.rs
+++ b/src/methods.rs
@@ -280,6 +280,7 @@ macro_rules! apply_m (
 );
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
   // reproduce the tag_s and take_s macros, because of module import order
   macro_rules! tag_s (

--- a/src/str.rs
+++ b/src/str.rs
@@ -18,6 +18,7 @@
 /// # }
 /// ```
 #[macro_export]
+#[deprecated(since = "4.0.0", note = "Please use `tag` instead")]
 macro_rules! tag_s (
   ($i:expr, $tag: expr) => (
     {
@@ -47,6 +48,7 @@ macro_rules! tag_s (
 /// # fn main() {}
 /// ```
 #[macro_export]
+#[deprecated(since = "4.0.0", note = "Please use `tag_no_case` instead")]
 macro_rules! tag_no_case_s (
   ($i:expr, $tag: expr) => (
     {
@@ -74,6 +76,7 @@ macro_rules! tag_no_case_s (
 /// # }
 /// ```
 #[macro_export]
+#[deprecated(since = "4.0.0", note = "Please use `take` instead")]
 macro_rules! take_s (
   ($i:expr, $count:expr) => (
     {
@@ -97,6 +100,7 @@ macro_rules! take_s (
 ///  # }
 /// ```
 #[macro_export]
+#[deprecated(since = "4.0.0", note = "Please use `is_not` instead")]
 macro_rules! is_not_s (
   ($input:expr, $arr:expr) => (
     {
@@ -121,6 +125,7 @@ macro_rules! is_not_s (
 /// # }
 /// ```
 #[macro_export]
+#[deprecated(since = "4.0.0", note = "Please use `is_a` instead")]
 macro_rules! is_a_s (
   ($input:expr, $arr:expr) => (
     {
@@ -145,6 +150,7 @@ macro_rules! is_a_s (
 /// # }
 /// ```
 #[macro_export]
+#[deprecated(since = "4.0.0", note = "Please use `take_while` instead")]
 macro_rules! take_while_s (
   ($input:expr, $submac:ident!( $($args:tt)* )) => (
     {
@@ -172,6 +178,7 @@ macro_rules! take_while_s (
 /// # }
 /// ```
 #[macro_export]
+#[deprecated(since = "4.0.0", note = "Please use `take_while1` instead")]
 macro_rules! take_while1_s (
   ($input:expr, $submac:ident!( $($args:tt)* )) => (
     take_while1!($input, $submac!($($args)*))
@@ -186,6 +193,7 @@ macro_rules! take_while1_s (
 ///
 /// The argument is either a function `char -> bool` or a macro returning a `bool
 #[macro_export]
+#[deprecated(since = "4.0.0", note = "Please use `take_till` instead")]
 macro_rules! take_till_s (
   ($input:expr, $submac:ident!( $($args:tt)* )) => (
     {
@@ -202,6 +210,7 @@ macro_rules! take_till_s (
 ///
 /// The argument is either a function `char -> bool` or a macro returning a `bool
 #[macro_export]
+#[deprecated(since = "4.0.0", note = "Please use `take_till1` instead")]
 macro_rules! take_till1_s (
   ($input:expr, $submac:ident!( $($args:tt)* )) => (
     {
@@ -216,6 +225,7 @@ macro_rules! take_till1_s (
 /// `take_until_and_consume_s!(&str) => &str -> IResult<&str, &str>`
 /// generates a parser consuming all chars until the specified string is found and consumes it
 #[macro_export]
+#[deprecated(since = "4.0.0", note = "Please use `take_until_and_consume` instead")]
 macro_rules! take_until_and_consume_s (
   ($input:expr, $substr:expr) => (
     {
@@ -227,6 +237,7 @@ macro_rules! take_until_and_consume_s (
 /// `take_until_s!(&str) => &str -> IResult<&str, &str>`
 /// generates a parser consuming all chars until the specified string is found and leaves it in the remaining input
 #[macro_export]
+#[deprecated(since = "4.0.0", note = "Please use `take_until` instead")]
 macro_rules! take_until_s (
   ($input:expr, $substr:expr) => (
     {

--- a/src/util.rs
+++ b/src/util.rs
@@ -420,6 +420,7 @@ pub fn print_offsets<E>(input: &[u8], from: usize, offsets: &[(ErrorKind<E>, usi
 /// indicates which parser returned an error
 #[cfg_attr(rustfmt, rustfmt_skip)]
 #[derive(Debug,PartialEq,Eq,Hash,Clone)]
+#[allow(deprecated)]
 pub enum ErrorKind<E = u32> {
   Custom(E),
   Tag,
@@ -468,13 +469,19 @@ pub enum ErrorKind<E = u32> {
   Fix,
   Escaped,
   EscapedTransform,
+  #[deprecated(since = "4.0.0", note = "Please use `Tag` instead")]
   TagStr,
+  #[deprecated(since = "4.0.0", note = "Please use `IsNot` instead")]
   IsNotStr,
+  #[deprecated(since = "4.0.0", note = "Please use `IsA` instead")]
   IsAStr,
+  #[deprecated(since = "4.0.0", note = "Please use `TakeWhile1` instead")]
   TakeWhile1Str,
   NonEmpty,
   ManyMN,
+  #[deprecated(since = "4.0.0", note = "Please use `TakeUntilAndConsume` instead")]
   TakeUntilAndConsumeStr,
+  #[deprecated(since = "4.0.0", note = "Please use `TakeUntil` instead")]
   TakeUntilStr,
   Not,
   Permutation,

--- a/src/util.rs
+++ b/src/util.rs
@@ -492,6 +492,7 @@ pub enum ErrorKind<E = u32> {
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
+#[allow(deprecated)]
 pub fn error_to_u32<E>(e: &ErrorKind<E>) -> u32 {
   match *e {
     ErrorKind::Custom(_)                 => 0,
@@ -560,6 +561,7 @@ pub fn error_to_u32<E>(e: &ErrorKind<E>) -> u32 {
 
 impl<E> ErrorKind<E> {
   #[cfg_attr(rustfmt, rustfmt_skip)]
+  #[allow(deprecated)]
   pub fn description(&self) -> &str {
     match *self {
       ErrorKind::Custom(_)                 => "Custom error",
@@ -640,6 +642,7 @@ pub trait Convert<T> {
 
 impl<F, E: From<F>> Convert<ErrorKind<F>> for ErrorKind<E> {
   #[cfg_attr(rustfmt, rustfmt_skip)]
+  #[allow(deprecated)]
   fn convert(e: ErrorKind<F>) -> Self {
     match e {
       ErrorKind::Custom(c)                 => ErrorKind::Custom(E::from(c)),


### PR DESCRIPTION
Not much to see here.
Fixes #683 .