### PR TITLE
Implement Display on CompleteStr

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,7 @@ use traits::{AsBytes, AtEof, Compare, CompareResult, ExtendInto, FindSubstring, 
              ParseTo, Slice};
 
 use std::str::{self, CharIndices, Chars, FromStr};
+use std::fmt::Display;
 use std::ops::{Deref, Range, RangeFrom, RangeFull, RangeTo};
 use std::iter::{Enumerate, Map};
 use std::slice::Iter;
@@ -15,6 +16,12 @@ use std::slice::Iter;
 /// and `Incomplete` results.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct CompleteStr<'a>(pub &'a str);
+
+impl<'a> Display for CompleteStr<'a> {
+  fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    self.0.fmt(f)
+  }
+}
 
 impl<'a> Deref for CompleteStr<'a> {
   type Target = str;


### PR DESCRIPTION
This is Rust's preferred way of creating a ToString::to_string impl on a type

Since `impl<'a> From<CompleteStr<'a>> for String` is an orphan impl and thus disallowed, we cannot create a `String::from` function that accepts `CompleteStr`. Furthermore, implementing `Into` directly is bad practice because of the blanket impl in std.

The correct way to serialize a value into a type is not `String::from` or `Into::<String>::into`, but `ToString::to_string` ... which has a blanket impl powered by `Display`.

So this commit implements `Display` on `CompleteStr` in order to create `CompleteStr::to_string`.