### PR TITLE
impl AsRef<str> for CompleteStr

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -40,6 +40,12 @@ impl<'a> Display for CompleteStr<'a> {
   }
 }
 
+impl<'a> AsRef<str> for CompleteStr<'a> {
+  fn as_ref(&self) -> &str {
+    self.0
+  }
+}
+
 impl<'a> Deref for CompleteStr<'a> {
   type Target = &'a str;
 


### PR DESCRIPTION
This allows a `CompleteStr` to inter-operate with more existing string-y methods, like ones accepting a..

```rust
fn foo<S: AsRef<str>>(string: S) -> ..
```
..which is pretty common, and [(kinda?) recommended by the stdlib](https://doc.rust-lang.org/std/convert/trait.AsRef.html#examples). 