### PR TITLE
Inline Deref for CompleteStr/CompleteByteSlice

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -49,6 +49,7 @@ impl<'a> AsRef<str> for CompleteStr<'a> {
 impl<'a> Deref for CompleteStr<'a> {
   type Target = &'a str;
 
+  #[inline]
   fn deref(&self) -> &Self::Target {
     &self.0
   }
@@ -212,6 +213,7 @@ impl<'a, 'b> From<&'b &'a [u8]> for CompleteByteSlice<'a> {
 impl<'a> Deref for CompleteByteSlice<'a> {
   type Target = &'a [u8];
 
+  #[inline]
   fn deref(&self) -> &Self::Target {
     &self.0
   }


### PR DESCRIPTION
While upgrading to Nom 4.0.0, I noticed that in the compiled binary, there were plenty of calls Deref method of CompleteStr. Considering this function is pretty much a no-op, gets called automatically when you want to call a `str` method, having to call it confuses compiler optimizations there is no reason for it to compile into an actual call.

An alternative would be for an user to use LTO.