### PR TITLE
Remove unused import.

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -823,7 +823,6 @@ macro_rules! take_until1 (
       use $crate::InputLength;
       use $crate::FindSubstring;
       use $crate::InputTake;
-      use $crate::AtEof;
       let input = $i;
 
       let res: IResult<_,_> = match input.find_substring($substr) {


### PR DESCRIPTION
This generates a warning everytime take_until1 is used.
