### PR TITLE
Feature/warnings

### DIFF
--- a/src/branch.rs
+++ b/src/branch.rs
@@ -198,6 +198,7 @@ macro_rules! alt (
 
           // Compile-time hack to ensure that res's E type is not under-specified.
           // This all has no effect at runtime.
+          #[allow(dead_code)]
           fn unify_types<T>(_: &T, _: &T) {}
           if let Err(Err::Error(ref e2)) = out {
             unify_types(&e, e2);

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -597,6 +597,7 @@ macro_rules! take_till1 (
   ($input:expr, $submac:ident!( $($args:tt)* )) => (
     {
       use $crate::InputTakeAtPosition;
+      use $crate::ErrorKind;
       let input = $input;
       input.split_at_position1(|c| $submac!(c, $($args)*), ErrorKind::TakeTill1)
     }


### PR DESCRIPTION
Silence a missing import error and a dead code warning

It seems that alt! does not always use the unify_types function, though I haven't been able to isolate exactly why.