### PR TITLE
Implement ExtendInto for &str and &[u8]

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1089,7 +1089,37 @@ impl ExtendInto for [u8] {
 }
 
 #[cfg(feature = "alloc")]
+impl<'a> ExtendInto for &'a [u8] {
+  type Item = u8;
+  type Extender = Vec<u8>;
+
+  #[inline]
+  fn new_builder(&self) -> Vec<u8> {
+    Vec::new()
+  }
+  #[inline]
+  fn extend_into(&self, acc: &mut Vec<u8>) {
+    acc.extend(self.iter().cloned());
+  }
+}
+
+#[cfg(feature = "alloc")]
 impl ExtendInto for str {
+  type Item = char;
+  type Extender = String;
+
+  #[inline]
+  fn new_builder(&self) -> String {
+    String::new()
+  }
+  #[inline]
+  fn extend_into(&self, acc: &mut String) {
+    acc.push_str(self);
+  }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> ExtendInto for &'a str {
   type Item = char;
   type Extender = String;
 


### PR DESCRIPTION
This is useful when writing parser generic over input.

Example:
```rust
fn some_parser<I>(input: I) -> IResult<I, SomeType>
    where I: ExtendInto + ...
{...}

some_parser(CompleteStr("str"));
some_parser("str"); // Needs &str: ExtendInto
```