### PR TITLE
Add a conversion from &str to CompleteStr

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,7 @@ use traits::{AsBytes, AtEof, Compare, CompareResult, ExtendInto, FindSubstring, 
              ParseTo, Slice};
 
 use std::str::{self, CharIndices, Chars, FromStr};
+use std::convert::From;
 use std::ops::{Deref, Range, RangeFrom, RangeFull, RangeTo};
 use std::iter::{Enumerate, Map};
 use std::slice::Iter;
@@ -15,6 +16,12 @@ use std::slice::Iter;
 /// and `Incomplete` results.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct CompleteStr<'a>(pub &'a str);
+
+impl<'a> From<&'a str> for CompleteStr<'a> {
+  fn from(src: &'a str) -> Self {
+    CompleteStr(src)
+  }
+}
 
 impl<'a> Deref for CompleteStr<'a> {
   type Target = str;

--- a/src/types.rs
+++ b/src/types.rs
@@ -23,11 +23,17 @@ impl<'a> From<&'a str> for CompleteStr<'a> {
   }
 }
 
-impl<'a> Deref for CompleteStr<'a> {
-  type Target = str;
+impl<'a, 'b> From<&'b &'a str> for CompleteStr<'a> {
+  fn from(src: &'b &'a str) -> Self {
+    CompleteStr(*src)
+  }
+}
 
-  fn deref(&self) -> &str {
-    self.0
+impl<'a> Deref for CompleteStr<'a> {
+  type Target = &'a str;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
   }
 }
 
@@ -167,18 +173,30 @@ impl<'a> ExtendInto for CompleteStr<'a> {
   }
 }
 
-/// Holds a complete String, for which the `at_eof` method always returns true
+/// Holds a complete byte array, for which the `at_eof` method always returns true
 ///
 /// This means that this input type will completely avoid nom's streaming features
 /// and `Incomplete` results.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct CompleteByteSlice<'a>(pub &'a [u8]);
 
-impl<'a> Deref for CompleteByteSlice<'a> {
-  type Target = [u8];
+impl<'a> From<&'a [u8]> for CompleteByteSlice<'a> {
+  fn from(src: &'a [u8]) -> Self {
+    CompleteByteSlice(src)
+  }
+}
 
-  fn deref(&self) -> &[u8] {
-    self.0
+impl<'a, 'b> From<&'b &'a [u8]> for CompleteByteSlice<'a> {
+  fn from(src: &'b &'a [u8]) -> Self {
+    CompleteByteSlice(*src)
+  }
+}
+
+impl<'a> Deref for CompleteByteSlice<'a> {
+  type Target = &'a [u8];
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
   }
 }
 


### PR DESCRIPTION
This commit expands on the addition of `Deref<Target=&str>` and provides a means of downcasting an `&str` into a `CompleteStr`.

This should not be used arbitrarily, but is an excellent convenience for manipulating `CompleteStr`s using `&str` methods. Since the `Deref` work always returns bare `&str`s, even from string slices that are known to be `CompleteStr`, converting back into `CompleteStr` is safe and useful.