### PR TITLE
Implement Error (and Display) for nom::Err

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -80,6 +80,35 @@ pub enum Err<I, E = u32> {
   Failure(Context<I, E>),
 }
 
+use std::fmt;
+impl<I, E> fmt::Display for Err<I, E>
+where
+  I: fmt::Debug,
+  E: fmt::Debug,
+{
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "{:?}", self)
+  }
+}
+
+use std::error::Error;
+impl<I, E> Error for Err<I, E>
+where
+  I: fmt::Debug,
+  E: fmt::Debug,
+{
+  fn description(&self) -> &str {
+    match self {
+      Err::Incomplete(..) => "there was not enough data",
+      Err::Error(Context::Code(_, error_kind)) | Err::Failure(Context::Code(_, error_kind)) => error_kind.description(),
+    }
+  }
+
+  fn cause(&self) -> Option<&Error> {
+    None
+  }
+}
+
 use util::Convert;
 
 impl<I, F, E: From<F>> Convert<Err<I, F>> for Err<I, E> {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -80,7 +80,10 @@ pub enum Err<I, E = u32> {
   Failure(Context<I, E>),
 }
 
+#[cfg(feature = "std")]
 use std::fmt;
+
+#[cfg(feature = "std")]
 impl<I, E> fmt::Display for Err<I, E>
 where
   I: fmt::Debug,
@@ -91,7 +94,10 @@ where
   }
 }
 
+#[cfg(feature = "std")]
 use std::error::Error;
+
+#[cfg(feature = "std")]
 impl<I, E> Error for Err<I, E>
 where
   I: fmt::Debug,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -99,8 +99,10 @@ where
 {
   fn description(&self) -> &str {
     match self {
-      Err::Incomplete(..) => "there was not enough data",
-      Err::Error(Context::Code(_, error_kind)) | Err::Failure(Context::Code(_, error_kind)) => error_kind.description(),
+      &Err::Incomplete(..) => "there was not enough data",
+      &Err::Error(Context::Code(_, ref error_kind)) | &Err::Failure(Context::Code(_, ref error_kind)) => error_kind.description(),
+      #[cfg(feature = "verbose-errors")]
+      &Err::Error(Context::List(..)) | &Err::Failure(Context::List(..)) => "list of errors",
     }
   }
 


### PR DESCRIPTION
This allows  the use of `?` inside a function whose output type is `Result<_, Box<Error>>`

Example:
```rust
named!(some_parser, ...);
fn some_fn() -> Result<SomeType, Box<Error>> {
    let value = some_parser(...)?;
    ...
}
```

[`Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html) is implemented only because [`Error`](https://doc.rust-lang.org/std/error/trait.Error.html) depends on it.