### PR TITLE
Fix unused import warning in `eat_separator!`

### DIFF
--- a/src/whitespace.rs
+++ b/src/whitespace.rs
@@ -714,7 +714,7 @@ macro_rules! separated_list_sep (
 macro_rules! eat_separator (
   ($i:expr, $arr:expr) => (
     {
-      use $crate::{ErrorKind, FindToken, InputTakeAtPosition};
+      use $crate::{FindToken, InputTakeAtPosition};
       let input = $i;
       input.split_at_position(|c| !$arr.find_token(c))
     }


### PR DESCRIPTION
Compiler shows **warning: unused import: `ErrorKind`** with the following code:
``` rust
let _ = eat_separator!(nom::types::CompleteStr("\r\n"), "\r\n");
```

