### PR TITLE
Fix doctest formatting

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -126,6 +126,7 @@ macro_rules! bits_impl (
 ///
 /// A partial byte remaining in the input will be ignored and the given parser will start parsing
 /// at the next full byte.
+///
 /// ```
 /// # #[macro_use] extern crate nom;
 /// # use nom::rest;
@@ -255,6 +256,7 @@ macro_rules! bytes_impl (
 ///
 /// Signature:
 /// `take_bits!(type, count) => ( (&[T], usize), U, usize) -> IResult<(&[T], usize), U>`
+///
 /// ```
 /// # #[macro_use] extern crate nom;
 /// # fn main() {
@@ -326,6 +328,7 @@ macro_rules! take_bits (
 ///
 /// The caller must specify the number of bits to consume. The matched value is included in the
 /// result on success.
+///
 /// ```
 /// # #[macro_use] extern crate nom;
 /// # fn main() {

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -45,6 +45,7 @@
 //! invoked. A `method!` invocation always has to have the type of `self`
 //! declared and it can't be a reference due to Rust's borrow lifetime
 //! restrictions:
+//!
 //! ```ignore
 //! //                  -`self`'s type-
 //! method!(method_name<  Parser<'a> >, ...);
@@ -52,6 +53,7 @@
 //! `self`'s type always comes first.
 //! The next difference is you have to input the self struct. Due to Rust's
 //! macro hygiene the macro can't declare it on it's own.
+//!
 //! ```ignore
 //! //                                                 -self-
 //! method!(method_name<Parser<'a>, &'a str, &'a str>, self, ...);
@@ -63,6 +65,7 @@
 //! method will return self to the caller.
 //!
 //! To call a method on self you need to use the `call_m!` macro. For example:
+//!
 //! ```ignore
 //! struct<'a> Parser<'a> {
 //!   parsed: &'a str,
@@ -75,6 +78,7 @@
 //! ```
 //! More complicated combinations still mostly look the same as their `named!`
 //! counterparts:
+//!
 //! ```ignore
 //!    method!(pub simple_chain<&mut Parser<'a>, &'a str, &'a str>, self,
 //!      do_parse!(

--- a/src/str.rs
+++ b/src/str.rs
@@ -166,6 +166,7 @@ macro_rules! take_while_s (
 /// returns the longest (non empty) list of characters until the provided function fails.
 ///
 /// The argument is either a function `char -> bool` or a macro returning a `bool`
+///
 /// ```
 /// # #[macro_use] extern crate nom;
 /// # use nom::is_alphanumeric;


### PR DESCRIPTION
It seems that rustdoc had previously ignored doctests which were not immediately preceded by an empty line and (on 1.25.0 stable) I'm now getting warnings about all such doctests, indicating that a future release of doctest will enable them. This PR adds an empty line before all such doctests, which silences the warnings and enables them (unless they are marked `ignore`).