### PR TITLE
Fix the coveralls step in the travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
-sudo: false
+# sudo is required to enable kcov to use the personality syscall
+sudo: required
 dist: trusty
 cache: cargo
 


### PR DESCRIPTION
The coveralls step in the Travis CI seems to be broken since few days.

The reason was: 
> Can't set personality: Operation not permitted
> kcov: error: Can't start/attach to /home/travis/build/Geal/nom/target/debug/deps/nom-1bf2433837785ec3

Fore more details: [travis-ci.org/Geal/nom#L2100](https://travis-ci.org/Geal/nom/jobs/361140317#L2100)

That related to [travis-ci#9061](https://github.com/travis-ci/travis-ci/issues/9061).

The fix is to set sudo at `required` in `.travis.yml`.