### PR TITLE
Some tests are constrained just on alloc

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1289,6 +1289,8 @@ macro_rules! recognize (
 mod tests {
   use internal::{Err, IResult, Needed};
   use util::ErrorKind;
+  #[cfg(feature = "alloc")]
+  use std::boxed::Box;
 
   // reproduce the tag and take macros, because of module import order
   macro_rules! tag (
@@ -1414,7 +1416,7 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn cond() {
     let f_true: Box<Fn(&'static [u8]) -> IResult<&[u8], Option<&[u8]>, CustomError>> = Box::new(closure!(
       &'static [u8],
@@ -1436,7 +1438,7 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn cond_wrapping() {
     // Test that cond!() will wrap a given identifier in the call!() macro.
     named!(tag_abcd, tag!("abcd"));

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -1031,6 +1031,8 @@ mod tests {
   use internal::{Err, IResult, Needed};
   use nom::{digit, be_u16, be_u8, le_u16};
   use std::str::{self, FromStr};
+  #[cfg(feature = "alloc")]
+  use std::vec::Vec;
   use util::ErrorKind;
 
   // reproduce the tag and take macros, because of module import order
@@ -1087,7 +1089,7 @@ mod tests {
   );
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn separated_list() {
     named!(multi<&[u8],Vec<&[u8]> >, separated_list!(tag!(","), tag!("abcd")));
     named!(multi_empty<&[u8],Vec<&[u8]> >, separated_list!(tag!(","), tag!("")));
@@ -1122,7 +1124,7 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn separated_list_complete() {
     use nom::alpha;
 
@@ -1149,7 +1151,7 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn separated_nonempty_list() {
     named!(multi<&[u8],Vec<&[u8]> >, separated_nonempty_list!(tag!(","), tag!("abcd")));
     named!(multi_longsep<&[u8],Vec<&[u8]> >, separated_nonempty_list!(tag!(".."), tag!("abcd")));
@@ -1180,7 +1182,7 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn separated_nonempty_list_complete() {
     use nom::alpha;
 
@@ -1210,7 +1212,7 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn many0() {
     named!(tag_abcd, tag!("abcd"));
     named!(tag_empty, tag!(""));
@@ -1246,7 +1248,7 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn many1() {
     named!(multi<&[u8],Vec<&[u8]> >, many1!(tag!("abcd")));
 
@@ -1267,7 +1269,7 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn many_till() {
     named!(multi<&[u8], (Vec<&[u8]>, &[u8]) >, many_till!( tag!( "abcd" ), tag!( "efgh" ) ) );
 
@@ -1311,7 +1313,7 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn many_m_n() {
     named!(multi<&[u8],Vec<&[u8]> >, many_m_n!(2, 4, tag!("Abcd")));
 
@@ -1335,7 +1337,7 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn count() {
     const TIMES: usize = 2;
     named!(tag_abc, tag!("abc"));
@@ -1368,7 +1370,7 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn count_zero() {
     const TIMES: usize = 0;
     named!(tag_abc, tag!("abc"));
@@ -1510,7 +1512,7 @@ mod tests {
   ));
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn length_count() {
     named!(tag_abc, tag!(&b"abc"[..]));
     named!( cnt<&[u8], Vec<&[u8]> >, length_count!(number, tag_abc) );
@@ -1585,7 +1587,7 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn fold_many0() {
     fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
       acc.push(item);
@@ -1615,7 +1617,7 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn fold_many1() {
     fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
       acc.push(item);
@@ -1640,7 +1642,7 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn fold_many_m_n() {
     fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
       acc.push(item);

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -730,25 +730,25 @@ where
 }
 
 /// Recognizes floating point number in a byte string and returns a f32
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub fn float(input: &[u8]) -> IResult<&[u8], f32> {
   flat_map!(input, recognize_float, parse_to!(f32))
 }
 
 /// Recognizes floating point number in a string and returns a f32
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub fn float_s(input: &str) -> IResult<&str, f32> {
   flat_map!(input, call!(recognize_float), parse_to!(f32))
 }
 
 /// Recognizes floating point number in a byte string and returns a f64
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub fn double(input: &[u8]) -> IResult<&[u8], f64> {
   flat_map!(input, call!(recognize_float), parse_to!(f64))
 }
 
 /// Recognizes floating point number in a string and returns a f64
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub fn double_s(input: &str) -> IResult<&str, f64> {
   flat_map!(input, call!(recognize_float), parse_to!(f64))
 }
@@ -1078,8 +1078,9 @@ mod tests {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn buffer_with_size() {
+    use std::vec::Vec;
     let i: Vec<u8> = vec![7, 8];
     let o: Vec<u8> = vec![4, 5, 6];
     //let arr:[u8; 6usize] = [3, 4, 5, 6, 7, 8];

--- a/src/str.rs
+++ b/src/str.rs
@@ -759,7 +759,7 @@ mod test {
   }
 
   #[test]
-  #[cfg(feature = "std")]
+  #[cfg(feature = "alloc")]
   fn recognize_is_a_s() {
     let a = "aabbab";
     let b = "ababcd";

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -231,7 +231,7 @@ fn issue_721() {
   assert_eq!(parse_to!("foo", String), Ok(("", "foo".to_string())));
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 named!(issue_717<&[u8], Vec<&[u8]> >,
   separated_list!(tag!([0x0]), is_not!([0x0u8]))
 );

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -65,7 +65,7 @@ fn overflow_incomplete_many0() {
 }
 
 #[test]
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 fn overflow_incomplete_many1() {
   named!(multi<&[u8], Vec<&[u8]> >, many1!( length_bytes!(be_u64) ) );
 


### PR DESCRIPTION
Hi! I checked one by one tests tagged by `std` feature to find out which one could be run also in `alloc` mode (as `std` enables `alloc`) to extend code coverage.

Initially, I just tried to investigate #706, which just looks like to work correctly...