### PR TITLE
Fix nostd

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -45,7 +45,7 @@ macro_rules! bits (
 macro_rules! bits_impl (
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Context,Err,Needed};
 
       let input = ($i, 0usize);
@@ -90,7 +90,7 @@ macro_rules! bits_impl (
 macro_rules! bits_impl (
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,Needed,Context};
 
       let input = ($i, 0usize);
@@ -157,7 +157,7 @@ macro_rules! bytes (
 macro_rules! bytes_impl (
   ($macro_i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,Needed};
 
       let inp;
@@ -217,7 +217,7 @@ macro_rules! bytes_impl (
 macro_rules! bytes_impl (
   ($macro_i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,Needed};
 
       let inp;
@@ -271,11 +271,11 @@ macro_rules! bytes_impl (
 macro_rules! take_bits (
   ($i:expr, $t:ty, $count:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Needed,IResult};
 
-      use std::ops::Div;
-      use std::convert::Into;
+      use $crate::lib::std::ops::Div;
+      use $crate::lib::std::convert::Into;
       //println!("taking {} bits from {:?}", $count, $i);
       let (input, bit_offset) = $i;
       let res : IResult<(&[u8],usize), $t> = if $count == 0 {
@@ -341,7 +341,7 @@ macro_rules! take_bits (
 macro_rules! tag_bits (
   ($i:expr, $t:ty, $count:expr, $p: pat) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,IResult};
 
       match take_bits!($i, $t, $count) {
@@ -366,7 +366,7 @@ macro_rules! tag_bits (
 
 #[cfg(test)]
 mod tests {
-  use std::ops::{AddAssign, Shl, Shr};
+  use lib::std::ops::{AddAssign, Shl, Shr};
   use internal::{Err, Needed};
   use util::ErrorKind;
 

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -186,7 +186,7 @@ macro_rules! alt (
 
   (__impl $i:expr, $subrule:ident!( $($args:tt)*) | $($rest:tt)*) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::Err;
 
       let i_ = $i.clone();
@@ -212,7 +212,7 @@ macro_rules! alt (
 
   (__impl $i:expr, $subrule:ident!( $($args:tt)* ) => { $gen:expr } | $($rest:tt)*) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::Err;
 
       let i_ = $i.clone();
@@ -286,7 +286,7 @@ macro_rules! alt_complete (
 
   ($i:expr, $subrule:ident!( $($args:tt)*) | $($rest:tt)*) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::Err;
 
       let i_ = $i.clone();
@@ -312,7 +312,7 @@ macro_rules! alt_complete (
 
   ($i:expr, $subrule:ident!( $($args:tt)* ) => { $gen:expr } | $($rest:tt)+) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::Err;
 
       let i_ = $i.clone();
@@ -436,8 +436,8 @@ macro_rules! alt_complete (
 macro_rules! switch (
   (__impl $i:expr, $submac:ident!( $($args:tt)* ), $( $($p:pat)|+ => $subrule:ident!( $($args2:tt)* ))|* ) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Err,Convert,ErrorKind};
 
       let i_ = $i.clone();
@@ -560,8 +560,8 @@ macro_rules! switch (
 macro_rules! permutation (
   ($i:expr, $($rest:tt)*) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Err,Convert,ErrorKind};
 
       let mut res    = permutation_init!((), $($rest)*);
@@ -602,45 +602,45 @@ macro_rules! permutation (
 #[macro_export]
 macro_rules! permutation_init (
   ((), $e:ident?, $($rest:tt)*) => (
-    permutation_init!((::std::option::Option::None), $($rest)*)
+    permutation_init!(($crate::lib::std::option::Option::None), $($rest)*)
   );
   ((), $e:ident, $($rest:tt)*) => (
-    permutation_init!((::std::option::Option::None), $($rest)*)
+    permutation_init!(($crate::lib::std::option::Option::None), $($rest)*)
   );
 
   ((), $submac:ident!( $($args:tt)* )?, $($rest:tt)*) => (
-    permutation_init!((::std::option::Option::None), $($rest)*)
+    permutation_init!(($crate::lib::std::option::Option::None), $($rest)*)
   );
   ((), $submac:ident!( $($args:tt)* ), $($rest:tt)*) => (
-    permutation_init!((::std::option::Option::None), $($rest)*)
+    permutation_init!(($crate::lib::std::option::Option::None), $($rest)*)
   );
 
   (($($parsed:expr),*), $e:ident?, $($rest:tt)*) => (
-    permutation_init!(($($parsed),* , ::std::option::Option::None), $($rest)*);
+    permutation_init!(($($parsed),* , $crate::lib::std::option::Option::None), $($rest)*);
   );
   (($($parsed:expr),*), $e:ident, $($rest:tt)*) => (
-    permutation_init!(($($parsed),* , ::std::option::Option::None), $($rest)*);
+    permutation_init!(($($parsed),* , $crate::lib::std::option::Option::None), $($rest)*);
   );
 
   (($($parsed:expr),*), $submac:ident!( $($args:tt)* )?, $($rest:tt)*) => (
-    permutation_init!(($($parsed),* , ::std::option::Option::None), $($rest)*);
+    permutation_init!(($($parsed),* , $crate::lib::std::option::Option::None), $($rest)*);
   );
   (($($parsed:expr),*), $submac:ident!( $($args:tt)* ), $($rest:tt)*) => (
-    permutation_init!(($($parsed),* , ::std::option::Option::None), $($rest)*);
+    permutation_init!(($($parsed),* , $crate::lib::std::option::Option::None), $($rest)*);
   );
 
   (($($parsed:expr),*), $e:ident) => (
-    ($($parsed),* , ::std::option::Option::None)
+    ($($parsed),* , $crate::lib::std::option::Option::None)
   );
   (($($parsed:expr),*), $e:ident?) => (
-    ($($parsed),* , ::std::option::Option::None)
+    ($($parsed),* , $crate::lib::std::option::Option::None)
   );
 
   (($($parsed:expr),*), $submac:ident!( $($args:tt)* )?) => (
-    ($($parsed),* , ::std::option::Option::None)
+    ($($parsed),* , $crate::lib::std::option::Option::None)
   );
   (($($parsed:expr),*), $submac:ident!( $($args:tt)* )) => (
-    ($($parsed),* , ::std::option::Option::None)
+    ($($parsed),* , $crate::lib::std::option::Option::None)
   );
   (($($parsed:expr),*),) => (
     ($($parsed),*)
@@ -712,7 +712,7 @@ macro_rules! permutation_unwrap (
     if res.is_some() {
       succ!($it, permutation_unwrap!((res.unwrap()), $res, $($rest)*))
     } else {
-      ::std::option::Option::None
+      $crate::lib::std::option::Option::None
     }
   });
 
@@ -724,7 +724,7 @@ macro_rules! permutation_unwrap (
     if res.is_some() {
       succ!($it, permutation_unwrap!((res.unwrap()), $res, $($rest)*))
     } else {
-      ::std::option::Option::None
+      $crate::lib::std::option::Option::None
     }
   });
 
@@ -736,7 +736,7 @@ macro_rules! permutation_unwrap (
     if res.is_some() {
       succ!($it, permutation_unwrap!(($($parsed),* , res.unwrap()), $res, $($rest)*))
     } else {
-      ::std::option::Option::None
+      $crate::lib::std::option::Option::None
     }
   });
 
@@ -748,31 +748,31 @@ macro_rules! permutation_unwrap (
     if res.is_some() {
       succ!($it, permutation_unwrap!(($($parsed),* , res.unwrap()), $res, $($rest)*))
     } else {
-      ::std::option::Option::None
+      $crate::lib::std::option::Option::None
     }
   });
 
   ($it:tt, ($($parsed:expr),*), $res:ident?, $e:ident) => (
-    ::std::option::Option::Some(($($parsed),* , { acc!($it, $res) }))
+    $crate::lib::std::option::Option::Some(($($parsed),* , { acc!($it, $res) }))
   );
   ($it:tt, ($($parsed:expr),*), $res:ident, $e:ident) => ({
     let res = acc!($it, $res);
     if res.is_some() {
-      ::std::option::Option::Some(($($parsed),* , res.unwrap() ))
+      $crate::lib::std::option::Option::Some(($($parsed),* , res.unwrap() ))
     } else {
-      ::std::option::Option::None
+      $crate::lib::std::option::Option::None
     }
   });
 
   ($it:tt, ($($parsed:expr),*), $res:ident, $submac:ident!( $($args:tt)* )?) => (
-    ::std::option::Option::Some(($($parsed),* , { acc!($it, $res) }))
+    $crate::lib::std::option::Option::Some(($($parsed),* , { acc!($it, $res) }))
   );
   ($it:tt, ($($parsed:expr),*), $res:ident, $submac:ident!( $($args:tt)* )) => ({
     let res = acc!($it, $res);
     if res.is_some() {
-      ::std::option::Option::Some(($($parsed),* , res.unwrap() ))
+      $crate::lib::std::option::Option::Some(($($parsed),* , res.unwrap() ))
     } else {
-      ::std::option::Option::None
+      $crate::lib::std::option::Option::None
     }
   });
 );
@@ -791,22 +791,22 @@ macro_rules! permutation_iterator (
     permutation_iterator!($it, $i, $all_done, $needed, $res, $submac!($($args)*) , $($rest)*);
   };
   ($it:tt, $i:expr, $all_done:expr, $needed:expr, $res:expr, $submac:ident!( $($args:tt)* ), $($rest:tt)*) => ({
-    use ::std::result::Result::*;
-    use ::std::option::Option::*;
+    use $crate::lib::std::result::Result::*;
+    use $crate::lib::std::option::Option::*;
     use $crate::Err;
 
     if acc!($it, $res) == None {
       match $submac!($i, $($args)*) {
         Ok((i,o))     => {
           $i = i;
-          acc!($it, $res) = ::std::option::Option::Some(o);
+          acc!($it, $res) = $crate::lib::std::option::Option::Some(o);
           continue;
         },
         Err(Err::Error(_)) => {
           $all_done = false;
         },
         Err(e) => {
-          $needed = ::std::option::Option::Some(e);
+          $needed = $crate::lib::std::option::Option::Some(e);
           break;
         }
       };
@@ -825,8 +825,8 @@ macro_rules! permutation_iterator (
     permutation_iterator!($it, $i, $all_done, $needed, $res, $submac!($($args)*));
   };
   ($it:tt, $i:expr, $all_done:expr, $needed:expr, $res:expr, $submac:ident!( $($args:tt)* )) => ({
-    use ::std::result::Result::*;
-    use ::std::option::Option::*;
+    use $crate::lib::std::result::Result::*;
+    use $crate::lib::std::option::Option::*;
     use $crate::Err;
 
     if acc!($it, $res) == None {
@@ -851,7 +851,7 @@ macro_rules! permutation_iterator (
 #[cfg(test)]
 mod tests {
   #[cfg(feature = "alloc")]
-  use std::string::{String, ToString};
+  use lib::std::string::{String, ToString};
   use internal::{Err, IResult, Needed};
   use util::ErrorKind;
 
@@ -876,7 +876,7 @@ mod tests {
     ($i:expr, $bytes: expr) => (
       {
         use $crate::need_more;
-        use std::cmp::min;
+        use $crate::lib::std::cmp::min;
 
         let len = $i.len();
         let blen = $bytes.len();

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -20,7 +20,7 @@
 macro_rules! tag (
   ($i:expr, $tag: expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,Needed,IResult,ErrorKind};
       use $crate::{Compare,CompareResult,InputLength,need_more,InputTake};
 
@@ -61,7 +61,7 @@ macro_rules! tag (
 macro_rules! tag_no_case (
   ($i:expr, $tag: expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,Needed,IResult,ErrorKind};
       use $crate::{Compare,CompareResult,InputLength,InputTake};
 
@@ -161,7 +161,7 @@ macro_rules! escaped (
   // Internal parser, do not use directly
   (__impl $i: expr, $normal:ident!(  $($args:tt)* ), $control_char: expr, $escapable:ident!(  $($args2:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,Needed,IResult,ErrorKind,need_more};
       use $crate::AsChar;
       use $crate::InputIter;
@@ -269,7 +269,7 @@ macro_rules! escaped (
 /// ```ignore
 /// # #[macro_use] extern crate nom;
 /// # use nom::alpha;
-/// # use std::str::from_utf8;
+/// # use $crate::lib::std::str::from_utf8;
 /// # fn main() {
 /// fn to_s(i:Vec<u8>) -> String {
 ///   String::from_utf8_lossy(&i).into_owned()
@@ -294,7 +294,7 @@ macro_rules! escaped_transform (
   // Internal parser, do not use directly
   (__impl $i: expr, $normal:ident!(  $($args:tt)* ), $control_char: expr, $transform:ident!(  $($args2:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind};
       use $crate::AsChar;
       use $crate::ExtendInto;
@@ -486,8 +486,8 @@ macro_rules! take_while1 (
 macro_rules! take_while_m_n (
   ($input:expr, $m:expr, $n:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::IResult;
       use $crate::ErrorKind;
 
@@ -625,8 +625,8 @@ macro_rules! take_till1 (
 macro_rules! take (
   ($i:expr, $count:expr) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Needed,IResult};
 
       use $crate::InputIter;
@@ -664,7 +664,7 @@ macro_rules! take_str (
     {
       let input: &[u8] = $i;
 
-      map_res!(input, take!($size), ::std::str::from_utf8)
+      map_res!(input, take!($size), $crate::lib::std::str::from_utf8)
     }
   );
 );
@@ -688,8 +688,8 @@ macro_rules! take_str (
 macro_rules! take_until_and_consume (
   ($i:expr, $substr:expr) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Needed,IResult,ErrorKind,need_more_err};
       use $crate::InputLength;
       use $crate::FindSubstring;
@@ -729,8 +729,8 @@ macro_rules! take_until_and_consume (
 macro_rules! take_until_and_consume1 (
   ($i:expr, $substr:expr) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Err,Needed,IResult,ErrorKind,need_more_err};
 
       use $crate::InputLength;
@@ -774,8 +774,8 @@ macro_rules! take_until_and_consume1 (
 macro_rules! take_until (
   ($i:expr, $substr:expr) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Needed,IResult,need_more_err, ErrorKind};
 
       use $crate::InputLength;
@@ -817,8 +817,8 @@ macro_rules! take_until (
 macro_rules! take_until1 (
   ($i:expr, $substr:expr) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Err,Needed,IResult,need_more_err,ErrorKind};
       use $crate::InputLength;
       use $crate::FindSubstring;
@@ -862,8 +862,8 @@ macro_rules! take_until1 (
 macro_rules! take_until_either_and_consume (
   ($input:expr, $arr:expr) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Needed,IResult,need_more_err,ErrorKind};
 
       use $crate::InputLength;
@@ -921,8 +921,8 @@ macro_rules! take_until_either_and_consume (
 macro_rules! take_until_either_and_consume1 (
   ($input:expr, $arr:expr) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Err,Needed,IResult,need_more_err,ErrorKind};
 
       use $crate::InputLength;
@@ -982,8 +982,8 @@ macro_rules! take_until_either_and_consume1 (
 macro_rules! take_until_either (
   ($input:expr, $arr:expr) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Needed,IResult,need_more_err,ErrorKind};
 
       use $crate::InputIter;
@@ -1025,8 +1025,8 @@ macro_rules! take_until_either (
 macro_rules! take_until_either1 (
   ($input:expr, $arr:expr) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Err,Needed,IResult,need_more_err,ErrorKind};
 
       use $crate::InputIter;
@@ -1107,8 +1107,8 @@ mod tests {
   macro_rules! char (
     ($i:expr, $c: expr) => (
       {
-        use ::std::result::Result::*;
-        use ::std::option::Option::*;
+        use $crate::lib::std::result::Result::*;
+        use $crate::lib::std::option::Option::*;
         use $crate::{Err,Needed};
 
         use $crate::Slice;
@@ -1231,7 +1231,7 @@ mod tests {
   #[cfg(feature = "verbose-errors")]
   #[test]
   fn escape_transform() {
-    use std::str;
+    use lib::std::str;
 
     named!(
       esc<String>,

--- a/src/character.rs
+++ b/src/character.rs
@@ -2,7 +2,7 @@
 
 use internal::{IResult, Needed};
 use traits::{AsChar, InputIter, InputLength, Slice};
-use std::ops::RangeFrom;
+use lib::std::ops::RangeFrom;
 use traits::{need_more, AtEof};
 
 /// matches one of the provided characters
@@ -22,8 +22,8 @@ use traits::{need_more, AtEof};
 macro_rules! one_of (
   ($i:expr, $inp: expr) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Err,Needed};
 
       use $crate::Slice;
@@ -61,8 +61,8 @@ macro_rules! one_of (
 macro_rules! none_of (
   ($i:expr, $inp: expr) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Err,Needed};
 
       use $crate::Slice;
@@ -99,8 +99,8 @@ macro_rules! none_of (
 macro_rules! char (
   ($i:expr, $c: expr) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Err,Needed};
 
       use $crate::Slice;

--- a/src/character.rs
+++ b/src/character.rs
@@ -146,10 +146,12 @@ where
   let mut it = input.iter_indices();
   match it.next() {
     None => need_more(input, Needed::Size(1)),
-    Some((_, c)) => match it.next() {
-      None => Ok((input.slice(input.input_len()..), c.as_char())),
-      Some((idx, _)) => Ok((input.slice(idx..), c.as_char())),
-    },
+    Some((_, c)) => {
+      match it.next() {
+        None => Ok((input.slice(input.input_len()..), c.as_char())),
+        Some((idx, _)) => Ok((input.slice(idx..), c.as_char())),
+      }
+    }
   }
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -315,7 +315,7 @@ macro_rules! error_node_position(
     {
     let mut error_vec = match $next {
       $crate::Context::Code(i, e) => {
-        let mut v = ::std::vec::Vec::new();
+        let mut v = $crate::lib::std::vec::Vec::new();
         v.push((i, e));
         v
       },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,15 +359,30 @@ extern crate regex;
 #[cfg(nightly)]
 extern crate test;
 
-#[cfg(not(feature = "std"))]
-mod std {
-  #[cfg(feature = "alloc")]
-  #[macro_use]
-  pub use alloc::{boxed, string, vec};
+/// Lib module to re-export everything needed from `std` or `core`/`alloc`. This is how `serde` does
+/// it, albeit there it is not public.
+pub mod lib {
+  /// `std` facade allowing `std`/`core` to be interchangeable. Reexports `alloc` crate optionally,
+  /// as well as `core` or `std`
+  #[cfg(not(feature = "std"))]
+  pub mod std {
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(feature = "alloc", macro_use)]
+    pub use alloc::{boxed, string, vec};
 
-  pub use core::{cmp, convert, fmt, iter, mem, ops, option, result, slice, str};
-  pub mod prelude {
-    pub use core::prelude as v1;
+    pub use core::{cmp, convert, fmt, iter, mem, ops, option, result, slice, str};
+    pub mod prelude {
+      pub use core::prelude as v1;
+    }
+  }
+
+  #[cfg(feature = "std")]
+  pub mod std {
+    pub use std::{boxed, string, vec, cmp, convert, fmt, iter, mem,
+                  ops, option, result, slice, str, collections, hash};
+    pub mod prelude {
+      pub use std::prelude as v1;
+    }
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,8 @@
 //! # }
 //! ```
 //!
-//! It defines a function named `parens`, which will recognize a sequence of the character `(`, the longest byte array not containing `)`, then the character `)`, and will return the byte array in the middle.
+//! It defines a function named `parens`, which will recognize a sequence of the character `(`, the longest byte array not containing `)`,
+//! then the character `)`, and will return the byte array in the middle.
 //!
 //! Here is another parser, written without using nom's macros this time:
 //!
@@ -163,17 +164,22 @@
 //!
 //! It can have the following values:
 //!
-//! - a correct result `Ok((I,O))` with the first element being the remaining of the input (not parsed yet), and the second the output value;
-//! - an error `Err(Err::Error(c))` with `c` an enum that contians an error code with its position in the input, and optionally a chain of accumulated errors;
+//! - a correct result `Ok((I,O))` with the first element being the remaining of the input (not parsed yet), and the second the output
+//! value;
+//! - an error `Err(Err::Error(c))` with `c` an enum that contians an error code with its position in the input, and optionally a chain of
+//! accumulated errors;
 //! - an error `Err(Err::Incomplete(Needed))` indicating that more input is necessary. `Needed` can indicate how much data is needed
-//! - an error `Err(Err::Failure(c))`. It works like the `Error` case, except it indicates an unrecoverable error: we cannot backtrack and test another parser
+//! - an error `Err(Err::Failure(c))`. It works like the `Error` case, except it indicates an unrecoverable error: we cannot backtrack and
+//! test another parser
 //!
 //! Please refer to the [documentation][doc] for an exhaustive list of parsers. See also the
 //! ["choose a combinator" guide](https://github.com/Geal/nom/blob/master/doc/choosing_a_combinator.md)**.
 //!
 //! ## Making new parsers with macros
 //!
-//! Macros are the main way to make new parsers by combining other ones. Those macros accept other macros or function names as arguments. You then need to make a function out of that combinator with **`named!`**, or a closure with **`closure!`**. Here is how you would do, with the **`tag!`** and **`take!`** combinators:
+//! Macros are the main way to make new parsers by combining other ones. Those macros accept other macros or function names as arguments.
+//! You then need to make a function out of that combinator with **`named!`**, or a closure with **`closure!`**. Here is how you would do,
+//! with the **`tag!`** and **`take!`** combinators:
 //!
 //! ```rust
 //! # #[macro_use] extern crate nom;
@@ -196,29 +202,31 @@
 //!
 //! **IMPORTANT NOTE**: Rust's macros can be very sensitive to the syntax, so you may encounter an error compiling parsers like this one:
 //!
-//! ```rust
-//! # #[macro_use] extern crate nom;
-//! # fn main() {
-//! named!(my_function<&[u8], Vec<&[u8]>>, many0!(tag!("abcd")));
-//! # }
-//! ```
+#![cfg_attr(doc = r##" ```rust
+ # #[macro_use] extern crate nom;
+ # fn main() {
+ named!(my_function<&[u8], Vec<&[u8]>>, many0!(tag!("abcd")));
+ # }
+ ```"##, any(feature = "alloc", feature = "std"))]
 //!
 //! You will get the following error: `error: expected an item keyword`. This
 //! happens because `>>` is seen as an operator, so the macro parser does not
 //! recognize what we want. There is a way to avoid it, by inserting a space:
 //!
-//! ```rust
-//! # #[macro_use] extern crate nom;
-//! # fn main() {
-//! named!(my_function<&[u8], Vec<&[u8]> >, many0!(tag!("abcd")));
-//! # }
-//! ```
+//!
+#![cfg_attr(doc = r##" ```rust
+ # #[macro_use] extern crate nom;
+ # fn main() {
+ named!(my_function<&[u8], Vec<&[u8]> >, many0!(tag!("abcd")));
+ # }
+ ```"##, any(feature = "alloc", feature = "std"))]
 //!
 //! This will compile correctly. I am very sorry for this inconvenience.
 //!
 //! ## Combining parsers
 //!
-//! There are more high level patterns, like the **`alt!`** combinator, which provides a choice between multiple parsers. If one branch fails, it tries the next, and returns the result of the first parser that succeeds:
+//! There are more high level patterns, like the **`alt!`** combinator, which provides a choice between multiple parsers. If one branch
+//! fails, it tries the next, and returns the result of the first parser that succeeds:
 //!
 //! ```rust
 //! # #[macro_use] extern crate nom;
@@ -247,20 +255,20 @@
 //!
 //! **`many0!`** applies a parser 0 or more times, and returns a vector of the aggregated results:
 //!
-//! ```rust
-//! # #[macro_use] extern crate nom;
-//! # fn main() {
-//! use std::str;
-//!
-//! named!(multi< Vec<&str> >, many0!( map_res!(tag!( "abcd" ), str::from_utf8) ) );
-//! let a = b"abcdef";
-//! let b = b"abcdabcdef";
-//! let c = b"azerty";
-//! assert_eq!(multi(a), Ok((&b"ef"[..],     vec!["abcd"])));
-//! assert_eq!(multi(b), Ok((&b"ef"[..],     vec!["abcd", "abcd"])));
-//! assert_eq!(multi(c), Ok((&b"azerty"[..], Vec::new())));
-//! # }
-//! ```
+#![cfg_attr(doc = r##" ```rust
+ # #[macro_use] extern crate nom;
+ # fn main() {
+ use std::str;
+
+ named!(multi< Vec<&str> >, many0!( map_res!(tag!( "abcd" ), str::from_utf8) ) );
+ let a = b"abcdef";
+ let b = b"abcdabcdef";
+ let c = b"azerty";
+ assert_eq!(multi(a), Ok((&b"ef"[..],     vec!["abcd"])));
+ assert_eq!(multi(b), Ok((&b"ef"[..],     vec!["abcd", "abcd"])));
+ assert_eq!(multi(c), Ok((&b"azerty"[..], Vec::new())));
+ # }
+ ```"##, any(feature = "alloc", feature = "std"))]
 //!
 //! Here are some basic combining macros available:
 //!
@@ -268,7 +276,8 @@
 //! - **`many0!`**: will apply the parser 0 or more times (if it returns the `O` type, the new parser returns `Vec<O>`)
 //! - **`many1!`**: will apply the parser 1 or more times
 //!
-//! There are more complex (and more useful) parsers like `do_parse!` and `tuple!`, which are used to apply a series of parsers then assemble their results.
+//! There are more complex (and more useful) parsers like `do_parse!` and `tuple!`, which are used to apply a series of parsers then
+//! assemble their results.
 //!
 //! Example with `tuple!`:
 //!
@@ -335,9 +344,12 @@
 //! # }
 //! ```
 //!
-//! The double right arrow `>>` is used as separator between every parser in the sequence, and the last closure can see the variables storing the result of parsers. Unless the specified return type is already a tuple, the final line should be that type wrapped in a tuple.
+//! The double right arrow `>>` is used as separator between every parser in the sequence, and the last closure can see the variables
+//! storing the result of parsers. Unless the specified return type is already a tuple, the final line should be that type wrapped in a
+//! tuple.
 //!
-//! More examples of [`do_parse!`](macro.do_parse.html) and [`tuple!`](macro.tuple.html) usage can be found in the [INI file parser example](tests/ini.rs).
+//! More examples of [`do_parse!`](macro.do_parse.html) and [`tuple!`](macro.tuple.html) usage can be found in the
+//! [INI file parser example](tests/ini.rs).
 //!
 //! **Going further:** read the [guides](https://github.com/Geal/nom/tree/master/doc)!
 #![cfg_attr(not(feature = "std"), feature(alloc))]
@@ -378,8 +390,7 @@ pub mod lib {
 
   #[cfg(feature = "std")]
   pub mod std {
-    pub use std::{boxed, string, vec, cmp, convert, fmt, iter, mem,
-                  ops, option, result, slice, str, collections, hash};
+    pub use std::{boxed, string, vec, cmp, convert, fmt, iter, mem, ops, option, result, slice, str, collections, hash};
     pub mod prelude {
       pub use std::prelude as v1;
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -371,7 +371,7 @@ macro_rules! apply (
 macro_rules! return_error (
   ($i:expr, $code:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Context,Err,ErrorKind};
 
       let i_ = $i.clone();
@@ -396,7 +396,7 @@ macro_rules! return_error (
   );
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Context,Err,ErrorKind};
 
       let i_ = $i.clone();
@@ -444,7 +444,7 @@ macro_rules! return_error (
 macro_rules! add_return_error (
   ($i:expr, $code:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,Context,ErrorKind};
 
       fn unify_types<I,E>(_: &Context<I,E>, _: &Context<I,E>) {}
@@ -488,7 +488,7 @@ macro_rules! add_return_error (
 macro_rules! complete (
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind};
 
       let i_ = $i.clone();
@@ -537,7 +537,7 @@ macro_rules! complete (
 #[macro_export]
 macro_rules! try_parse (
   ($i:expr, $submac:ident!( $($args:tt)* )) => ({
-    use ::std::result::Result::*;
+    use $crate::lib::std::result::Result::*;
 
     match $submac!($i, $($args)*) {
       Ok((i,o)) => (i,o),
@@ -580,7 +580,7 @@ macro_rules! map_res (
   // Internal parser, do not use directly
   (__impl $i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::Err;
 
       let i_ = $i.clone();
@@ -619,8 +619,8 @@ macro_rules! map_opt (
   // Internal parser, do not use directly
   (__impl $i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Err,ErrorKind};
 
       let i_ = $i.clone();
@@ -659,9 +659,9 @@ macro_rules! map_opt (
 macro_rules! parse_to (
   ($i:expr, $t:ty ) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Err,ErrorKind,Context};
 
       use $crate::ParseTo;
@@ -691,7 +691,7 @@ macro_rules! verify (
   // Internal parser, do not use directly
   (__impl $i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind};
 
       let i_ = $i.clone();
@@ -742,7 +742,7 @@ macro_rules! verify (
 macro_rules! value (
   ($i:expr, $res:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       match $submac!($i, $($args)*) {
         Ok((i,_)) => {
@@ -770,7 +770,7 @@ macro_rules! value (
 macro_rules! expr_res (
   ($i:expr, $e:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind};
 
       match $e {
@@ -815,12 +815,12 @@ macro_rules! expr_res (
 macro_rules! expr_opt (
   ($i:expr, $e:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind};
 
       match $e {
-        ::std::option::Option::Some(output) => Ok(($i, output)),
-        ::std::option::Option::None         => Err(Err::Error(error_position!($i, ErrorKind::ExprOpt::<u32>)))
+        $crate::lib::std::option::Option::Some(output) => Ok(($i, output)),
+        $crate::lib::std::option::Option::None         => Err(Err::Error(error_position!($i, ErrorKind::ExprOpt::<u32>)))
       }
     }
   );
@@ -855,8 +855,8 @@ macro_rules! expr_opt (
 macro_rules! opt(
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::Err;
 
       let i_ = $i.clone();
@@ -895,7 +895,7 @@ macro_rules! opt(
 macro_rules! opt_res (
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::Err;
 
       let i_ = $i.clone();
@@ -948,16 +948,16 @@ macro_rules! opt_res (
 macro_rules! cond_with_error(
   ($i:expr, $cond:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Convert,Err,Needed,IResult};
 
       if $cond {
         match $submac!($i, $($args)*) {
-          Ok((i,o)) => Ok((i, ::std::option::Option::Some(o))),
+          Ok((i,o)) => Ok((i, $crate::lib::std::option::Option::Some(o))),
           Err(e)    => Err(e),
         }
       } else {
-        let res: ::std::result::Result<_,_> = Ok(($i, ::std::option::Option::None));
+        let res: $crate::lib::std::result::Result<_,_> = Ok(($i, $crate::lib::std::option::Option::None));
         res
       }
     }
@@ -1003,8 +1003,8 @@ macro_rules! cond_with_error(
 macro_rules! cond(
   ($i:expr, $cond:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::Err;
 
       if $cond {
@@ -1061,7 +1061,7 @@ macro_rules! cond(
 macro_rules! cond_reduce(
   ($i:expr, $cond:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Convert,Err,ErrorKind,IResult};
       let default_err = Err(Err::convert(Err::Error(error_position!($i, ErrorKind::CondReduce::<u32>))));
 
@@ -1102,7 +1102,7 @@ macro_rules! cond_reduce(
 macro_rules! peek(
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Convert,Err};
 
       let i_ = $i.clone();
@@ -1143,7 +1143,7 @@ macro_rules! peek(
 macro_rules! not(
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Context,ErrorKind,Err,IResult};
 
       let i_ = $i.clone();
@@ -1188,7 +1188,7 @@ macro_rules! not(
 macro_rules! tap (
   ($i:expr, $name:ident : $submac:ident!( $($args:tt)* ) => $e:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Convert,Err,Needed,IResult};
 
       match $submac!($i, $($args)*) {
@@ -1220,7 +1220,7 @@ macro_rules! tap (
 macro_rules! eof (
   ($i:expr,) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{AtEof,Err,ErrorKind};
 
       use $crate::InputLength;
@@ -1266,7 +1266,7 @@ macro_rules! exact (
 macro_rules! recognize (
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       use $crate::Offset;
       use $crate::Slice;
@@ -1293,7 +1293,7 @@ mod tests {
   // reproduce the tag and take macros, because of module import order
   macro_rules! tag (
     ($i:expr, $tag: expr) => ({
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,Needed,IResult,ErrorKind};
       use $crate::{Compare,CompareResult,InputLength,Slice,need_more};
 
@@ -1404,7 +1404,7 @@ mod tests {
     assert_eq!(opt_res_abcd(c), Err(Err::Incomplete(Needed::Size(4))));
   }
 
-  use std::convert::From;
+  use lib::std::convert::From;
   #[derive(Debug, PartialEq)]
   pub struct CustomError(&'static str);
   impl From<u32> for CustomError {

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -390,11 +390,13 @@ mod tests {
           output
         );
       }
-      other => panic!(
+      other => {
+        panic!(
         "`Parser.tag_abc` didn't succeed when it should have. \
          Got `{:?}`.",
         other
-      ),
+      )
+      }
     }
   }
 
@@ -420,11 +422,13 @@ mod tests {
           output
         );
       }
-      other => panic!(
+      other => {
+        panic!(
         "`Parser.tag_bcd` didn't succeed when it should have. \
          Got `{:?}`.",
         other
-      ),
+      )
+      }
     }
   }
 
@@ -450,11 +454,13 @@ mod tests {
           output
         );
       }
-      other => panic!(
+      other => {
+        panic!(
         "`Parser.tag_hij` didn't succeed when it should have. \
          Got `{:?}`.",
         other
-      ),
+      )
+      }
     }
   }
 
@@ -480,11 +486,13 @@ mod tests {
           output
         );
       }
-      other => panic!(
+      other => {
+        panic!(
         "`Parser.tag_ijk` didn't succeed when it should have. \
          Got `{:?}`.",
         other
-      ),
+      )
+      }
     }
   }
   #[test]
@@ -509,11 +517,13 @@ mod tests {
           output
         );
       }
-      other => panic!(
+      other => {
+        panic!(
         "`Parser.simple_call` didn't succeed when it should have. \
          Got `{:?}`.",
         other
-      ),
+      )
+      }
     }
   }
 
@@ -545,11 +555,13 @@ mod tests {
           p.bcd
         );
       }
-      other => panic!(
+      other => {
+        panic!(
         "`Parser.use_apply` didn't succeed when it should have. \
          Got `{:?}`.",
         other
-      ),
+      )
+      }
     }
   }
 
@@ -574,11 +586,13 @@ mod tests {
           output
         );
       }
-      other => panic!(
+      other => {
+        panic!(
         "`Parser.simple_peek` didn't succeed when it should have. \
          Got `{:?}`.",
         other
-      ),
+      )
+      }
     }
   }
 
@@ -610,11 +624,13 @@ mod tests {
           p.bcd
         );
       }
-      other => panic!(
+      other => {
+        panic!(
         "`Parser.simple_chain` didn't succeed when it should have. \
          Got `{:?}`.",
         other
-      ),
+      )
+      }
     }
   }
 }

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -286,7 +286,7 @@ mod tests {
   macro_rules! tag_s (
     ($i:expr, $tag: expr) => (
       {
-        use ::std::result::Result::*;
+        use $crate::lib::std::result::Result::*;
         use $crate::{Err,ErrorKind,Needed,IResult, need_more};
 
         let res: IResult<_,_> = if $tag.len() > $i.len() {
@@ -305,7 +305,7 @@ mod tests {
   macro_rules! take_s (
     ($i:expr, $count:expr) => (
       {
-        use ::std::result::Result::*;
+        use $crate::lib::std::result::Result::*;
         use $crate::{Needed,IResult,need_more};
 
         let cnt = $count as usize;

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -7,13 +7,13 @@
 macro_rules! separated_list(
   ($i:expr, $sep:ident!( $($args:tt)* ), $submac:ident!( $($args2:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::Err;
 
       use $crate::InputLength;
 
       //FIXME: use crate vec
-      let mut res   = ::std::vec::Vec::new();
+      let mut res   = $crate::lib::std::vec::Vec::new();
       let mut input = $i.clone();
 
       // get the first element
@@ -95,11 +95,11 @@ macro_rules! separated_list(
 macro_rules! separated_nonempty_list(
   ($i:expr, $sep:ident!( $($args:tt)* ), $submac:ident!( $($args2:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind};
       use $crate::InputLength;
 
-      let mut res   = ::std::vec::Vec::new();
+      let mut res   = $crate::lib::std::vec::Vec::new();
       let mut input = $i.clone();
 
       // get the first element
@@ -241,11 +241,11 @@ macro_rules! separated_nonempty_list_complete {
 macro_rules! many0(
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,AtEof};
 
       let ret;
-      let mut res   = ::std::vec::Vec::new();
+      let mut res   = $crate::lib::std::vec::Vec::new();
       let mut input = $i.clone();
 
       loop {
@@ -309,7 +309,7 @@ macro_rules! many0(
 macro_rules! many1(
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::Err;
 
       use $crate::InputLength;
@@ -323,10 +323,10 @@ macro_rules! many1(
         )),
         Err(i) => Err(i),
         Ok((i1,o1))   => {
-          let mut res    = ::std::vec::Vec::with_capacity(4);
+          let mut res    = $crate::lib::std::vec::Vec::with_capacity(4);
           res.push(o1);
           let mut input  = i1;
-          let mut error = ::std::option::Option::None;
+          let mut error = $crate::lib::std::option::Option::None;
           loop {
             let input_ = input.clone();
             match $submac!(input_, $($args)*) {
@@ -334,7 +334,7 @@ macro_rules! many1(
                 break;
               },
               Err(e) => {
-                error = ::std::option::Option::Some(e);
+                error = $crate::lib::std::option::Option::Some(e);
                 break;
               },
               Ok((i, o)) => {
@@ -348,8 +348,8 @@ macro_rules! many1(
           }
 
           match error {
-            ::std::option::Option::Some(e) => Err(e),
-            ::std::option::Option::None    => Ok((input, res))
+            $crate::lib::std::option::Option::Some(e) => Err(e),
+            $crate::lib::std::option::Option::None    => Ok((input, res))
           }
         }
       }
@@ -390,11 +390,11 @@ macro_rules! many1(
 macro_rules! many_till(
   (__impl $i:expr, $submac1:ident!( $($args1:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind};
 
       let ret;
-      let mut res   = ::std::vec::Vec::new();
+      let mut res   = $crate::lib::std::vec::Vec::new();
       let mut input = $i.clone();
 
       loop {
@@ -478,16 +478,16 @@ macro_rules! many_till(
 macro_rules! many_m_n(
   ($i:expr, $m:expr, $n: expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Context,Err,Needed};
 
       use $crate::InputLength;
-      let mut res          = ::std::vec::Vec::with_capacity($m);
+      let mut res          = $crate::lib::std::vec::Vec::with_capacity($m);
       let mut input        = $i.clone();
       let mut count: usize = 0;
       let mut err          = false;
-      let mut incomplete: ::std::option::Option<Needed> = ::std::option::Option::None;
-      let mut failure:    ::std::option::Option<Context<_,_>> = ::std::option::Option::None;
+      let mut incomplete: $crate::lib::std::option::Option<Needed> = $crate::lib::std::option::Option::None;
+      let mut failure:    $crate::lib::std::option::Option<Context<_,_>> = $crate::lib::std::option::Option::None;
       loop {
         if count == $n { break }
         let i_ = input.clone();
@@ -506,11 +506,11 @@ macro_rules! many_m_n(
             break;
           },
           Err(Err::Incomplete(i)) => {
-            incomplete = ::std::option::Option::Some(i);
+            incomplete = $crate::lib::std::option::Option::Some(i);
             break;
           },
           Err(Err::Failure(e)) => {
-            failure = ::std::option::Option::Some(e);
+            failure = $crate::lib::std::option::Option::Some(e);
             break;
           },
         }
@@ -521,19 +521,19 @@ macro_rules! many_m_n(
           Err(Err::Error(error_position!($i, $crate::ErrorKind::ManyMN)))
         } else {
           match failure {
-            ::std::option::Option::Some(i) => Err(Err::Failure(i)),
-            ::std::option::Option::None => match incomplete {
-              ::std::option::Option::Some(i) => $crate::need_more($i, i),
-              ::std::option::Option::None    => $crate::need_more($i, Needed::Unknown)
+            $crate::lib::std::option::Option::Some(i) => Err(Err::Failure(i)),
+            $crate::lib::std::option::Option::None => match incomplete {
+              $crate::lib::std::option::Option::Some(i) => $crate::need_more($i, i),
+              $crate::lib::std::option::Option::None    => $crate::need_more($i, Needed::Unknown)
             }
           }
         }
       } else {
         match failure {
-          ::std::option::Option::Some(i) => Err(Err::Failure(i)),
-          ::std::option::Option::None => match incomplete {
-            ::std::option::Option::Some(i) => $crate::need_more($i, i),
-            ::std::option::Option::None    => Ok((input, res))
+          $crate::lib::std::option::Option::Some(i) => Err(Err::Failure(i)),
+          $crate::lib::std::option::Option::None => match incomplete {
+            $crate::lib::std::option::Option::Some(i) => $crate::need_more($i, i),
+            $crate::lib::std::option::Option::None    => Ok((input, res))
           }
         }
       }
@@ -568,12 +568,12 @@ macro_rules! many_m_n(
 macro_rules! count(
   ($i:expr, $submac:ident!( $($args:tt)* ), $count: expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err};
 
       let ret;
       let mut input = $i.clone();
-      let mut res   = ::std::vec::Vec::new();
+      let mut res   = $crate::lib::std::vec::Vec::new();
 
       loop {
         if res.len() == $count {
@@ -636,13 +636,13 @@ macro_rules! count(
 macro_rules! count_fixed (
   ($i:expr, $typ:ty, $submac:ident!( $($args:tt)* ), $count: expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err};
 
       let ret;
       let mut input = $i.clone();
       // `$typ` must be Copy, and thus having no destructor, this is panic safe
-      let mut res: [$typ; $count] = unsafe{[::std::mem::uninitialized(); $count as usize]};
+      let mut res: [$typ; $count] = unsafe{[$crate::lib::std::mem::uninitialized(); $count as usize]};
       let mut cnt: usize = 0;
 
       loop {
@@ -684,7 +684,7 @@ macro_rules! count_fixed (
 macro_rules! length_count(
   ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,Convert};
 
       match $submac!($i, $($args)*) {
@@ -719,7 +719,7 @@ macro_rules! length_count(
 #[macro_export]
 macro_rules! length_data(
   ($i:expr, $submac:ident!( $($args:tt)* )) => ({
-    use ::std::result::Result::*;
+    use $crate::lib::std::result::Result::*;
     use $crate::{Convert,Err};
 
     match $submac!($i, $($args)*) {
@@ -747,7 +747,7 @@ macro_rules! length_data(
 macro_rules! length_value(
   ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,Convert};
 
       match $submac!($i, $($args)*) {
@@ -807,7 +807,7 @@ macro_rules! length_value(
 macro_rules! fold_many0(
   ($i:expr, $submac:ident!( $($args:tt)* ), $init:expr, $f:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,AtEof};
 
       let ret;
@@ -878,7 +878,7 @@ macro_rules! fold_many0(
 macro_rules! fold_many1(
   ($i:expr, $submac:ident!( $($args:tt)* ), $init:expr, $f:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,Needed,InputLength,Context,AtEof};
 
       match $submac!($i, $($args)*) {
@@ -893,27 +893,27 @@ macro_rules! fold_many1(
           let f = $f;
           let mut acc = f($init, o1);
           let mut input  = i1;
-          let mut incomplete: ::std::option::Option<Needed> =
-            ::std::option::Option::None;
-          let mut failure: ::std::option::Option<Context<_,_>> =
-            ::std::option::Option::None;
+          let mut incomplete: $crate::lib::std::option::Option<Needed> =
+            $crate::lib::std::option::Option::None;
+          let mut failure: $crate::lib::std::option::Option<Context<_,_>> =
+            $crate::lib::std::option::Option::None;
           loop {
             match $submac!(input, $($args)*) {
               Err(Err::Error(_))                    => {
                 break;
               },
               Err(Err::Incomplete(i)) => {
-                incomplete = ::std::option::Option::Some(i);
+                incomplete = $crate::lib::std::option::Option::Some(i);
                 break;
               },
               Err(Err::Failure(e)) => {
-                failure = ::std::option::Option::Some(e);
+                failure = $crate::lib::std::option::Option::Some(e);
                 break;
               },
               Ok((i, o)) => {
                 if i.input_len() == input.input_len() {
                   if !i.at_eof() {
-                    failure = ::std::option::Option::Some(error_position!(i, $crate::ErrorKind::Many1));
+                    failure = $crate::lib::std::option::Option::Some(error_position!(i, $crate::ErrorKind::Many1));
                   }
                   break;
                 }
@@ -924,10 +924,10 @@ macro_rules! fold_many1(
           }
 
           match failure {
-            ::std::option::Option::Some(e) => Err(Err::Error(e)),
-            ::std::option::Option::None    => match incomplete {
-              ::std::option::Option::Some(i) => $crate::need_more($i, i),
-              ::std::option::Option::None    => Ok((input, acc))
+            $crate::lib::std::option::Option::Some(e) => Err(Err::Error(e)),
+            $crate::lib::std::option::Option::None    => match incomplete {
+              $crate::lib::std::option::Option::Some(i) => $crate::need_more($i, i),
+              $crate::lib::std::option::Option::None    => Ok((input, acc))
             }
           }
         }
@@ -970,7 +970,7 @@ macro_rules! fold_many1(
 macro_rules! fold_many_m_n(
   ($i:expr, $m:expr, $n: expr, $submac:ident!( $($args:tt)* ), $init:expr, $f:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,Needed};
 
       use $crate::InputLength;
@@ -979,7 +979,7 @@ macro_rules! fold_many_m_n(
       let mut input        = $i.clone();
       let mut count: usize = 0;
       let mut err          = false;
-      let mut incomplete: ::std::option::Option<Needed> = ::std::option::Option::None;
+      let mut incomplete: $crate::lib::std::option::Option<Needed> = $crate::lib::std::option::Option::None;
       loop {
         if count == $n { break }
         match $submac!(input, $($args)*) {
@@ -998,7 +998,7 @@ macro_rules! fold_many_m_n(
             break;
           },
           Err(Err::Incomplete(i)) => {
-            incomplete = ::std::option::Option::Some(i);
+            incomplete = $crate::lib::std::option::Option::Some(i);
             break;
           },
         }
@@ -1009,14 +1009,14 @@ macro_rules! fold_many_m_n(
           Err(Err::Error(error_position!($i, $crate::ErrorKind::ManyMN)))
         } else {
           match incomplete {
-            ::std::option::Option::Some(i) => Err(Err::Incomplete(i)),
-            ::std::option::Option::None    => Err(Err::Incomplete(Needed::Unknown))
+            $crate::lib::std::option::Option::Some(i) => Err(Err::Incomplete(i)),
+            $crate::lib::std::option::Option::None    => Err(Err::Incomplete(Needed::Unknown))
           }
         }
       } else {
         match incomplete {
-          ::std::option::Option::Some(i) => Err(Err::Incomplete(i)),
-          ::std::option::Option::None    => Ok((input, acc))
+          $crate::lib::std::option::Option::Some(i) => Err(Err::Incomplete(i)),
+          $crate::lib::std::option::Option::None    => Ok((input, acc))
         }
       }
     }
@@ -1030,7 +1030,7 @@ macro_rules! fold_many_m_n(
 mod tests {
   use internal::{Err, IResult, Needed};
   use nom::{digit, be_u16, be_u8, le_u16};
-  use std::str::{self, FromStr};
+  use lib::std::str::{self, FromStr};
   use util::ErrorKind;
 
   // reproduce the tag and take macros, because of module import order
@@ -1053,7 +1053,7 @@ mod tests {
   macro_rules! tag_bytes (
     ($i:expr, $bytes: expr) => (
       {
-        use std::cmp::min;
+        use $crate::lib::std::cmp::min;
         let len = $i.len();
         let blen = $bytes.len();
         let m   = min(len, blen);

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -222,21 +222,21 @@ macro_rules! separated_nonempty_list_complete {
 ///
 /// `many0` will only return `Error` if the embedded parser does not consume any input
 /// (to avoid infinite loops).
-///
-/// ```
-/// # #[macro_use] extern crate nom;
-/// # fn main() {
-///  named!(multi<&[u8], Vec<&[u8]> >, many0!( tag!( "abcd" ) ) );
-///
-///  let a = b"abcdabcdefgh";
-///  let b = b"azerty";
-///
-///  let res = vec![&b"abcd"[..], &b"abcd"[..]];
-///  assert_eq!(multi(&a[..]),Ok((&b"efgh"[..], res)));
-///  assert_eq!(multi(&b[..]),Ok((&b"azerty"[..], Vec::new())));
-/// # }
-/// ```
-///
+
+#[cfg_attr(doc = r##"
+ ```
+ # #[macro_use] extern crate nom;
+ # fn main() {
+  named!(multi<&[u8], Vec<&[u8]> >, many0!( tag!( "abcd" ) ) );
+
+  let a = b"abcdabcdefgh";
+  let b = b"azerty";
+
+  let res = vec![&b"abcd"[..], &b"abcd"[..]];
+  assert_eq!(multi(&a[..]),Ok((&b"efgh"[..], res)));
+  assert_eq!(multi(&b[..]),Ok((&b"azerty"[..], Vec::new())));
+ # }
+ ```"##, any(feature = "alloc", feature = "std"))]
 #[macro_export]
 macro_rules! many0(
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
@@ -290,21 +290,22 @@ macro_rules! many0(
 ///
 /// the embedded parser may return Incomplete
 ///
-/// ```
-/// # #[macro_use] extern crate nom;
-/// # use nom::Err;
-/// # use nom::ErrorKind;
-/// # fn main() {
-///  named!(multi<&[u8], Vec<&[u8]> >, many1!( tag!( "abcd" ) ) );
-///
-///  let a = b"abcdabcdefgh";
-///  let b = b"azerty";
-///
-///  let res = vec![&b"abcd"[..], &b"abcd"[..]];
-///  assert_eq!(multi(&a[..]),Ok((&b"efgh"[..], res)));
-///  assert_eq!(multi(&b[..]), Err(Err::Error(error_position!(&b[..], ErrorKind::Many1))));
-/// # }
-/// ```
+#[cfg_attr(doc = r##"```
+
+ # #[macro_use] extern crate nom;
+ # use nom::Err;
+ # use nom::ErrorKind;
+ # fn main() {
+  named!(multi<&[u8], Vec<&[u8]> >, many1!( tag!( "abcd" ) ) );
+
+  let a = b"abcdabcdefgh";
+  let b = b"azerty";
+
+  let res = vec![&b"abcd"[..], &b"abcd"[..]];
+  assert_eq!(multi(&a[..]),Ok((&b"efgh"[..], res)));
+  assert_eq!(multi(&b[..]), Err(Err::Error(error_position!(&b[..], ErrorKind::Many1))));
+
+```"##, any(feature = "alloc", feature = "std"))]
 #[macro_export]
 macro_rules! many1(
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
@@ -1242,7 +1243,11 @@ mod tests {
   #[bench]
   fn many0_bench(b: &mut Bencher) {
     named!(multi<&[u8],Vec<&[u8]> >, many0!(tag!("abcd")));
-    b.iter(|| multi(&b"abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"[..]));
+    b.iter(|| {
+      multi(
+        &b"abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"[..],
+      )
+    });
   }
 
   #[test]

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -443,8 +443,8 @@ pub fn be_u64(i: &[u8]) -> IResult<&[u8], u64, u32> {
   if i.len() < 8 {
     need_more(i, Needed::Size(8))
   } else {
-    let res = ((i[0] as u64) << 56) + ((i[1] as u64) << 48) + ((i[2] as u64) << 40) + ((i[3] as u64) << 32) + ((i[4] as u64) << 24)
-      + ((i[5] as u64) << 16) + ((i[6] as u64) << 8) + i[7] as u64;
+    let res = ((i[0] as u64) << 56) + ((i[1] as u64) << 48) + ((i[2] as u64) << 40) + ((i[3] as u64) << 32) +
+      ((i[4] as u64) << 24) + ((i[5] as u64) << 16) + ((i[6] as u64) << 8) + i[7] as u64;
     Ok((&i[8..], res))
   }
 }
@@ -533,8 +533,8 @@ pub fn le_u64(i: &[u8]) -> IResult<&[u8], u64> {
   if i.len() < 8 {
     need_more(i, Needed::Size(8))
   } else {
-    let res = ((i[7] as u64) << 56) + ((i[6] as u64) << 48) + ((i[5] as u64) << 40) + ((i[4] as u64) << 32) + ((i[3] as u64) << 24)
-      + ((i[2] as u64) << 16) + ((i[1] as u64) << 8) + i[0] as u64;
+    let res = ((i[7] as u64) << 56) + ((i[6] as u64) << 48) + ((i[5] as u64) << 40) + ((i[4] as u64) << 32) +
+      ((i[3] as u64) << 24) + ((i[2] as u64) << 16) + ((i[1] as u64) << 8) + i[0] as u64;
     Ok((&i[8..], res))
   }
 }
@@ -769,10 +769,9 @@ mod tests {
     let r2 = x(&b"abcefgh"[..]);
     assert_eq!(
       r2,
-      Err(Err::Error(error_position!(
-        &b"abcefgh"[..],
-        ErrorKind::TagClosure
-      ),))
+      Err(Err::Error(
+        error_position!(&b"abcefgh"[..], ErrorKind::TagClosure),
+      ))
     );
   }
 

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -7,17 +7,17 @@
 //!
 
 #[cfg(feature = "alloc")]
-use std::boxed::Box;
+use lib::std::boxed::Box;
 
 #[cfg(feature = "std")]
-use std::fmt::Debug;
+use lib::std::fmt::Debug;
 use internal::*;
 use traits::{AsChar, InputIter, InputLength, InputTakeAtPosition};
 use traits::{need_more, need_more_err, AtEof};
-use std::ops::{Range, RangeFrom, RangeTo};
+use lib::std::ops::{Range, RangeFrom, RangeTo};
 use traits::{Compare, CompareResult, Offset, Slice};
 use util::ErrorKind;
-use std::mem::transmute;
+use lib::std::mem::transmute;
 
 #[cfg(feature = "alloc")]
 #[inline]
@@ -1385,7 +1385,7 @@ mod tests {
     assert_eq!(int_parse(&[0x80, 0x00]), Ok((&b""[..], 128_u16)));
   }
 
-  use std::convert::From;
+  use lib::std::convert::From;
   impl From<u32> for CustomError {
     fn from(_: u32) -> Self {
       CustomError

--- a/src/regexp.rs
+++ b/src/regexp.rs
@@ -570,10 +570,9 @@ mod tests {
     assert_eq!(rm("2015-09-07"), Ok(("", "2015-09-07")));
     assert_eq!(
       rm("blah"),
-      Err(Err::Error(error_position!(
-        &"blah"[..],
-        ErrorKind::RegexpMatch::<u32>
-      ),))
+      Err(Err::Error(
+        error_position!(&"blah"[..], ErrorKind::RegexpMatch::<u32>),
+      ))
     );
     assert_eq!(rm("2015-09-07blah"), Ok(("", "2015-09-07blah")));
   }
@@ -585,10 +584,9 @@ mod tests {
     assert_eq!(rm("2015-09-07"), Ok(("", "2015-09-07")));
     assert_eq!(
       rm("blah"),
-      Err(Err::Error(error_position!(
-        &"blah"[..],
-        ErrorKind::RegexpMatch::<u32>
-      ),))
+      Err(Err::Error(
+        error_position!(&"blah"[..], ErrorKind::RegexpMatch::<u32>),
+      ))
     );
     assert_eq!(rm("2015-09-07blah"), Ok(("", "2015-09-07blah")));
   }
@@ -599,10 +597,9 @@ mod tests {
     assert_eq!(rm("2015-09-07"), Ok(("", "2015-09-07")));
     assert_eq!(
       rm("blah"),
-      Err(Err::Error(error_position!(
-        &"blah"[..],
-        ErrorKind::RegexpFind::<u32>
-      ),))
+      Err(Err::Error(
+        error_position!(&"blah"[..], ErrorKind::RegexpFind::<u32>),
+      ))
     );
     assert_eq!(rm("2015-09-07blah"), Ok(("blah", "2015-09-07")));
   }
@@ -614,10 +611,9 @@ mod tests {
     assert_eq!(rm("2015-09-07"), Ok(("", "2015-09-07")));
     assert_eq!(
       rm("blah"),
-      Err(Err::Error(error_position!(
-        &"blah"[..],
-        ErrorKind::RegexpFind::<u32>
-      ),))
+      Err(Err::Error(
+        error_position!(&"blah"[..], ErrorKind::RegexpFind::<u32>),
+      ))
     );
     assert_eq!(rm("2015-09-07blah"), Ok(("blah", "2015-09-07")));
   }

--- a/src/regexp.rs
+++ b/src/regexp.rs
@@ -26,7 +26,7 @@ macro_rules! regex_bytes (
 macro_rules! re_match (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::InputLength;
@@ -51,7 +51,7 @@ macro_rules! re_match (
 macro_rules! re_match_static (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::InputLength;
@@ -75,7 +75,7 @@ macro_rules! re_match_static (
 macro_rules! re_bytes_match (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::InputLength;
@@ -100,7 +100,7 @@ macro_rules! re_bytes_match (
 macro_rules! re_bytes_match_static (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::InputLength;
@@ -124,7 +124,7 @@ macro_rules! re_bytes_match_static (
 macro_rules! re_find (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -148,7 +148,7 @@ macro_rules! re_find (
 macro_rules! re_find_static (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -172,7 +172,7 @@ macro_rules! re_find_static (
 macro_rules! re_bytes_find (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -196,7 +196,7 @@ macro_rules! re_bytes_find (
 macro_rules! re_bytes_find_static (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -220,7 +220,7 @@ macro_rules! re_bytes_find_static (
 macro_rules! re_matches (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -249,7 +249,7 @@ macro_rules! re_matches (
 macro_rules! re_matches_static (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -277,7 +277,7 @@ macro_rules! re_matches_static (
 macro_rules! re_bytes_matches (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -306,7 +306,7 @@ macro_rules! re_bytes_matches (
 macro_rules! re_bytes_matches_static (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -334,7 +334,7 @@ macro_rules! re_bytes_matches_static (
 macro_rules! re_capture (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -363,7 +363,7 @@ macro_rules! re_capture (
 macro_rules! re_capture_static (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -391,7 +391,7 @@ macro_rules! re_capture_static (
 macro_rules! re_bytes_capture (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -420,7 +420,7 @@ macro_rules! re_bytes_capture (
 macro_rules! re_bytes_capture_static (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -448,7 +448,7 @@ macro_rules! re_bytes_capture_static (
 macro_rules! re_captures (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -479,7 +479,7 @@ macro_rules! re_captures (
 macro_rules! re_captures_static (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -508,7 +508,7 @@ macro_rules! re_captures_static (
 macro_rules! re_bytes_captures (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -538,7 +538,7 @@ macro_rules! re_bytes_captures (
 macro_rules! re_bytes_captures_static (
   ($i:expr, $re:expr) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,ErrorKind,IResult};
 
       use $crate::Slice;
@@ -560,7 +560,7 @@ macro_rules! re_bytes_captures_static (
 );
 #[cfg(test)]
 mod tests {
-  use std::vec::Vec;
+  use lib::std::vec::Vec;
   use util::ErrorKind;
   use internal::Err;
 

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -82,7 +82,7 @@ macro_rules! tuple_parser (
   );
   ($i:expr, ($($parsed:expr),*)) => (
     {
-      ::std::result::Result::Ok(($i, ($($parsed),*)))
+      $crate::lib::std::result::Result::Ok(($i, ($($parsed),*)))
     }
   );
 );
@@ -117,7 +117,7 @@ macro_rules! pair(
 macro_rules! separated_pair(
   ($i:expr, $submac:ident!( $($args:tt)* ), $($rest:tt)+) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       match tuple_parser!($i, (), $submac!($($args)*), $($rest)*) {
         Err(e)    => Err(e),
@@ -139,7 +139,7 @@ macro_rules! separated_pair(
 macro_rules! preceded(
   ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       match tuple!($i, $submac!($($args)*), $submac2!($($args2)*)) {
         Err(e) => Err(e),
@@ -169,7 +169,7 @@ macro_rules! preceded(
 macro_rules! terminated(
   ($i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       match tuple!($i, $submac!($($args)*), $submac2!($($args2)*)) {
         Err(e) => Err(e),
@@ -215,7 +215,7 @@ macro_rules! terminated(
 macro_rules! delimited(
   ($i:expr, $submac:ident!( $($args:tt)* ), $($rest:tt)+) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       match tuple_parser!($i, (), $submac!($($args)*), $($rest)*) {
         Err(e) => Err(e),
@@ -304,7 +304,7 @@ macro_rules! delimited(
 #[macro_export]
 macro_rules! do_parse (
   (__impl $i:expr, ( $($rest:expr),* )) => (
-    ::std::result::Result::Ok(($i, ( $($rest),* )))
+    $crate::lib::std::result::Result::Ok(($i, ( $($rest),* )))
   );
 
   (__impl $i:expr, $field:ident : $submac:ident!( $($args:tt)* ) ) => (
@@ -341,7 +341,7 @@ macro_rules! do_parse (
   );
   (__impl $i:expr, $submac:ident!( $($args:tt)* ) >> $($rest:tt)*) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       let i_ = $i.clone();
       match $submac!(i_, $($args)*) {
@@ -360,7 +360,7 @@ macro_rules! do_parse (
 
   (__impl $i:expr, $field:ident : $submac:ident!( $($args:tt)* ) >> $($rest:tt)*) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       let i_ = $i.clone();
       match  $submac!(i_, $($args)*) {
@@ -380,7 +380,7 @@ macro_rules! do_parse (
   );
 
   (__impl $i:expr, $submac:ident!( $($args:tt)* ) >> ( $($rest:tt)* )) => ({
-    use ::std::result::Result::*;
+    use $crate::lib::std::result::Result::*;
 
     match $submac!($i, $($args)*) {
       Err(e) => Err(e),
@@ -395,7 +395,7 @@ macro_rules! do_parse (
   );
 
   (__impl $i:expr, $field:ident : $submac:ident!( $($args:tt)* ) >> ( $($rest:tt)* )) => ({
-    use ::std::result::Result::*;
+    use $crate::lib::std::result::Result::*;
 
     match $submac!($i, $($args)*) {
       Err(e) => Err(e),
@@ -407,12 +407,12 @@ macro_rules! do_parse (
   });
 
   (__finalize $i:expr, ( $o: expr )) => ({
-    use ::std::result::Result::Ok;
+    use $crate::lib::std::result::Result::Ok;
     Ok(($i, $o))
   });
 
   (__finalize $i:expr, ( $($rest:tt)* )) => ({
-    use ::std::result::Result::Ok;
+    use $crate::lib::std::result::Result::Ok;
     Ok(($i, ( $($rest)* )))
   });
 
@@ -463,7 +463,7 @@ mod tests {
     ($i:expr, $bytes: expr) => (
       {
         use $crate::need_more;
-        use std::cmp::min;
+        use $crate::lib::std::cmp::min;
 
         let len = $i.len();
         let blen = $bytes.len();
@@ -539,7 +539,7 @@ mod tests {
   }
 
   // do it this way if you can use box patterns
-  /*use std::str;
+  /*use $crate::lib::std::str;
   fn error_to_string(e:Err) -> String
     match e {
       NodePosition(ErrorKind::Custom(42), i1, box Position(ErrorKind::Tag, i2)) => {
@@ -553,7 +553,7 @@ mod tests {
   }*/
 
   #[cfg(feature = "verbose-errors")]
-  use std::collections;
+  use lib::std::collections;
 
   #[cfg_attr(rustfmt, rustfmt_skip)]
   #[cfg(feature = "verbose-errors")]

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -845,10 +845,9 @@ mod tests {
     );
     assert_eq!(
       delimited_abc_def_ghi(&b"xxxdefghi"[..]),
-      Err(Err::Error(error_position!(
-        &b"xxxdefghi"[..],
-        ErrorKind::Tag
-      ),))
+      Err(Err::Error(
+        error_position!(&b"xxxdefghi"[..], ErrorKind::Tag),
+      ))
     );
     assert_eq!(
       delimited_abc_def_ghi(&b"abcxxxghi"[..]),

--- a/src/simple_errors.rs
+++ b/src/simple_errors.rs
@@ -14,7 +14,7 @@
 //! The main drawback is that it is a lot slower than default error
 //! management.
 use util::{Convert, ErrorKind};
-use std::convert::From;
+use lib::std::convert::From;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Context<I, E = u32> {
@@ -84,9 +84,9 @@ impl<I,O,E> IResult<I,O,E> {
 }
 
 #[cfg(feature = "std")]
-use std::any::Any;
+use $crate::lib::std::any::Any;
 #[cfg(feature = "std")]
-use std::{error,fmt};
+use $crate::lib::std::{error,fmt};
 #[cfg(feature = "std")]
 impl<E: fmt::Debug+Any> error::Error for Err<E> {
   fn description(&self) -> &str {
@@ -137,7 +137,7 @@ impl<E: fmt::Debug> fmt::Display for Err<E> {
 macro_rules! fix_error (
   ($i:expr, $t:ty, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::Err;
       use $crate::{Convert,Context,ErrorKind};
 
@@ -188,7 +188,7 @@ macro_rules! flat_map(
   );
   (__impl $i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Convert,Err};
 
       ($submac!($i, $($args)*)).and_then(|(i,o)| {

--- a/src/str.rs
+++ b/src/str.rs
@@ -272,11 +272,13 @@ mod test {
           output
         );
       }
-      other => panic!(
-        "Parser `tag_s` didn't succeed when it should have. \
+      other => {
+        panic!(
+          "Parser `tag_s` didn't succeed when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     };
   }
 
@@ -333,11 +335,13 @@ mod test {
           output
         );
       }
-      other => panic!(
-        "Parser `take_s` didn't succeed when it should have. \
+      other => {
+        panic!(
+          "Parser `take_s` didn't succeed when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     };
   }
 
@@ -364,11 +368,13 @@ mod test {
           output
         );
       }
-      other => panic!(
-        "Parser `take_until_s` didn't succeed when it should have. \
+      other => {
+        panic!(
+          "Parser `take_until_s` didn't succeed when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     };
   }
 
@@ -378,11 +384,13 @@ mod test {
 
     match take_s!(INPUT, 13) {
       Err(Err::Incomplete(_)) => (),
-      other => panic!(
-        "Parser `take_s` didn't require more input when it should have. \
+      other => {
+        panic!(
+          "Parser `take_s` didn't require more input when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     }
   }
 
@@ -447,11 +455,13 @@ mod test {
           output
         );
       }
-      other => panic!(
-        "Parser `take_till_s` didn't succeed when it should have. \
+      other => {
+        panic!(
+          "Parser `take_till_s` didn't succeed when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     };
   }
 
@@ -480,11 +490,13 @@ mod test {
           output
         );
       }
-      other => panic!(
-        "Parser `take_while_s` didn't succeed when it should have. \
+      other => {
+        panic!(
+          "Parser `take_while_s` didn't succeed when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     };
   }
 
@@ -511,11 +523,13 @@ mod test {
           output
         );
       }
-      other => panic!(
-        "Parser `is_not_s` didn't succeed when it should have. \
+      other => {
+        panic!(
+          "Parser `is_not_s` didn't succeed when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     };
   }
 
@@ -542,11 +556,13 @@ mod test {
           output
         );
       }
-      other => panic!(
-        "Parser `take_until_and_consume_s` didn't succeed when it should have. \
+      other => {
+        panic!(
+          "Parser `take_until_and_consume_s` didn't succeed when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     };
   }
 
@@ -575,11 +591,13 @@ mod test {
           output
         );
       }
-      other => panic!(
-        "Parser `take_while_s` didn't succeed when it should have. \
+      other => {
+        panic!(
+          "Parser `take_while_s` didn't succeed when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     };
   }
 
@@ -592,10 +610,12 @@ mod test {
     }
     match test(INPUT) {
       Err(Err::Error(_)) => (),
-      other => panic!(
-        "Parser `is_not_s` didn't fail when it should have. Got `{:?}`.",
-        other
-      ),
+      other => {
+        panic!(
+          "Parser `is_not_s` didn't fail when it should have. Got `{:?}`.",
+          other
+        )
+      }
     };
   }
 
@@ -624,11 +644,13 @@ mod test {
           output
         );
       }
-      other => panic!(
-        "Parser `take_while1_s` didn't succeed when it should have. \
+      other => {
+        panic!(
+          "Parser `take_while1_s` didn't succeed when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     };
   }
 
@@ -639,11 +661,13 @@ mod test {
 
     match take_until_and_consume_s!(INPUT, FIND) {
       Err(Err::Incomplete(_)) => (),
-      other => panic!(
-        "Parser `take_until_and_consume_s` didn't require more input when it should have. \
+      other => {
+        panic!(
+          "Parser `take_until_and_consume_s` didn't require more input when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     };
   }
 
@@ -654,11 +678,13 @@ mod test {
 
     match take_until_s!(INPUT, FIND) {
       Err(Err::Incomplete(_)) => (),
-      other => panic!(
-        "Parser `take_until_s` didn't require more input when it should have. \
+      other => {
+        panic!(
+          "Parser `take_until_s` didn't require more input when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     };
   }
 
@@ -685,11 +711,13 @@ mod test {
           output
         );
       }
-      other => panic!(
-        "Parser `is_a_s` didn't succeed when it should have. \
+      other => {
+        panic!(
+          "Parser `is_a_s` didn't succeed when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     };
   }
 
@@ -704,11 +732,13 @@ mod test {
     }
     match test(INPUT) {
       Err(Err::Error(_)) => (),
-      other => panic!(
-        "Parser `take_while1_s` didn't fail when it should have. \
+      other => {
+        panic!(
+          "Parser `take_while1_s` didn't fail when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     };
   }
 
@@ -721,10 +751,12 @@ mod test {
     }
     match test(INPUT) {
       Err(Err::Error(_)) => (),
-      other => panic!(
-        "Parser `is_a_s` didn't fail when it should have. Got `{:?}`.",
-        other
-      ),
+      other => {
+        panic!(
+          "Parser `is_a_s` didn't fail when it should have. Got `{:?}`.",
+          other
+        )
+      }
     };
   }
 
@@ -735,11 +767,13 @@ mod test {
 
     match take_until_and_consume_s!(INPUT, FIND) {
       Err(Err::Incomplete(_)) => (),
-      other => panic!(
-        "Parser `take_until_and_consume_s` didn't fail when it should have. \
+      other => {
+        panic!(
+          "Parser `take_until_and_consume_s` didn't fail when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     };
   }
 
@@ -750,11 +784,13 @@ mod test {
 
     match take_until_s!(INPUT, FIND) {
       Err(Err::Incomplete(_)) => (),
-      other => panic!(
-        "Parser `take_until_and_consume_s` didn't fail when it should have. \
+      other => {
+        panic!(
+          "Parser `take_until_and_consume_s` didn't fail when it should have. \
          Got `{:?}`.",
-        other
-      ),
+          other
+        )
+      }
     };
   }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -519,7 +519,7 @@ impl<'a> InputTakeAtPosition for &'a [u8] {
   {
     match (0..self.len()).find(|b| predicate(self[*b])) {
       Some(i) => Ok((&self[i..], &self[..i])),
-      None    => Err(Err::Incomplete(Needed::Size(1)))
+      None => Err(Err::Incomplete(Needed::Size(1))),
     }
   }
 
@@ -530,7 +530,7 @@ impl<'a> InputTakeAtPosition for &'a [u8] {
     match (0..self.len()).find(|b| predicate(self[*b])) {
       Some(0) => Err(Err::Error(Context::Code(self, e))),
       Some(i) => Ok((&self[i..], &self[..i])),
-      None    => Err(Err::Incomplete(Needed::Size(1)))
+      None => Err(Err::Incomplete(Needed::Size(1))),
     }
   }
 }
@@ -586,8 +586,8 @@ impl<'a> InputTakeAtPosition for &'a str {
     P: Fn(Self::Item) -> bool,
   {
     match self.char_indices().find(|&(_, c)| predicate(c)) {
-      Some((i,_)) => Ok((&self[i..], &self[..i])),
-      None        => Err(Err::Incomplete(Needed::Size(1)))
+      Some((i, _)) => Ok((&self[i..], &self[..i])),
+      None => Err(Err::Incomplete(Needed::Size(1))),
     }
   }
 
@@ -596,9 +596,9 @@ impl<'a> InputTakeAtPosition for &'a str {
     P: Fn(Self::Item) -> bool,
   {
     match self.char_indices().find(|&(_, c)| predicate(c)) {
-      Some((0,_)) => Err(Err::Error(Context::Code(self, e))),
-      Some((i,_)) => Ok((&self[i..], &self[..i])),
-      None        => Err(Err::Incomplete(Needed::Size(1)))
+      Some((0, _)) => Err(Err::Error(Context::Code(self, e))),
+      Some((i, _)) => Ok((&self[i..], &self[..i])),
+      None => Err(Err::Incomplete(Needed::Size(1))),
     }
   }
 }
@@ -611,7 +611,7 @@ impl<'a> InputTakeAtPosition for CompleteStr<'a> {
     P: Fn(Self::Item) -> bool,
   {
     match self.0.char_indices().find(|&(_, c)| predicate(c)) {
-      Some((i,_)) => Ok((CompleteStr(&self.0[i..]), CompleteStr(&self.0[..i]))),
+      Some((i, _)) => Ok((CompleteStr(&self.0[i..]), CompleteStr(&self.0[..i]))),
       None => {
         let (i, o) = self.0.take_split(self.0.len());
         Ok((CompleteStr(i), CompleteStr(o)))
@@ -624,8 +624,8 @@ impl<'a> InputTakeAtPosition for CompleteStr<'a> {
     P: Fn(Self::Item) -> bool,
   {
     match self.0.char_indices().find(|&(_, c)| predicate(c)) {
-      Some((0,_)) => Err(Err::Error(Context::Code(CompleteStr(self.0), e))),
-      Some((i,_)) => Ok((CompleteStr(&self.0[i..]), CompleteStr(&self.0[..i]))),
+      Some((0, _)) => Err(Err::Error(Context::Code(CompleteStr(self.0), e))),
+      Some((i, _)) => Ok((CompleteStr(&self.0[i..]), CompleteStr(&self.0[..i]))),
       None => {
         if self.0.len() == 0 {
           Err(Err::Error(Context::Code(CompleteStr(self.0), e)))
@@ -703,10 +703,16 @@ impl<'a, 'b> Compare<&'b [u8]> for &'a [u8] {
     let other = &t[..m];
 
     if !reduced.iter().zip(other).all(|(a, b)| match (*a, *b) {
-      (0...64, 0...64) | (91...96, 91...96) | (123...255, 123...255) => a == b,
-      (65...90, 65...90) | (97...122, 97...122) | (65...90, 97...122) | (97...122, 65...90) => *a | 0b00_10_00_00 == *b | 0b00_10_00_00,
+      (0...64, 0...64) |
+      (91...96, 91...96) |
+      (123...255, 123...255) => a == b,
+      (65...90, 65...90) |
+      (97...122, 97...122) |
+      (65...90, 97...122) |
+      (97...122, 65...90) => *a | 0b00_10_00_00 == *b | 0b00_10_00_00,
       _ => false,
-    }) {
+    })
+    {
       CompareResult::Error
     } else if m < blen {
       CompareResult::Incomplete
@@ -748,10 +754,9 @@ impl<'a, 'b> Compare<&'b str> for &'a str {
   #[cfg(feature = "alloc")]
   #[inline(always)]
   fn compare_no_case(&self, t: &'b str) -> CompareResult {
-    let pos = self
-      .chars()
-      .zip(t.chars())
-      .position(|(a, b)| a.to_lowercase().zip(b.to_lowercase()).any(|(a, b)| a != b));
+    let pos = self.chars().zip(t.chars()).position(|(a, b)| {
+      a.to_lowercase().zip(b.to_lowercase()).any(|(a, b)| a != b)
+    });
 
     match pos {
       Some(_) => CompareResult::Error,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,15 +1,15 @@
 //! Traits input types have to implement to work with nom combinators
 //!
 use internal::{Err, IResult, Needed};
-use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
-use std::iter::Enumerate;
-use std::slice::Iter;
-use std::iter::Map;
+use lib::std::ops::{Range, RangeFrom, RangeFull, RangeTo};
+use lib::std::iter::Enumerate;
+use lib::std::slice::Iter;
+use lib::std::iter::Map;
 
-use std::str::Chars;
-use std::str::CharIndices;
-use std::str::FromStr;
-use std::str::from_utf8;
+use lib::std::str::Chars;
+use lib::std::str::CharIndices;
+use lib::std::str::FromStr;
+use lib::std::str::from_utf8;
 
 use memchr;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,10 +3,10 @@
 
 use traits::{AsBytes, AtEof, Compare, CompareResult, FindSubstring, FindToken, InputIter, InputLength, InputTake, Offset, ParseTo, Slice};
 
-use std::str::{self, CharIndices, Chars, FromStr};
-use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
-use std::iter::{Enumerate, Map};
-use std::slice::Iter;
+use lib::std::str::{self, CharIndices, Chars, FromStr};
+use lib::std::ops::{Range, RangeFrom, RangeFull, RangeTo};
+use lib::std::iter::{Enumerate, Map};
+use lib::std::slice::Iter;
 
 /// Holds a complete String, for which the `at_eof` method always returns true
 ///

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,12 +4,12 @@ use internal::{Err, IResult};
 use verbose_errors::Context;
 
 #[cfg(feature = "std")]
-use std::collections::HashMap;
+use lib::std::collections::HashMap;
 
 #[cfg(feature = "alloc")]
-use std::vec::Vec;
+use lib::std::vec::Vec;
 #[cfg(feature = "alloc")]
-use std::string::ToString;
+use lib::std::string::ToString;
 
 #[cfg(feature = "std")]
 pub trait HexDisplay {
@@ -107,7 +107,7 @@ impl HexDisplay for str {
 macro_rules! dbg (
   ($i: expr, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       let l = line!();
       match $submac!($i, $($args)*) {
         Err(e) => {
@@ -187,7 +187,7 @@ pub fn compare_error_paths<P: Clone + PartialEq, E: Clone + PartialEq>(e1: &Cont
 
 #[cfg(feature = "std")]
 #[cfg(feature = "verbose-errors")]
-use std::hash::Hash;
+use lib::std::hash::Hash;
 
 #[cfg(feature = "std")]
 #[cfg(feature = "verbose-errors")]

--- a/src/util.rs
+++ b/src/util.rs
@@ -197,7 +197,8 @@ pub fn add_error_pattern<'a, I: Clone + Hash + Eq, O, E: Clone + Hash + Eq>(
   message: &'a str,
 ) -> bool {
   match res {
-    Err(Err::Error(e)) | Err(Err::Failure(e)) => {
+    Err(Err::Error(e)) |
+    Err(Err::Failure(e)) => {
       h.insert(error_to_list(&e), message);
       true
     }

--- a/src/verbose_errors.rs
+++ b/src/verbose_errors.rs
@@ -14,7 +14,7 @@
 //! The main drawback is that it is a lot slower than default error
 //! management.
 use util::{Convert, ErrorKind};
-use std::convert::From;
+use lib::std::convert::From;
 
 /// Contains the error that a parser can return
 ///
@@ -104,11 +104,11 @@ impl<I,O,E> IResult<I,O,E> {
 }
 
 #[cfg(feature = "std")]
-use std::any::Any;
+use $crate::lib::std::any::Any;
 #[cfg(feature = "std")]
-use std::{error,fmt};
+use $crate::lib::std::{error,fmt};
 #[cfg(feature = "std")]
-use std::fmt::Debug;
+use $crate::lib::std::fmt::Debug;
 #[cfg(feature = "std")]
 impl<P:Debug+Any,E:Debug+Any> error::Error for Err<P,E> {
   fn description(&self) -> &str {
@@ -171,7 +171,7 @@ impl<P:fmt::Debug,E:fmt::Debug> fmt::Display for Err<P,E> {
 macro_rules! fix_error (
   ($i:expr, $t:ty, $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,Convert,ErrorKind,Context};
 
       match $submac!($i, $($args)*) {
@@ -241,7 +241,7 @@ macro_rules! flat_map(
   );
   (__impl $i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,Convert};
 
       ($submac!($i, $($args)*)).and_then(|(i,o)| {

--- a/src/whitespace.rs
+++ b/src/whitespace.rs
@@ -828,7 +828,7 @@ macro_rules! sep (
 use internal::IResult;
 use traits::{InputTakeAtPosition, FindToken, AsChar};
 #[allow(unused_imports)]
-pub fn sp<'a,T>(input: T) -> IResult<T, T>
+pub fn sp<'a, T>(input: T) -> IResult<T, T>
 where
   T: InputTakeAtPosition,
   <T as InputTakeAtPosition>::Item: AsChar + Clone,

--- a/src/whitespace.rs
+++ b/src/whitespace.rs
@@ -97,7 +97,7 @@
 #[macro_export]
 macro_rules! wrap_sep (
   ($i:expr, $separator:expr, $submac:ident!( $($args:tt)* )) => ({
-    use ::std::result::Result::*;
+    use $crate::lib::std::result::Result::*;
     use $crate::{Err,Convert,IResult};
 
     fn unify_types<I,O,P,E>(_: &IResult<I,O,E>, _: &IResult<I,P,E>) {}
@@ -142,7 +142,7 @@ macro_rules! pair_sep (
 #[macro_export]
 macro_rules! delimited_sep (
   ($i:expr, $separator:path, $submac1:ident!( $($args1:tt)* ), $($rest:tt)+) => ({
-    use ::std::result::Result::*;
+    use $crate::lib::std::result::Result::*;
 
     match tuple_sep!($i, $separator, (), $submac1!($($args1)*), $($rest)*) {
       Err(e) => Err(e),
@@ -160,7 +160,7 @@ macro_rules! delimited_sep (
 #[macro_export]
 macro_rules! separated_pair_sep (
   ($i:expr, $separator:path, $submac1:ident!( $($args1:tt)* ), $($rest:tt)+) => ({
-    use ::std::result::Result::*;
+    use $crate::lib::std::result::Result::*;
 
     match tuple_sep!($i, $separator, (), $submac1!($($args1)*), $($rest)*) {
       Err(e) => Err(e),
@@ -178,7 +178,7 @@ macro_rules! separated_pair_sep (
 #[macro_export]
 macro_rules! preceded_sep (
   ($i:expr, $separator:path, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => ({
-    use ::std::result::Result::*;
+    use $crate::lib::std::result::Result::*;
 
     match pair_sep!($i, $separator, $submac!($($args)*), $submac2!($($args2)*)) {
       Err(e) => Err(e),
@@ -202,7 +202,7 @@ macro_rules! preceded_sep (
 #[macro_export]
 macro_rules! terminated_sep (
   ($i:expr, $separator:path, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => ({
-    use ::std::result::Result::*;
+    use $crate::lib::std::result::Result::*;
 
     match pair_sep!($i, $separator, $submac!($($args)*), $submac2!($($args2)*)) {
       Err(e) => Err(e),
@@ -231,7 +231,7 @@ macro_rules! tuple_sep (
   );
   ($i:expr, $separator:path, (), $submac:ident!( $($args:tt)* ), $($rest:tt)*) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       match sep!($i, $separator, $submac!($($args)*)) {
         Err(e) => Err(e),
@@ -243,7 +243,7 @@ macro_rules! tuple_sep (
   );
   ($i:expr, $separator:path, ($($parsed:tt)*), $submac:ident!( $($args:tt)* ), $($rest:tt)*) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       match sep!($i, $separator, $submac!($($args)*)) {
         Err(e) => Err(e),
@@ -258,7 +258,7 @@ macro_rules! tuple_sep (
   );
   ($i:expr, $separator:path, (), $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       match sep!($i, $separator, $submac!($($args)*)) {
         Err(e) => Err(e),
@@ -270,7 +270,7 @@ macro_rules! tuple_sep (
   );
   ($i:expr, $separator:path, ($($parsed:expr),*), $submac:ident!( $($args:tt)* )) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       match sep!($i, $separator, $submac!($($args)*)) {
         Err(e) => Err(e),
@@ -291,7 +291,7 @@ macro_rules! tuple_sep (
 #[macro_export]
 macro_rules! do_parse_sep (
   (__impl $i:expr, $separator:path, ( $($rest:expr),* )) => (
-    ::std::result::Result::Ok(($i, ( $($rest),* )))
+    $crate::lib::std::result::Result::Ok(($i, ( $($rest),* )))
   );
 
   (__impl $i:expr, $separator:path, $e:ident >> $($rest:tt)*) => (
@@ -299,7 +299,7 @@ macro_rules! do_parse_sep (
   );
   (__impl $i:expr, $separator:path, $submac:ident!( $($args:tt)* ) >> $($rest:tt)*) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       match sep!($i, $separator, $submac!($($args)*)) {
         Err(e) => Err(e),
@@ -316,7 +316,7 @@ macro_rules! do_parse_sep (
 
   (__impl $i:expr, $separator:path, $field:ident : $submac:ident!( $($args:tt)* ) >> $($rest:tt)*) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       match sep!($i, $separator, $submac!($($args)*)) {
         Err(e) => Err(e),
@@ -334,7 +334,7 @@ macro_rules! do_parse_sep (
   );
 
   (__impl $i:expr, $separator:path, $submac:ident!( $($args:tt)* ) >> ( $($rest:tt)* )) => ({
-    use ::std::result::Result::*;
+    use $crate::lib::std::result::Result::*;
 
     match sep!($i, $separator, $submac!($($args)*)) {
       Err(e) => Err(e),
@@ -349,7 +349,7 @@ macro_rules! do_parse_sep (
   );
 
   (__impl $i:expr, $separator:path, $field:ident : $submac:ident!( $($args:tt)* ) >> ( $($rest:tt)* )) => ({
-    use ::std::result::Result::*;
+    use $crate::lib::std::result::Result::*;
 
     match sep!($i, $separator, $submac!($($args)*)) {
       Err(e) => Err(e),
@@ -372,8 +372,8 @@ macro_rules! do_parse_sep (
 macro_rules! permutation_sep (
   ($i:expr, $separator:path, $($rest:tt)*) => (
     {
-      use ::std::result::Result::*;
-      use ::std::option::Option::*;
+      use $crate::lib::std::result::Result::*;
+      use $crate::lib::std::option::Option::*;
       use $crate::{Err,ErrorKind,Convert};
 
       let mut res    = permutation_init!((), $($rest)*);
@@ -424,21 +424,21 @@ macro_rules! permutation_iterator_sep (
     permutation_iterator_sep!($it, $i, $separator, $all_done, $needed, $res, $submac!($($args)*), $($rest)*);
   });
   ($it:tt, $i:expr, $separator:path, $all_done:expr, $needed:expr, $res:expr, $submac:ident!( $($args:tt)* ), $($rest:tt)*) => ({
-    use ::std::result::Result::*;
+    use $crate::lib::std::result::Result::*;
     use $crate::Err;
 
-    if acc!($it, $res) == ::std::option::Option::None {
+    if acc!($it, $res) == $crate::lib::std::option::Option::None {
       match {sep!($i, $separator, $submac!($($args)*))} {
         Ok((i,o))     => {
           $i = i;
-          acc!($it, $res) = ::std::option::Option::Some(o);
+          acc!($it, $res) = $crate::lib::std::option::Option::Some(o);
           continue;
         },
         Err(Err::Error(_)) => {
           $all_done = false;
         },
         Err(e) => {
-          $needed = ::std::option::Option::Some(e);
+          $needed = $crate::lib::std::option::Option::Some(e);
           break;
         }
       };
@@ -457,21 +457,21 @@ macro_rules! permutation_iterator_sep (
     permutation_iterator_sep!($it, $i, $separator, $all_done, $needed, $res, $submac!($($args)*));
   });
   ($it:tt, $i:expr, $separator:path, $all_done:expr, $needed:expr, $res:expr, $submac:ident!( $($args:tt)* )) => ({
-    use ::std::result::Result::*;
+    use $crate::lib::std::result::Result::*;
     use $crate::Err;
 
-    if acc!($it, $res) == ::std::option::Option::None {
+    if acc!($it, $res) == $crate::lib::std::option::Option::None {
       match sep!($i, $separator, $submac!($($args)*)) {
         Ok((i,o))     => {
           $i = i;
-          acc!($it, $res) = ::std::option::Option::Some(o);
+          acc!($it, $res) = $crate::lib::std::option::Option::Some(o);
           continue;
         },
         Err(Err::Error(_)) => {
           $all_done = false;
         },
         Err(e) => {
-          $needed = ::std::option::Option::Some(e);
+          $needed = $crate::lib::std::option::Option::Some(e);
           break;
         }
       };
@@ -488,7 +488,7 @@ macro_rules! alt_sep (
 
   (__impl $i:expr, $separator:path, $subrule:ident!( $($args:tt)*) | $($rest:tt)*) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err};
 
       let res = sep!($i, $separator, $subrule!($($args)*));
@@ -502,7 +502,7 @@ macro_rules! alt_sep (
 
   (__impl $i:expr, $separator:path, $subrule:ident!( $($args:tt)* ) => { $gen:expr } | $($rest:tt)+) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err};
 
       match sep!($i, $separator, $subrule!( $($args)* )) {
@@ -525,7 +525,7 @@ macro_rules! alt_sep (
 
   (__impl $i:expr, $separator:path, $subrule:ident!( $($args:tt)* ) => { $gen:expr }) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err};
 
       match sep!($i, $separator, $subrule!( $($args)* )) {
@@ -547,7 +547,7 @@ macro_rules! alt_sep (
 
   (__impl $i:expr, $separator:path, $subrule:ident!( $($args:tt)*)) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err};
 
       match sep!($i, $separator, $subrule!( $($args)* )) {
@@ -564,14 +564,14 @@ macro_rules! alt_sep (
   );
 
   (__impl $i:expr) => ({
-    use ::std::result::Result::*;
+    use $crate::lib::std::result::Result::*;
     use $crate::{Err,Needed,IResult};
 
     Err(Err::Error(error_position!($i, $crate::ErrorKind::Alt)))
   });
 
   (__impl $i:expr, $separator:path) => ({
-    use ::std::result::Result::*;
+    use $crate::lib::std::result::Result::*;
     use $crate::{Err,Needed,IResult};
 
     Err(Err::Error(error_position!($i, $crate::ErrorKind::Alt)))
@@ -593,7 +593,7 @@ macro_rules! alt_complete_sep (
 
   ($i:expr, $separator:path, $subrule:ident!( $($args:tt)*) | $($rest:tt)*) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       let res = complete!($i, sep!($separator, $subrule!($($args)*)));
       match res {
@@ -605,7 +605,7 @@ macro_rules! alt_complete_sep (
 
   ($i:expr, $separator:path, $subrule:ident!( $($args:tt)* ) => { $gen:expr } | $($rest:tt)+) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err,Needed,IResult};
 
       match complete!($i, sep!($separator, $subrule!($($args)*))) {
@@ -643,7 +643,7 @@ macro_rules! alt_complete_sep (
 macro_rules! switch_sep (
   (__impl $i:expr, $separator:path, $submac:ident!( $($args:tt)* ), $($p:pat => $subrule:ident!( $($args2:tt)* ))|* ) => (
     {
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
       use $crate::{Err};
 
       match sep!($i, $separator, $submac!($($args)*)) {
@@ -875,7 +875,7 @@ macro_rules! ws (
       use $crate::sp;
       use $crate::Convert;
       use $crate::Err;
-      use ::std::result::Result::*;
+      use $crate::lib::std::result::Result::*;
 
       match sep!($i, sp, $($args)*) {
         Err(e) => Err(e),
@@ -894,7 +894,7 @@ macro_rules! ws (
 #[allow(dead_code)]
 mod tests {
   #[cfg(feature = "alloc")]
-  use std::string::{String, ToString};
+  use lib::std::string::{String, ToString};
   use internal::{Err, IResult, Needed};
   use super::sp;
   use util::ErrorKind;

--- a/tests/arithmetic_ast.rs
+++ b/tests/arithmetic_ast.rs
@@ -54,6 +54,7 @@ impl Debug for Expr {
   }
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 named!(parens< CompleteStr, Expr >, delimited!(
     delimited!(opt!(multispace), tag!("("), opt!(multispace)),
     map!(map!(expr, Box::new), Expr::Paren),
@@ -61,6 +62,7 @@ named!(parens< CompleteStr, Expr >, delimited!(
   )
 );
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 named!(factor< CompleteStr, Expr >, alt_complete!(
     map!(
       map_res!(
@@ -85,6 +87,7 @@ fn fold_exprs(initial: Expr, remainder: Vec<(Oper, Expr)>) -> Expr {
   })
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 named!(term< CompleteStr, Expr >, do_parse!(
     initial: factor >>
     remainder: many0!(
@@ -96,6 +99,7 @@ named!(term< CompleteStr, Expr >, do_parse!(
     (fold_exprs(initial, remainder))
 ));
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 named!(expr< CompleteStr, Expr >, do_parse!(
     initial: term >>
     remainder: many0!(
@@ -107,6 +111,7 @@ named!(expr< CompleteStr, Expr >, do_parse!(
     (fold_exprs(initial, remainder))
 ));
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[test]
 fn factor_test() {
   assert_eq!(
@@ -116,6 +121,7 @@ fn factor_test() {
 }
 
 #[test]
+#[cfg(any(feature = "alloc", feature = "std"))]
 fn term_test() {
   assert_eq!(
     term(CompleteStr(" 3 *  5   ")).map(|(i, x)| (i, format!("{:?}", x))),
@@ -124,6 +130,7 @@ fn term_test() {
 }
 
 #[test]
+#[cfg(any(feature = "alloc", feature = "std"))]
 fn expr_test() {
   assert_eq!(
     expr(CompleteStr(" 1 + 2 *  3 ")).map(|(i, x)| (i, format!("{:?}", x))),
@@ -139,6 +146,7 @@ fn expr_test() {
   );
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[test]
 fn parens_test() {
   assert_eq!(

--- a/tests/css.rs
+++ b/tests/css.rs
@@ -41,7 +41,7 @@ fn parse_color() {
         red: 47,
         green: 20,
         blue: 223,
-      }
+      },
     ))
   );
 }

--- a/tests/custom_errors.rs
+++ b/tests/custom_errors.rs
@@ -25,9 +25,7 @@ fn test2(input: &str) -> IResult<&str, &str, CustomError> {
 }
 
 fn test3(input: &str) -> IResult<&str, &str, CustomError> {
-  verify!(input, test1, |s: &str| {
-    s.starts_with("abcd")
-  })
+  verify!(input, test1, |s: &str| s.starts_with("abcd"))
 }
 
 #[cfg(feature = "alloc")]

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -35,6 +35,7 @@ named!(key_value    <CompleteByteSlice,(&str,&str)>,
   )
 );
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 named!(keys_and_values<CompleteByteSlice, HashMap<&str, &str> >,
   map!(
     many0!(terminated!(key_value, opt!(multispace))),
@@ -42,6 +43,7 @@ named!(keys_and_values<CompleteByteSlice, HashMap<&str, &str> >,
   )
 );
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 named!(category_and_keys<CompleteByteSlice,(&str,HashMap<&str,&str>)>,
   do_parse!(
     category: category         >>
@@ -51,6 +53,7 @@ named!(category_and_keys<CompleteByteSlice,(&str,HashMap<&str,&str>)>,
   )
 );
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 named!(categories<CompleteByteSlice, HashMap<&str, HashMap<&str,&str> > >,
   map!(
     many0!(
@@ -148,6 +151,7 @@ key = value2",
   assert_eq!(res, Ok((ini_without_key_value, ("parameter", "value"))));
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[test]
 fn parse_multiple_keys_and_values_test() {
   let ini_file = CompleteByteSlice(
@@ -173,7 +177,8 @@ key = value2
   assert_eq!(res, Ok((ini_without_key_value, expected)));
 }
 
-#[test]
+
+#[cfg(any(feature = "alloc", feature = "std"))]#[test]
 fn parse_category_then_multiple_keys_and_values_test() {
   //FIXME: there can be an empty line or a comment line after a category
   let ini_file = CompleteByteSlice(
@@ -200,6 +205,7 @@ key = value2
   assert_eq!(res, Ok((ini_after_parser, ("abcd", expected_h))));
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[test]
 fn parse_multiple_categories_test() {
   let ini_file = CompleteByteSlice(

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -59,8 +59,10 @@ named!(key_value    <CompleteStr,(&str,&str)>,
   )
 );
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 named!(keys_and_values_aggregator<CompleteStr, Vec<(&str, &str)> >, many0!(key_value));
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 fn keys_and_values(input: CompleteStr) -> IResult<CompleteStr, HashMap<&str, &str>> {
   match keys_and_values_aggregator(input) {
     Ok((i, tuple_vec)) => Ok((i, tuple_vec.into_iter().collect())),
@@ -68,12 +70,15 @@ fn keys_and_values(input: CompleteStr) -> IResult<CompleteStr, HashMap<&str, &st
   }
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 named!(category_and_keys<CompleteStr,(&str,HashMap<&str,&str>)>,
   pair!(category, keys_and_values)
 );
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 named!(categories_aggregator<CompleteStr, Vec<(&str, HashMap<&str,&str>)> >, many0!(category_and_keys));
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 fn categories(input: CompleteStr) -> IResult<CompleteStr, HashMap<&str, HashMap<&str, &str>>> {
   match categories_aggregator(input) {
     Ok((i, tuple_vec)) => Ok((i, tuple_vec.into_iter().collect())),
@@ -162,6 +167,7 @@ key = value2",
   assert_eq!(res, Ok((ini_without_key_value, ("parameter", "value"))));
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[test]
 fn parse_multiple_keys_and_values_test() {
   let ini_file = CompleteStr(
@@ -187,6 +193,7 @@ key = value2
   assert_eq!(res, Ok((ini_without_key_value, expected)));
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[test]
 fn parse_category_then_multiple_keys_and_values_test() {
   //FIXME: there can be an empty line or a comment line after a category
@@ -214,6 +221,7 @@ key = value2
   assert_eq!(res, Ok((ini_after_parser, ("abcd", expected_h))));
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[test]
 fn parse_multiple_categories_test() {
   let ini_file = CompleteStr(

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -48,6 +48,7 @@ named!(range<&[u8], Range>,
     )
 );
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[allow(dead_code)]
 named!(literal<&[u8], Vec<char> >,
     map!(
@@ -58,6 +59,7 @@ named!(literal<&[u8], Vec<char> >,
     )
 );
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[test]
 fn issue_58() {
   let _ = range(&b"abcd"[..]);
@@ -135,6 +137,7 @@ fn take_till_issue() {
   assert_eq!(nothing(b"abc"), Ok((&b"abc"[..], &b""[..])));
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 named!(
   issue_498<Vec<&[u8]>>,
   separated_nonempty_list!(opt!(space), tag!("abcd"))
@@ -176,6 +179,7 @@ fn issue_655() {
 #[cfg(feature = "std")]
 named!(issue_666 <CompleteByteSlice, CompleteByteSlice>, dbg_dmp!(tag!("abc")));
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[test]
 fn issue_667() {
   use nom::alpha;

--- a/tests/multiline.rs
+++ b/tests/multiline.rs
@@ -13,16 +13,22 @@ pub fn read_line(input: CompleteStr) -> IResult<CompleteStr, CompleteStr> {
   terminated!(input, alphanumeric, end_of_line)
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub fn read_lines(input: CompleteStr) -> IResult<CompleteStr, Vec<CompleteStr>> {
   many0!(input, read_line)
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[cfg(feature = "alloc")]
 #[test]
 fn read_lines_test() {
   let res = Ok((
     CompleteStr(""),
-    vec![CompleteStr("Duck"), CompleteStr("Dog"), CompleteStr("Cow")],
+    vec![
+      CompleteStr("Duck"),
+      CompleteStr("Dog"),
+      CompleteStr("Cow"),
+    ],
   ));
 
   assert_eq!(read_lines(CompleteStr("Duck\nDog\nCow\n")), res);


### PR DESCRIPTION
This *should* fix #473 (it has fixed it for me). I didn't add any tests since the issue was that the library was using `std` instead of `core` even in a `no_std` context. 

What I've done is what serde does -- made a `lib` module that is a facade over `std` and reexports various things from there or `core` depending. This had to be public to be used in macros. 

P.S: I apologise if I've done something wrong!