### PR TITLE
impl Deref for CompleteStr, CompleteByteSlice

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,7 @@
 use traits::{AsBytes, AtEof, Compare, CompareResult, FindSubstring, FindToken, InputIter, InputLength, InputTake, Offset, ParseTo, Slice};
 
 use std::str::{self, CharIndices, Chars, FromStr};
-use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
+use std::ops::{Deref, Range, RangeFrom, RangeFull, RangeTo};
 use std::iter::{Enumerate, Map};
 use std::slice::Iter;
 
@@ -14,6 +14,14 @@ use std::slice::Iter;
 /// and `Incomplete` results.
 #[derive(Clone, Copy, Debug, PartialEq, Hash)]
 pub struct CompleteStr<'a>(pub &'a str);
+
+impl<'a> Deref for CompleteStr<'a> {
+  type Target = str;
+
+  fn deref(&self) -> &str {
+    self.0
+  }
+}
 
 impl<'a> AtEof for CompleteStr<'a> {
   fn at_eof(&self) -> bool {
@@ -142,6 +150,14 @@ impl<'a> AsBytes for CompleteStr<'a> {
 /// and `Incomplete` results.
 #[derive(Clone, Copy, Debug, PartialEq, Hash)]
 pub struct CompleteByteSlice<'a>(pub &'a [u8]);
+
+impl<'a> Deref for CompleteByteSlice<'a> {
+  type Target = [u8];
+
+  fn deref(&self) -> &[u8] {
+    self.0
+  }
+}
 
 impl<'a> AtEof for CompleteByteSlice<'a> {
   fn at_eof(&self) -> bool {


### PR DESCRIPTION
With the impending increased use of `CompleteStr` and `CompleteByteSlice` in 4.0, this should give users (myself included) an easier time with low overhead.

Instead of:

```rust
named!(var<CompleteStr, Item>,
        do_parse!(
            name: ws!( alpha ) >>
            (Item::Var(name.0.to_string()))
        ));
```

We can avoid explicitly getting `name.0` thanks to Deref:

```rust
named!(var<CompleteStr, Item>,
        do_parse!(
            name: ws!( alpha ) >>
            (Item::Var(name.to_string()))
        ));
```