### PR TITLE
Clippy fixes

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1226,7 +1226,6 @@ mod tests {
   #[cfg(feature = "alloc")]
   #[test]
   fn escaping_complete_str() {
-    use nom::alpha0;
     named!(esc<CompleteStr, CompleteStr>, escaped!(call!(alpha), '\\', one_of!("\"n\\")));
     assert_eq!(
       esc(CompleteStr("abcd;")),

--- a/src/character.rs
+++ b/src/character.rs
@@ -107,10 +107,7 @@ macro_rules! char (
       use $crate::AsChar;
       use $crate::InputIter;
 
-      match ($i).iter_elements().next().map(|c| {
-        let b = c.as_char() == $c;
-        b
-      }) {
+      match ($i).iter_elements().next().map(|c| c.as_char() == $c) {
         None        => $crate::need_more($i, Needed::Size(1)),
         Some(false) => {
           let e: $crate::ErrorKind<u32> = $crate::ErrorKind::Char;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -96,8 +96,7 @@ impl<I, E> Err<I, E> {
   pub fn into_error_kind(self) -> ::util::ErrorKind<E> {
     match self {
       Err::Incomplete(_) => ::util::ErrorKind::Complete,
-      Err::Failure(c) => c.into_error_kind(),
-      Err::Error(c) => c.into_error_kind(),
+      Err::Failure(c) | Err::Error(c) => c.into_error_kind(),
     }
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,6 +343,7 @@
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 #![cfg_attr(all(not(feature = "std"), feature = "alloc"), feature(alloc))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(core_float))]
 //#![warn(missing_docs)]
 #![cfg_attr(feature = "cargo-clippy", allow(doc_markdown))]
 #![cfg_attr(nightly, feature(test))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,7 +345,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(core_float))]
 //#![warn(missing_docs)]
-#![cfg_attr(feature = "cargo-clippy", allow(doc_markdown))]
+#![cfg_attr(feature = "cargo-clippy", allow(doc_markdown, inline_always, type_complexity))]
 #![cfg_attr(nightly, feature(test))]
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -613,37 +613,25 @@ macro_rules! i64 ( ($i:expr, $e:expr) => ( {if Endianness::Big == $e { be_i64($i
 /// Recognizes big endian 4 bytes floating point number
 #[inline]
 pub fn be_f32(input: &[u8]) -> IResult<&[u8], f32> {
-  match be_u32(input) {
-    Err(e) => Err(e),
-    Ok((i, o)) => Ok((i, f32::from_bits(o))),
-  }
+  be_u32(input).map(|(i, o)| (i, f32::from_bits(o)))
 }
 
 /// Recognizes big endian 8 bytes floating point number
 #[inline]
 pub fn be_f64(input: &[u8]) -> IResult<&[u8], f64> {
-  match be_u64(input) {
-    Err(e) => Err(e),
-    Ok((i, o)) => Ok((i, f64::from_bits(o))),
-  }
+  be_u64(input).map(|(i, o)| (i, f64::from_bits(o)))
 }
 
 /// Recognizes little endian 4 bytes floating point number
 #[inline]
 pub fn le_f32(input: &[u8]) -> IResult<&[u8], f32> {
-  match le_u32(input) {
-    Err(e) => Err(e),
-    Ok((i, o)) => Ok((i, f32::from_bits(o))),
-  }
+  le_u32(input).map(|(i, o)| (i, f32::from_bits(o)))
 }
 
 /// Recognizes little endian 8 bytes floating point number
 #[inline]
 pub fn le_f64(input: &[u8]) -> IResult<&[u8], f64> {
-  match le_u64(input) {
-    Err(e) => Err(e),
-    Ok((i, o)) => Ok((i, f64::from_bits(o))),
-  }
+  le_u64(input).map(|(i, o)| (i, f64::from_bits(o)))
 }
 
 /// Recognizes a hex-encoded integer

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -410,7 +410,7 @@ pub fn be_u16(i: &[u8]) -> IResult<&[u8], u16> {
   if i.len() < 2 {
     need_more(i, Needed::Size(2))
   } else {
-    let res = ((i[0] as u16) << 8) + i[1] as u16;
+    let res = (u16::from(i[0]) << 8) + u16::from(i[1]);
     Ok((&i[2..], res))
   }
 }
@@ -421,7 +421,7 @@ pub fn be_u24(i: &[u8]) -> IResult<&[u8], u32> {
   if i.len() < 3 {
     need_more(i, Needed::Size(3))
   } else {
-    let res = ((i[0] as u32) << 16) + ((i[1] as u32) << 8) + (i[2] as u32);
+    let res = (u32::from(i[0]) << 16) + (u32::from(i[1]) << 8) + u32::from(i[2]);
     Ok((&i[3..], res))
   }
 }
@@ -432,7 +432,7 @@ pub fn be_u32(i: &[u8]) -> IResult<&[u8], u32> {
   if i.len() < 4 {
     need_more(i, Needed::Size(4))
   } else {
-    let res = ((i[0] as u32) << 24) + ((i[1] as u32) << 16) + ((i[2] as u32) << 8) + i[3] as u32;
+    let res = (u32::from(i[0]) << 24) + (u32::from(i[1]) << 16) + (u32::from(i[2]) << 8) + u32::from(i[3]);
     Ok((&i[4..], res))
   }
 }
@@ -443,8 +443,8 @@ pub fn be_u64(i: &[u8]) -> IResult<&[u8], u64, u32> {
   if i.len() < 8 {
     need_more(i, Needed::Size(8))
   } else {
-    let res = ((i[0] as u64) << 56) + ((i[1] as u64) << 48) + ((i[2] as u64) << 40) + ((i[3] as u64) << 32) + ((i[4] as u64) << 24)
-      + ((i[5] as u64) << 16) + ((i[6] as u64) << 8) + i[7] as u64;
+    let res = (u64::from(i[0]) << 56) + (u64::from(i[1]) << 48) + (u64::from(i[2]) << 40) + (u64::from(i[3]) << 32)
+      + (u64::from(i[4]) << 24) + (u64::from(i[5]) << 16) + (u64::from(i[6]) << 8) + u64::from(i[7]);
     Ok((&i[8..], res))
   }
 }
@@ -500,7 +500,7 @@ pub fn le_u16(i: &[u8]) -> IResult<&[u8], u16> {
   if i.len() < 2 {
     need_more(i, Needed::Size(2))
   } else {
-    let res = ((i[1] as u16) << 8) + i[0] as u16;
+    let res = (u16::from(i[1]) << 8) + u16::from(i[0]);
     Ok((&i[2..], res))
   }
 }
@@ -511,7 +511,7 @@ pub fn le_u24(i: &[u8]) -> IResult<&[u8], u32> {
   if i.len() < 3 {
     need_more(i, Needed::Size(3))
   } else {
-    let res = (i[0] as u32) + ((i[1] as u32) << 8) + ((i[2] as u32) << 16);
+    let res = u32::from(i[0]) + (u32::from(i[1]) << 8) + (u32::from(i[2]) << 16);
     Ok((&i[3..], res))
   }
 }
@@ -522,7 +522,7 @@ pub fn le_u32(i: &[u8]) -> IResult<&[u8], u32> {
   if i.len() < 4 {
     need_more(i, Needed::Size(4))
   } else {
-    let res = ((i[3] as u32) << 24) + ((i[2] as u32) << 16) + ((i[1] as u32) << 8) + i[0] as u32;
+    let res = (u32::from(i[3]) << 24) + (u32::from(i[2]) << 16) + (u32::from(i[1]) << 8) + u32::from(i[0]);
     Ok((&i[4..], res))
   }
 }
@@ -533,8 +533,8 @@ pub fn le_u64(i: &[u8]) -> IResult<&[u8], u64> {
   if i.len() < 8 {
     need_more(i, Needed::Size(8))
   } else {
-    let res = ((i[7] as u64) << 56) + ((i[6] as u64) << 48) + ((i[5] as u64) << 40) + ((i[4] as u64) << 32) + ((i[3] as u64) << 24)
-      + ((i[2] as u64) << 16) + ((i[1] as u64) << 8) + i[0] as u64;
+    let res = (u64::from(i[7]) << 56) + (u64::from(i[6]) << 48) + (u64::from(i[5]) << 40) + (u64::from(i[4]) << 32)
+      + (u64::from(i[3]) << 24) + (u64::from(i[2]) << 16) + (u64::from(i[1]) << 8) + u64::from(i[0]);
     Ok((&i[8..], res))
   }
 }

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -670,7 +670,7 @@ where
   T: InputLength + AtEof,
 {
   if input.input_len() == 0 {
-    return need_more_err(input, Needed::Unknown, ErrorKind::NonEmpty::<u32>);
+    need_more_err(input, Needed::Unknown, ErrorKind::NonEmpty::<u32>)
   } else {
     Ok((input.slice(input.input_len()..), input))
   }

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -694,6 +694,7 @@ pub fn rest_s(input: &str) -> IResult<&str, &str> {
 
 #[allow(unused_imports)]
 #[cfg_attr(rustfmt, rustfmt_skip)]
+#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 pub fn recognize_float<T>(input: T) -> IResult<T, T, u32>
 where
   T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -17,7 +17,10 @@ use traits::{need_more, need_more_err, AtEof};
 use std::ops::{Range, RangeFrom, RangeTo};
 use traits::{Compare, CompareResult, Offset, Slice};
 use util::ErrorKind;
-use std::mem::transmute;
+
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)] // warning is false positive
+use core::num::Float;
 
 #[cfg(feature = "alloc")]
 #[inline]
@@ -612,7 +615,7 @@ macro_rules! i64 ( ($i:expr, $e:expr) => ( {if Endianness::Big == $e { be_i64($i
 pub fn be_f32(input: &[u8]) -> IResult<&[u8], f32> {
   match be_u32(input) {
     Err(e) => Err(e),
-    Ok((i, o)) => unsafe { Ok((i, transmute::<u32, f32>(o))) },
+    Ok((i, o)) => Ok((i, f32::from_bits(o))),
   }
 }
 
@@ -621,7 +624,7 @@ pub fn be_f32(input: &[u8]) -> IResult<&[u8], f32> {
 pub fn be_f64(input: &[u8]) -> IResult<&[u8], f64> {
   match be_u64(input) {
     Err(e) => Err(e),
-    Ok((i, o)) => unsafe { Ok((i, transmute::<u64, f64>(o))) },
+    Ok((i, o)) => Ok((i, f64::from_bits(o))),
   }
 }
 
@@ -630,7 +633,7 @@ pub fn be_f64(input: &[u8]) -> IResult<&[u8], f64> {
 pub fn le_f32(input: &[u8]) -> IResult<&[u8], f32> {
   match le_u32(input) {
     Err(e) => Err(e),
-    Ok((i, o)) => unsafe { Ok((i, transmute::<u32, f32>(o))) },
+    Ok((i, o)) => Ok((i, f32::from_bits(o))),
   }
 }
 
@@ -639,7 +642,7 @@ pub fn le_f32(input: &[u8]) -> IResult<&[u8], f32> {
 pub fn le_f64(input: &[u8]) -> IResult<&[u8], f64> {
   match le_u64(input) {
     Err(e) => Err(e),
-    Ok((i, o)) => unsafe { Ok((i, transmute::<u64, f64>(o))) },
+    Ok((i, o)) => Ok((i, f64::from_bits(o))),
   }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -24,7 +24,6 @@ use util::ErrorKind;
 pub trait InputLength {
   /// calculates the input length, as indicated by its name,
   /// and the name of the trait itself
-  #[inline]
   fn input_len(&self) -> usize;
 }
 
@@ -156,31 +155,24 @@ as_bytes_array_impls! {
 /// transforms common types to a char for basic token parsing
 pub trait AsChar {
   /// makes a char from self
-  #[inline]
   fn as_char(self) -> char;
 
   /// tests that self is an alphabetic character
   ///
   /// warning: for `&str` it recognizes alphabetic
   /// characters outside of the 52 ASCII letters
-  #[inline]
   fn is_alpha(self) -> bool;
 
   /// tests that self is an alphabetic character
   /// or a decimal digit
-  #[inline]
   fn is_alphanum(self) -> bool;
   /// tests that self is a decimal digit
-  #[inline]
   fn is_dec_digit(self) -> bool;
   /// tests that self is an hex digit
-  #[inline]
   fn is_hex_digit(self) -> bool;
   /// tests that self is an octal digit
-  #[inline]
   fn is_oct_digit(self) -> bool;
   /// gets the len in bytes for self
-  #[inline]
   fn len(self) -> usize;
 }
 
@@ -900,7 +892,6 @@ impl<'a, R: FromStr> ParseTo<R> for &'a str {
 /// `Index`, but can actually return
 /// something else than a `&[T]` or `&str`
 pub trait Slice<R> {
-  #[inline(always)]
   fn slice(&self, range: R) -> Self;
 }
 
@@ -1050,10 +1041,8 @@ pub trait ExtendInto {
   type Extender: Extend<Self::Item>;
 
   /// create a new `Extend` of the correct type
-  #[inline]
   fn new_builder(&self) -> Self::Extender;
   /// accumulate the input into an accumulator
-  #[inline]
   fn extend_into(&self, acc: &mut Self::Extender);
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -153,6 +153,7 @@ as_bytes_array_impls! {
 }
 
 /// transforms common types to a char for basic token parsing
+#[cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty))]
 pub trait AsChar {
   /// makes a char from self
   fn as_char(self) -> char;

--- a/src/whitespace.rs
+++ b/src/whitespace.rs
@@ -831,6 +831,7 @@ macro_rules! sep (
 use internal::IResult;
 use traits::{AsChar, FindToken, InputTakeAtPosition};
 #[allow(unused_imports)]
+#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 pub fn sp<'a, T>(input: T) -> IResult<T, T>
 where
   T: InputTakeAtPosition,

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -16,7 +16,7 @@ named!(category<CompleteByteSlice, &str>, map_res!(
     complete_byte_slice_to_str
 ));
 
-fn complete_byte_slice_to_str<'a>(s: CompleteByteSlice<'a>) -> Result<&'a str, str::Utf8Error> {
+fn complete_byte_slice_to_str(s: CompleteByteSlice) -> Result<&str, str::Utf8Error> {
   str::from_utf8(s.0)
 }
 


### PR DESCRIPTION
This fixes most of clippy's warnings.

The most debatable change is globally allowing `inline_always` and `type_complexity`.
Feel free to not include them.

There is also a small simplification of the float parsers.