### PR TITLE
Reformat code with rustfmt

### DIFF
--- a/benches/arithmetic.rs
+++ b/benches/arithmetic.rs
@@ -4,8 +4,8 @@ extern crate test;
 #[macro_use]
 extern crate nom;
 
-use test::Bencher;
 use nom::digit;
+use test::Bencher;
 
 // Parser definition
 
@@ -30,34 +30,26 @@ named!(
 named!(
   term<i64>,
   do_parse!(
-    init: factor
-      >> res:
-        fold_many0!(
-          pair!(alt!(tag!("*") | tag!("/")), factor),
-          init,
-          |acc, (op, val): (&[u8], i64)| if (op[0] as char) == '*' {
-            acc * val
-          } else {
-            acc / val
-          }
-        ) >> (res)
+    init: factor >> res: fold_many0!(pair!(alt!(tag!("*") | tag!("/")), factor), init, |acc, (op, val): (&[u8], i64)| {
+      if (op[0] as char) == '*' {
+        acc * val
+      } else {
+        acc / val
+      }
+    }) >> (res)
   )
 );
 
 named!(
   expr<i64>,
   do_parse!(
-    init: term
-      >> res:
-        fold_many0!(
-          pair!(alt!(tag!("+") | tag!("-")), term),
-          init,
-          |acc, (op, val): (&[u8], i64)| if (op[0] as char) == '+' {
-            acc + val
-          } else {
-            acc - val
-          }
-        ) >> (res)
+    init: term >> res: fold_many0!(pair!(alt!(tag!("+") | tag!("-")), term), init, |acc, (op, val): (&[u8], i64)| {
+      if (op[0] as char) == '+' {
+        acc + val
+      } else {
+        acc - val
+      }
+    }) >> (res)
   )
 );
 

--- a/benches/ini.rs
+++ b/benches/ini.rs
@@ -6,17 +6,13 @@ extern crate nom;
 
 use nom::{alphanumeric, multispace, space};
 
-use std::str;
 use std::collections::HashMap;
+use std::str;
 
 named!(
   category<&str>,
   map_res!(
-    delimited!(
-      char!('['),
-      take_while!(call!(|c| c != ']' as u8)),
-      char!(']')
-    ),
+    delimited!(char!('['), take_while!(call!(|c| c != ']' as u8)), char!(']')),
     str::from_utf8
   )
 );

--- a/benches/ini_complete.rs
+++ b/benches/ini_complete.rs
@@ -4,11 +4,11 @@ extern crate test;
 #[macro_use]
 extern crate nom;
 
-use nom::{alphanumeric, multispace, space};
 use nom::types::CompleteByteSlice;
+use nom::{alphanumeric, multispace, space};
 
-use std::str;
 use std::collections::HashMap;
+use std::str;
 
 named!(category<CompleteByteSlice, &str>, map_res!(
     delimited!(

--- a/benches/json.rs
+++ b/benches/json.rs
@@ -9,8 +9,8 @@ use nom::{alphanumeric, recognize_float};
 
 use test::Bencher;
 
-use std::str;
 use std::collections::HashMap;
+use std::str;
 
 #[derive(Debug, PartialEq)]
 pub enum JsonValue {
@@ -28,46 +28,26 @@ named!(
   string<&str>,
   delimited!(
     char!('\"'),
-    map_res!(
-      escaped!(call!(alphanumeric), '\\', one_of!("\"n\\")),
-      str::from_utf8
-    ),
+    map_res!(escaped!(call!(alphanumeric), '\\', one_of!("\"n\\")), str::from_utf8),
     //map_res!(escaped!(take_while1!(is_alphanumeric), '\\', one_of!("\"n\\")), str::from_utf8),
     char!('\"')
   )
 );
 
-named!(
-  boolean<bool>,
-  alt!(value!(false, tag!("false")) | value!(true, tag!("true")))
-);
+named!(boolean<bool>, alt!(value!(false, tag!("false")) | value!(true, tag!("true"))));
 
 named!(
   array<Vec<JsonValue>>,
-  ws!(delimited!(
-    char!('['),
-    separated_list!(char!(','), value),
-    char!(']')
-  ))
+  ws!(delimited!(char!('['), separated_list!(char!(','), value), char!(']')))
 );
 
-named!(
-  key_value<(&str, JsonValue)>,
-  ws!(separated_pair!(string, char!(':'), value))
-);
+named!(key_value<(&str, JsonValue)>, ws!(separated_pair!(string, char!(':'), value)));
 
 named!(
   hash<HashMap<String, JsonValue>>,
   ws!(map!(
-    delimited!(
-      char!('{'),
-      separated_list!(char!(','), key_value),
-      char!('}')
-    ),
-    |tuple_vec| tuple_vec
-      .into_iter()
-      .map(|(k, v)| (String::from(k), v))
-      .collect()
+    delimited!(char!('{'), separated_list!(char!(','), key_value), char!('}')),
+    |tuple_vec| tuple_vec.into_iter().map(|(k, v)| (String::from(k), v)).collect()
   ))
 );
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,2 @@
 tab_spaces = 2
-struct_field_align_threshold = 100
 max_width = 140

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -369,8 +369,8 @@ macro_rules! tag_bits (
 
 #[cfg(test)]
 mod tests {
-  use lib::std::ops::{AddAssign, Shl, Shr};
   use internal::{Err, Needed};
+  use lib::std::ops::{AddAssign, Shl, Shr};
   use util::ErrorKind;
 
   #[test]
@@ -392,10 +392,7 @@ mod tests {
     assert_eq!(take_bits!((sl, 6), u16, 11), Ok(((&sl[2..], 1), 1504)));
     assert_eq!(take_bits!((sl, 0), u32, 20), Ok(((&sl[2..], 4), 700_163)));
     assert_eq!(take_bits!((sl, 4), u32, 20), Ok(((&sl[3..], 0), 716_851)));
-    assert_eq!(
-      take_bits!((sl, 4), u32, 22),
-      Err(Err::Incomplete(Needed::Size(22)))
-    );
+    assert_eq!(take_bits!((sl, 4), u32, 22), Err(Err::Incomplete(Needed::Size(22))));
   }
 
   #[test]
@@ -473,17 +470,8 @@ mod tests {
     let input = [0b10_10_10_10, 0b11_11_00_00, 0b00_11_00_11];
     let sl = &input[..];
 
-    assert_eq!(
-      take_bits!((sl, 0), FakeUint, 20),
-      Ok(((&sl[2..], 4), FakeUint(700_163)))
-    );
-    assert_eq!(
-      take_bits!((sl, 4), FakeUint, 20),
-      Ok(((&sl[3..], 0), FakeUint(716_851)))
-    );
-    assert_eq!(
-      take_bits!((sl, 4), FakeUint, 22),
-      Err(Err::Incomplete(Needed::Size(22)))
-    );
+    assert_eq!(take_bits!((sl, 0), FakeUint, 20), Ok(((&sl[2..], 4), FakeUint(700_163))));
+    assert_eq!(take_bits!((sl, 4), FakeUint, 20), Ok(((&sl[3..], 0), FakeUint(716_851))));
+    assert_eq!(take_bits!((sl, 4), FakeUint, 22), Err(Err::Incomplete(Needed::Size(22))));
   }
 }

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -852,9 +852,9 @@ macro_rules! permutation_iterator (
 
 #[cfg(test)]
 mod tests {
+  use internal::{Err, IResult, Needed};
   #[cfg(feature = "alloc")]
   use lib::std::string::{String, ToString};
-  use internal::{Err, IResult, Needed};
   use util::ErrorKind;
 
   // reproduce the tag and take macros, because of module import order
@@ -945,10 +945,7 @@ mod tests {
     #[allow(unused_variables)]
     fn dont_work(input: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
       use Context;
-      Err(Err::Error(Context::Code(
-        &b""[..],
-        ErrorKind::Custom(ErrorStr("abcd".to_string())),
-      )))
+      Err(Err::Error(Context::Code(&b""[..], ErrorKind::Custom(ErrorStr("abcd".to_string())))))
     }
 
     fn work2(input: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
@@ -979,10 +976,7 @@ mod tests {
     assert_eq!(alt4(b), Ok((&b""[..], b)));
 
     // test the alternative syntax
-    named!(
-      alt5<bool>,
-      alt!(tag!("abcd") => { |_| false } | tag!("efgh") => { |_| true })
-    );
+    named!(alt5<bool>, alt!(tag!("abcd") => { |_| false } | tag!("efgh") => { |_| true }));
     assert_eq!(alt5(a), Ok((&b""[..], false)));
     assert_eq!(alt5(b), Ok((&b""[..], true)));
 
@@ -1041,13 +1035,7 @@ mod tests {
     let b = &b"efghijkl"[..];
     assert_eq!(sw(b), Ok((&b""[..], &b"ijkl"[..])));
     let c = &b"afghijkl"[..];
-    assert_eq!(
-      sw(c),
-      Err(Err::Error(error_position!(
-        &b"afghijkl"[..],
-        ErrorKind::Switch
-      )))
-    );
+    assert_eq!(sw(c), Err(Err::Error(error_position!(&b"afghijkl"[..], ErrorKind::Switch))));
 
     let a = &b"xxxxefgh"[..];
     assert_eq!(sw(a), Ok((&b"gh"[..], &b"ef"[..])));
@@ -1055,10 +1043,7 @@ mod tests {
 
   #[test]
   fn permutation() {
-    named!(
-      perm<(&[u8], &[u8], &[u8])>,
-      permutation!(tag!("abcd"), tag!("efg"), tag!("hi"))
-    );
+    named!(perm<(&[u8], &[u8], &[u8])>, permutation!(tag!("abcd"), tag!("efg"), tag!("hi")));
 
     let expected = (&b"abcd"[..], &b"efg"[..], &b"hi"[..]);
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1077,15 +1077,15 @@ macro_rules! length_bytes(
 #[cfg(test)]
 mod tests {
   use internal::{Err, Needed};
-  use nom::{alpha, alphanumeric, digit, hex_digit, multispace, oct_digit, space};
-  use types::{CompleteByteSlice, CompleteStr};
-  use util::ErrorKind;
   #[cfg(feature = "alloc")]
   #[cfg(feature = "verbose-errors")]
   use lib::std::string::String;
   #[cfg(feature = "alloc")]
   #[cfg(feature = "verbose-errors")]
   use lib::std::vec::Vec;
+  use nom::{alpha, alphanumeric, digit, hex_digit, multispace, oct_digit, space};
+  use types::{CompleteByteSlice, CompleteStr};
+  use util::ErrorKind;
 
   macro_rules! one_of (
     ($i:expr, $inp: expr) => (
@@ -1147,10 +1147,7 @@ mod tests {
     assert_eq!(a_or_b(b), Ok((&b"cde"[..], &b"b"[..])));
 
     let c = &b"cdef"[..];
-    assert_eq!(
-      a_or_b(c),
-      Err(Err::Error(error_position!(c, ErrorKind::IsA::<u32>)))
-    );
+    assert_eq!(a_or_b(c), Err(Err::Error(error_position!(c, ErrorKind::IsA::<u32>))));
 
     let d = &b"bacdef"[..];
     assert_eq!(a_or_b(d), Ok((&b"cdef"[..], &b"ba"[..])));
@@ -1167,10 +1164,7 @@ mod tests {
     assert_eq!(a_or_b(b), Ok((&b"bde"[..], &b"c"[..])));
 
     let c = &b"abab"[..];
-    assert_eq!(
-      a_or_b(c),
-      Err(Err::Error(error_position!(c, ErrorKind::IsNot)))
-    );
+    assert_eq!(a_or_b(c), Err(Err::Error(error_position!(c, ErrorKind::IsNot))));
 
     let d = &b"cdefba"[..];
     assert_eq!(a_or_b(d), Ok((&b"ba"[..], &b"cdef"[..])));
@@ -1233,14 +1227,8 @@ mod tests {
   #[test]
   fn escaping_complete_str() {
     named!(esc<CompleteStr, CompleteStr>, escaped!(call!(alpha), '\\', one_of!("\"n\\")));
-    assert_eq!(
-      esc(CompleteStr("abcd;")),
-      Ok((CompleteStr(";"), CompleteStr("abcd")))
-    );
-    assert_eq!(
-      esc(CompleteStr("ab\\\"cd;")),
-      Ok((CompleteStr(";"), CompleteStr("ab\\\"cd")))
-    );
+    assert_eq!(esc(CompleteStr("abcd;")), Ok((CompleteStr(";"), CompleteStr("abcd"))));
+    assert_eq!(esc(CompleteStr("ab\\\"cd;")), Ok((CompleteStr(";"), CompleteStr("ab\\\"cd"))));
     //assert_eq!(esc("\\\"abcd;"), Ok((";", "\\\"abcd")));
     //assert_eq!(esc("\\n;"), Ok((";", "\\n")));
     //assert_eq!(esc("ab\\\"12"), Ok(("12", "ab\\\"")));
@@ -1299,19 +1287,10 @@ mod tests {
     );
 
     assert_eq!(esc(&b"abcd;"[..]), Ok((&b";"[..], String::from("abcd"))));
-    assert_eq!(
-      esc(&b"ab\\\"cd;"[..]),
-      Ok((&b";"[..], String::from("ab\"cd")))
-    );
-    assert_eq!(
-      esc(&b"\\\"abcd;"[..]),
-      Ok((&b";"[..], String::from("\"abcd")))
-    );
+    assert_eq!(esc(&b"ab\\\"cd;"[..]), Ok((&b";"[..], String::from("ab\"cd"))));
+    assert_eq!(esc(&b"\\\"abcd;"[..]), Ok((&b";"[..], String::from("\"abcd"))));
     assert_eq!(esc(&b"\\n;"[..]), Ok((&b";"[..], String::from("\n"))));
-    assert_eq!(
-      esc(&b"ab\\\"12"[..]),
-      Ok((&b"12"[..], String::from("ab\"")))
-    );
+    assert_eq!(esc(&b"ab\\\"12"[..]), Ok((&b"12"[..], String::from("ab\""))));
     assert_eq!(esc(&b"AB\\"[..]), Err(Err::Incomplete(Needed::Size(1))));
     assert_eq!(
       esc(&b"AB\\A"[..]),
@@ -1336,14 +1315,8 @@ mod tests {
         to_s
       )
     );
-    assert_eq!(
-      esc2(&b"ab&egrave;DEF;"[..]),
-      Ok((&b";"[..], String::from("abèDEF")))
-    );
-    assert_eq!(
-      esc2(&b"ab&egrave;D&agrave;EF;"[..]),
-      Ok((&b";"[..], String::from("abèDàEF")))
-    );
+    assert_eq!(esc2(&b"ab&egrave;DEF;"[..]), Ok((&b";"[..], String::from("abèDEF"))));
+    assert_eq!(esc2(&b"ab&egrave;D&agrave;EF;"[..]), Ok((&b";"[..], String::from("abèDàEF"))));
   }
 
   #[cfg(feature = "verbose-errors")]
@@ -1390,10 +1363,7 @@ mod tests {
       ))
     );
     assert_eq!(esc2("ab&egrave;DEF;"), Ok((";", String::from("abèDEF"))));
-    assert_eq!(
-      esc2("ab&egrave;D&agrave;EF;"),
-      Ok((";", String::from("abèDàEF")))
-    );
+    assert_eq!(esc2("ab&egrave;D&agrave;EF;"), Ok((";", String::from("abèDàEF"))));
 
     named!(esc3<&str, String>, escaped_transform!(alpha, '␛',
       alt!(
@@ -1429,10 +1399,7 @@ mod tests {
   fn take_until_and_consume_complete() {
     named!(x<CompleteStr,CompleteStr>, take_until_and_consume!("efgh"));
     let r = x(CompleteStr(&"abcdabcdefghijkl"[..]));
-    assert_eq!(
-      r,
-      Ok((CompleteStr(&"ijkl"[..]), CompleteStr(&"abcdabcd"[..])))
-    );
+    assert_eq!(r, Ok((CompleteStr(&"ijkl"[..]), CompleteStr(&"abcdabcd"[..]))));
 
     let r2 = x(CompleteStr(&"abcdabcdefgh"[..]));
     assert_eq!(r2, Ok((CompleteStr(&""[..]), CompleteStr(&"abcdabcd"[..]))));
@@ -1448,10 +1415,7 @@ mod tests {
 
     assert_eq!(
       x(CompleteStr(&"ab"[..])),
-      Err(Err::Error(error_position!(
-        CompleteStr(&"ab"[..]),
-        ErrorKind::TakeUntilAndConsume
-      )))
+      Err(Err::Error(error_position!(CompleteStr(&"ab"[..]), ErrorKind::TakeUntilAndConsume)))
     );
   }
 
@@ -1468,51 +1432,24 @@ mod tests {
     assert_eq!(r3, Err(Err::Incomplete(Needed::Size(5))));
 
     let r4 = x(&b"efgh"[..]);
-    assert_eq!(
-      r4,
-      Err(Err::Error(error_position!(
-        &b"efgh"[..],
-        ErrorKind::TakeUntilAndConsume1
-      )))
-    );
+    assert_eq!(r4, Err(Err::Error(error_position!(&b"efgh"[..], ErrorKind::TakeUntilAndConsume1))));
 
     named!(x2, take_until_and_consume1!(""));
     let r5 = x2(&b""[..]);
-    assert_eq!(
-      r5,
-      Err(Err::Error(error_position!(
-        &b""[..],
-        ErrorKind::TakeUntilAndConsume1
-      )))
-    );
+    assert_eq!(r5, Err(Err::Error(error_position!(&b""[..], ErrorKind::TakeUntilAndConsume1))));
 
     let r6 = x2(&b"a"[..]);
-    assert_eq!(
-      r6,
-      Err(Err::Error(error_position!(
-        &b"a"[..],
-        ErrorKind::TakeUntilAndConsume1
-      )))
-    );
+    assert_eq!(r6, Err(Err::Error(error_position!(&b"a"[..], ErrorKind::TakeUntilAndConsume1))));
 
     let r7 = x(&b"efghi"[..]);
-    assert_eq!(
-      r7,
-      Err(Err::Error(error_position!(
-        &b"efghi"[..],
-        ErrorKind::TakeUntilAndConsume1
-      )))
-    );
+    assert_eq!(r7, Err(Err::Error(error_position!(&b"efghi"[..], ErrorKind::TakeUntilAndConsume1))));
   }
 
   #[test]
   fn take_until_and_consume1_complete() {
     named!(x<CompleteStr, CompleteStr>, take_until_and_consume1!("efgh"));
     let r = x(CompleteStr(&"abcdabcdefghijkl"[..]));
-    assert_eq!(
-      r,
-      Ok((CompleteStr(&"ijkl"[..]), CompleteStr(&"abcdabcd"[..])))
-    );
+    assert_eq!(r, Ok((CompleteStr(&"ijkl"[..]), CompleteStr(&"abcdabcd"[..]))));
 
     let r2 = x(CompleteStr(&"abcdabcdefgh"[..]));
     assert_eq!(r2, Ok((CompleteStr(&""[..]), CompleteStr(&"abcdabcd"[..]))));
@@ -1520,47 +1457,32 @@ mod tests {
     let r3 = x(CompleteStr(&"abcefg"[..]));
     assert_eq!(
       r3,
-      Err(Err::Error(error_position!(
-        CompleteStr("abcefg"),
-        ErrorKind::TakeUntilAndConsume1
-      )))
+      Err(Err::Error(error_position!(CompleteStr("abcefg"), ErrorKind::TakeUntilAndConsume1)))
     );
 
     let r4 = x(CompleteStr(&"efgh"[..]));
     assert_eq!(
       r4,
-      Err(Err::Error(error_position!(
-        CompleteStr("efgh"),
-        ErrorKind::TakeUntilAndConsume1
-      )))
+      Err(Err::Error(error_position!(CompleteStr("efgh"), ErrorKind::TakeUntilAndConsume1)))
     );
 
     named!(x2<CompleteStr, CompleteStr>, take_until_and_consume1!(""));
     let r5 = x2(CompleteStr(""));
     assert_eq!(
       r5,
-      Err(Err::Error(error_position!(
-        CompleteStr(""),
-        ErrorKind::TakeUntilAndConsume1
-      )))
+      Err(Err::Error(error_position!(CompleteStr(""), ErrorKind::TakeUntilAndConsume1)))
     );
 
     let r6 = x2(CompleteStr("a"));
     assert_eq!(
       r6,
-      Err(Err::Error(error_position!(
-        CompleteStr("a"),
-        ErrorKind::TakeUntilAndConsume1
-      )))
+      Err(Err::Error(error_position!(CompleteStr("a"), ErrorKind::TakeUntilAndConsume1)))
     );
 
     let r7 = x(CompleteStr("efghi"));
     assert_eq!(
       r7,
-      Err(Err::Error(error_position!(
-        CompleteStr("efghi"),
-        ErrorKind::TakeUntilAndConsume1
-      )))
+      Err(Err::Error(error_position!(CompleteStr("efghi"), ErrorKind::TakeUntilAndConsume1)))
     );
   }
 
@@ -1574,16 +1496,10 @@ mod tests {
   #[test]
   fn take_until_either_complete() {
     named!(x<CompleteStr, CompleteStr>, take_until_either!("!."));
-    assert_eq!(
-      x(CompleteStr("123!abc")),
-      Ok((CompleteStr("!abc"), CompleteStr("123")))
-    );
+    assert_eq!(x(CompleteStr("123!abc")), Ok((CompleteStr("!abc"), CompleteStr("123"))));
     assert_eq!(
       x(CompleteStr("123")),
-      Err(Err::Error(error_position!(
-        CompleteStr("123"),
-        ErrorKind::TakeUntilEither
-      )))
+      Err(Err::Error(error_position!(CompleteStr("123"), ErrorKind::TakeUntilEither)))
     );
   }
 
@@ -1606,29 +1522,17 @@ mod tests {
     named!(y<CompleteStr,CompleteStr>, take_until!("end"));
     assert_eq!(
       y(CompleteStr("nd")),
-      Err(Err::Error(error_position!(
-        CompleteStr("nd"),
-        ErrorKind::TakeUntil
-      )))
+      Err(Err::Error(error_position!(CompleteStr("nd"), ErrorKind::TakeUntil)))
     );
     assert_eq!(
       y(CompleteStr("123")),
-      Err(Err::Error(error_position!(
-        CompleteStr("123"),
-        ErrorKind::TakeUntil
-      )))
+      Err(Err::Error(error_position!(CompleteStr("123"), ErrorKind::TakeUntil)))
     );
     assert_eq!(
       y(CompleteStr("123en")),
-      Err(Err::Error(error_position!(
-        CompleteStr("123en"),
-        ErrorKind::TakeUntil
-      )))
+      Err(Err::Error(error_position!(CompleteStr("123en"), ErrorKind::TakeUntil)))
     );
-    assert_eq!(
-      y(CompleteStr("123end")),
-      Ok((CompleteStr("end"), CompleteStr("123")))
-    );
+    assert_eq!(y(CompleteStr("123end")), Ok((CompleteStr("end"), CompleteStr("123"))));
   }
 
   #[test]
@@ -1639,10 +1543,7 @@ mod tests {
 
   #[test]
   fn recognize() {
-    named!(
-      x,
-      recognize!(delimited!(tag!("<!--"), take!(5), tag!("-->")))
-    );
+    named!(x, recognize!(delimited!(tag!("<!--"), take!(5), tag!("-->"))));
     let r = x(&b"<!-- abc --> aaa"[..]);
     assert_eq!(r, Ok((&b" aaa"[..], &b"<!-- abc -->"[..])));
 
@@ -1704,10 +1605,7 @@ mod tests {
     assert_eq!(f(&a[..]), Err(Err::Incomplete(Needed::Size(1))));
     assert_eq!(f(&b[..]), Err(Err::Incomplete(Needed::Size(1))));
     assert_eq!(f(&c[..]), Ok((&b"123"[..], &b[..])));
-    assert_eq!(
-      f(&d[..]),
-      Err(Err::Error(error_position!(&d[..], ErrorKind::TakeWhile1)))
-    );
+    assert_eq!(f(&d[..]), Err(Err::Error(error_position!(&d[..], ErrorKind::TakeWhile1))));
   }
 
   #[test]
@@ -1726,10 +1624,7 @@ mod tests {
     assert_eq!(x(&c[..]), Err(Err::Incomplete(Needed::Size(1))));
     assert_eq!(x(&d[..]), Ok((&b"123"[..], &c[..])));
     assert_eq!(x(&e[..]), Ok((&b"e"[..], &b"abcd"[..])));
-    assert_eq!(
-      x(&f[..]),
-      Err(Err::Error(error_position!(&f[..], ErrorKind::TakeWhileMN)))
-    );
+    assert_eq!(x(&f[..]), Err(Err::Error(error_position!(&f[..], ErrorKind::TakeWhileMN))));
   }
 
   #[test]
@@ -1743,27 +1638,12 @@ mod tests {
     let e = CompleteByteSlice(b"abcde");
     let f = CompleteByteSlice(b"123");
 
-    assert_eq!(
-      x(a),
-      Err(Err::Error(error_position!(a, ErrorKind::TakeWhileMN)))
-    );
-    assert_eq!(
-      x(b),
-      Err(Err::Error(error_position!(b, ErrorKind::TakeWhileMN)))
-    );
+    assert_eq!(x(a), Err(Err::Error(error_position!(a, ErrorKind::TakeWhileMN))));
+    assert_eq!(x(b), Err(Err::Error(error_position!(b, ErrorKind::TakeWhileMN))));
     assert_eq!(x(c), Ok((CompleteByteSlice(b""), c)));
-    assert_eq!(
-      x(d),
-      Ok((CompleteByteSlice(b"123"), CompleteByteSlice(b"abc")))
-    );
-    assert_eq!(
-      x(e),
-      Ok((CompleteByteSlice(b"e"), CompleteByteSlice(b"abcd")))
-    );
-    assert_eq!(
-      x(f),
-      Err(Err::Error(error_position!(f, ErrorKind::TakeWhileMN)))
-    );
+    assert_eq!(x(d), Ok((CompleteByteSlice(b"123"), CompleteByteSlice(b"abc"))));
+    assert_eq!(x(e), Ok((CompleteByteSlice(b"e"), CompleteByteSlice(b"abcd"))));
+    assert_eq!(x(f), Err(Err::Error(error_position!(f, ErrorKind::TakeWhileMN))));
   }
 
   #[test]
@@ -1775,23 +1655,14 @@ mod tests {
     let c = CompleteByteSlice(b"abcd123");
     let d = CompleteByteSlice(b"123");
 
-    assert_eq!(
-      f(a),
-      Err(Err::Error(error_position!(a, ErrorKind::TakeWhile1)))
-    );
+    assert_eq!(f(a), Err(Err::Error(error_position!(a, ErrorKind::TakeWhile1))));
     assert_eq!(f(b), Ok((CompleteByteSlice(b""), b)));
     assert_eq!(f(c), Ok((CompleteByteSlice(b"123"), b)));
-    assert_eq!(
-      f(d),
-      Err(Err::Error(error_position!(d, ErrorKind::TakeWhile1)))
-    );
+    assert_eq!(f(d), Err(Err::Error(error_position!(d, ErrorKind::TakeWhile1))));
 
     named!(f2<CompleteStr, CompleteStr>, take_while1!(|c: char| c.is_alphabetic()));
     let a2 = CompleteStr("");
-    assert_eq!(
-      f2(a2),
-      Err(Err::Error(error_position!(a2, ErrorKind::TakeWhile1)))
-    );
+    assert_eq!(f2(a2), Err(Err::Error(error_position!(a2, ErrorKind::TakeWhile1))));
   }
 
   #[test]
@@ -1819,14 +1690,8 @@ mod tests {
     let d = CompleteByteSlice(b"123");
 
     assert_eq!(f(a), Ok((a, a)));
-    assert_eq!(
-      f(b),
-      Ok((CompleteByteSlice(b"abcd"), CompleteByteSlice(b"")))
-    );
-    assert_eq!(
-      f(c),
-      Ok((CompleteByteSlice(b"abcd"), CompleteByteSlice(b"123")))
-    );
+    assert_eq!(f(b), Ok((CompleteByteSlice(b"abcd"), CompleteByteSlice(b""))));
+    assert_eq!(f(c), Ok((CompleteByteSlice(b"abcd"), CompleteByteSlice(b"123"))));
     assert_eq!(f(d), Ok((a, d)));
   }
 
@@ -1840,10 +1705,7 @@ mod tests {
     let d = b"123";
 
     assert_eq!(f(&a[..]), Err(Err::Incomplete(Needed::Size(1))));
-    assert_eq!(
-      f(&b[..]),
-      Err(Err::Error(error_position!(&b[..], ErrorKind::TakeTill1)))
-    );
+    assert_eq!(f(&b[..]), Err(Err::Error(error_position!(&b[..], ErrorKind::TakeTill1))));
     assert_eq!(f(&c[..]), Ok((&b"abcd"[..], &b"123"[..])));
     assert_eq!(f(&d[..]), Err(Err::Incomplete(Needed::Size(1))));
   }
@@ -1898,10 +1760,7 @@ mod tests {
     assert_eq!(g("xabcdéa"), Ok(("a", "xabcd")));
     assert_eq!(
       g("點xa"),
-      Err(Err::Error(error_position!(
-        "點xa",
-        ErrorKind::TakeUntilEitherAndConsume
-      )))
+      Err(Err::Error(error_position!("點xa", ErrorKind::TakeUntilEitherAndConsume)))
     );
   }
 
@@ -1954,10 +1813,7 @@ mod tests {
     assert_eq!(x(b"\x02."), Err(Err::Incomplete(Needed::Size(2))));
     assert_eq!(x(b"\x02"), Err(Err::Incomplete(Needed::Size(2))));
 
-    named!(
-      y,
-      do_parse!(tag!("magic") >> b: length_bytes!(le_u8) >> (b))
-    );
+    named!(y, do_parse!(tag!("magic") >> b: length_bytes!(le_u8) >> (b)));
     assert_eq!(y(b"magic\x02..>>"), Ok((&b">>"[..], &b".."[..])));
     assert_eq!(y(b"magic\x02.."), Ok((&[][..], &b".."[..])));
     assert_eq!(y(b"magic\x02."), Err(Err::Incomplete(Needed::Size(2))));
@@ -1972,28 +1828,16 @@ mod tests {
     assert_eq!(test(&b"abcdefgh"[..]), Ok((&b"efgh"[..], &b"abcd"[..])));
     assert_eq!(test(&b"ABCDefgh"[..]), Ok((&b"efgh"[..], &b"ABCD"[..])));
     assert_eq!(test(&b"ab"[..]), Err(Err::Incomplete(Needed::Size(4))));
-    assert_eq!(
-      test(&b"Hello"[..]),
-      Err(Err::Error(error_position!(&b"Hello"[..], ErrorKind::Tag)))
-    );
-    assert_eq!(
-      test(&b"Hel"[..]),
-      Err(Err::Error(error_position!(&b"Hel"[..], ErrorKind::Tag)))
-    );
+    assert_eq!(test(&b"Hello"[..]), Err(Err::Error(error_position!(&b"Hello"[..], ErrorKind::Tag))));
+    assert_eq!(test(&b"Hel"[..]), Err(Err::Error(error_position!(&b"Hel"[..], ErrorKind::Tag))));
 
     named!(test2<&str, &str>, tag_no_case!("ABcd"));
     assert_eq!(test2("aBCdefgh"), Ok(("efgh", "aBCd")));
     assert_eq!(test2("abcdefgh"), Ok(("efgh", "abcd")));
     assert_eq!(test2("ABCDefgh"), Ok(("efgh", "ABCD")));
     assert_eq!(test2("ab"), Err(Err::Incomplete(Needed::Size(4))));
-    assert_eq!(
-      test2("Hello"),
-      Err(Err::Error(error_position!(&"Hello"[..], ErrorKind::Tag)))
-    );
-    assert_eq!(
-      test2("Hel"),
-      Err(Err::Error(error_position!(&"Hel"[..], ErrorKind::Tag)))
-    );
+    assert_eq!(test2("Hello"), Err(Err::Error(error_position!(&"Hello"[..], ErrorKind::Tag))));
+    assert_eq!(test2("Hel"), Err(Err::Error(error_position!(&"Hel"[..], ErrorKind::Tag))));
   }
 
   #[test]

--- a/src/character.rs
+++ b/src/character.rs
@@ -1,8 +1,7 @@
 /// Character level parsers
-
 use internal::{IResult, Needed};
-use traits::{AsChar, InputIter, InputLength, Slice};
 use lib::std::ops::RangeFrom;
+use traits::{AsChar, InputIter, InputLength, Slice};
 use traits::{need_more, AtEof};
 
 /// matches one of the provided characters

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1288,9 +1288,9 @@ macro_rules! recognize (
 #[cfg(test)]
 mod tests {
   use internal::{Err, IResult, Needed};
-  use util::ErrorKind;
   #[cfg(feature = "alloc")]
   use lib::std::boxed::Box;
+  use util::ErrorKind;
 
   // reproduce the tag and take macros, because of module import order
   macro_rules! tag (
@@ -1379,10 +1379,7 @@ mod tests {
     assert_eq!(opt_res_abcd(a), Ok((&b"ef"[..], Ok(&b"abcd"[..]))));
     assert_eq!(
       opt_res_abcd(b),
-      Ok((
-        &b"bcdefg"[..],
-        Err(Err::Error(error_position!(b, ErrorKind::Tag)))
-      ))
+      Ok((&b"bcdefg"[..], Err(Err::Error(error_position!(b, ErrorKind::Tag)))))
     );
     assert_eq!(opt_res_abcd(c), Err(Err::Incomplete(Needed::Size(4))));
   }
@@ -1398,10 +1395,7 @@ mod tests {
     assert_eq!(opt_res_abcd(a), Ok((&b"ef"[..], Ok(&b"abcd"[..]))));
     assert_eq!(
       opt_res_abcd(b),
-      Ok((
-        &b"bcdefg"[..],
-        Err(Err::Error(error_position!(b, ErrorKind::Tag)))
-      ))
+      Ok((&b"bcdefg"[..], Err(Err::Error(error_position!(b, ErrorKind::Tag)))))
     );
     assert_eq!(opt_res_abcd(c), Err(Err::Incomplete(Needed::Size(4))));
   }
@@ -1418,14 +1412,10 @@ mod tests {
   #[test]
   #[cfg(feature = "alloc")]
   fn cond() {
-    let f_true: Box<Fn(&'static [u8]) -> IResult<&[u8], Option<&[u8]>, CustomError>> = Box::new(closure!(
-      &'static [u8],
-      fix_error!(CustomError, cond!(true, tag!("abcd")))
-    ));
-    let f_false: Box<Fn(&'static [u8]) -> IResult<&[u8], Option<&[u8]>, CustomError>> = Box::new(closure!(
-      &'static [u8],
-      fix_error!(CustomError, cond!(false, tag!("abcd")))
-    ));
+    let f_true: Box<Fn(&'static [u8]) -> IResult<&[u8], Option<&[u8]>, CustomError>> =
+      Box::new(closure!(&'static [u8], fix_error!(CustomError, cond!(true, tag!("abcd")))));
+    let f_false: Box<Fn(&'static [u8]) -> IResult<&[u8], Option<&[u8]>, CustomError>> =
+      Box::new(closure!(&'static [u8], fix_error!(CustomError, cond!(false, tag!("abcd")))));
     //let f_false = closure!(&'static [u8], cond!( false, tag!("abcd") ) );
 
     assert_eq!(f_true(&b"abcdef"[..]), Ok((&b"ef"[..], Some(&b"abcd"[..]))));
@@ -1442,14 +1432,10 @@ mod tests {
   fn cond_wrapping() {
     // Test that cond!() will wrap a given identifier in the call!() macro.
     named!(tag_abcd, tag!("abcd"));
-    let f_true: Box<Fn(&'static [u8]) -> IResult<&[u8], Option<&[u8]>, CustomError>> = Box::new(closure!(
-      &'static [u8],
-      fix_error!(CustomError, cond!(true, tag_abcd))
-    ));
-    let f_false: Box<Fn(&'static [u8]) -> IResult<&[u8], Option<&[u8]>, CustomError>> = Box::new(closure!(
-      &'static [u8],
-      fix_error!(CustomError, cond!(false, tag_abcd))
-    ));
+    let f_true: Box<Fn(&'static [u8]) -> IResult<&[u8], Option<&[u8]>, CustomError>> =
+      Box::new(closure!(&'static [u8], fix_error!(CustomError, cond!(true, tag_abcd))));
+    let f_false: Box<Fn(&'static [u8]) -> IResult<&[u8], Option<&[u8]>, CustomError>> =
+      Box::new(closure!(&'static [u8], fix_error!(CustomError, cond!(false, tag_abcd))));
     //let f_false = closure!(&'static [u8], cond!( b2, tag!("abcd") ) );
 
     assert_eq!(f_true(&b"abcdef"[..]), Ok((&b"ef"[..], Some(&b"abcd"[..]))));
@@ -1467,10 +1453,7 @@ mod tests {
 
     assert_eq!(peek_tag(&b"abcdef"[..]), Ok((&b"abcdef"[..], &b"abcd"[..])));
     assert_eq!(peek_tag(&b"ab"[..]), Err(Err::Incomplete(Needed::Size(4))));
-    assert_eq!(
-      peek_tag(&b"xxx"[..]),
-      Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
-    );
+    assert_eq!(peek_tag(&b"xxx"[..]), Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag))));
   }
 
   #[test]
@@ -1478,29 +1461,17 @@ mod tests {
     use types::CompleteStr;
 
     named!(not_aaa<()>, not!(tag!("aaa")));
-    assert_eq!(
-      not_aaa(&b"aaa"[..]),
-      Err(Err::Error(error_position!(&b"aaa"[..], ErrorKind::Not)))
-    );
+    assert_eq!(not_aaa(&b"aaa"[..]), Err(Err::Error(error_position!(&b"aaa"[..], ErrorKind::Not))));
     assert_eq!(not_aaa(&b"aa"[..]), Err(Err::Incomplete(Needed::Size(3))));
     assert_eq!(not_aaa(&b"abcd"[..]), Ok((&b"abcd"[..], ())));
 
     named!(not_aaa_complete<CompleteStr, ()>, not!(tag!("aaa")));
     assert_eq!(
       not_aaa_complete(CompleteStr("aaa")),
-      Err(Err::Error(error_position!(
-        CompleteStr("aaa"),
-        ErrorKind::Not
-      )))
+      Err(Err::Error(error_position!(CompleteStr("aaa"), ErrorKind::Not)))
     );
-    assert_eq!(
-      not_aaa_complete(CompleteStr("aa")),
-      Ok((CompleteStr("aa"), ()))
-    );
-    assert_eq!(
-      not_aaa_complete(CompleteStr("abcd")),
-      Ok((CompleteStr("abcd"), ()))
-    );
+    assert_eq!(not_aaa_complete(CompleteStr("aa")), Ok((CompleteStr("aa"), ())));
+    assert_eq!(not_aaa_complete(CompleteStr("abcd")), Ok((CompleteStr("abcd"), ())));
   }
 
   #[test]
@@ -1509,10 +1480,7 @@ mod tests {
     assert_eq!(test(&b"bcd"[..]), Err(Err::Incomplete(Needed::Size(5))));
     assert_eq!(
       test(&b"bcdefg"[..]),
-      Err(Err::Error(error_position!(
-        &b"bcdefg"[..],
-        ErrorKind::Verify
-      )))
+      Err(Err::Error(error_position!(&b"bcdefg"[..], ErrorKind::Verify)))
     );
     assert_eq!(test(&b"abcdefg"[..]), Ok((&b"fg"[..], &b"abcde"[..])));
   }

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -341,11 +341,7 @@ mod tests {
       Parser { bcd: "" }
     }
 
-    method!(
-      tag_abc<Parser<'a>, &'a str, &'a str>,
-      self,
-      tag_s!("áβç")
-    );
+    method!(tag_abc<Parser<'a>, &'a str, &'a str>, self, tag_s!("áβç"));
     method!(tag_bcd<Parser<'a> >(&'a str) -> &'a str, self, tag_s!("βçδ"));
     method!(pub tag_hij<Parser<'a> >(&'a str) -> &'a str, self, tag_s!("λïJ"));
     method!(pub tag_ijk<Parser<'a>, &'a str, &'a str>, self, tag_s!("ïJƙ"));
@@ -381,11 +377,7 @@ mod tests {
     let (_, res) = p.tag_abc(input);
     match res {
       Ok((extra, output)) => {
-        assert!(
-          extra == leftover,
-          "`Parser.tag_abc` consumed leftover input. leftover: {}",
-          extra
-        );
+        assert!(extra == leftover, "`Parser.tag_abc` consumed leftover input. leftover: {}", extra);
         assert!(
           output == consumed,
           "`Parser.tag_abc` doesnt return the string it consumed \
@@ -411,11 +403,7 @@ mod tests {
     let (_, res) = p.tag_bcd(input);
     match res {
       Ok((extra, output)) => {
-        assert!(
-          extra == leftover,
-          "`Parser.tag_bcd` consumed leftover input. leftover: {}",
-          extra
-        );
+        assert!(extra == leftover, "`Parser.tag_bcd` consumed leftover input. leftover: {}", extra);
         assert!(
           output == consumed,
           "`Parser.tag_bcd` doesn't return the string it consumed \
@@ -441,11 +429,7 @@ mod tests {
     let (_, res) = p.tag_hij(input);
     match res {
       Ok((extra, output)) => {
-        assert!(
-          extra == leftover,
-          "`Parser.tag_hij` consumed leftover input. leftover: {}",
-          extra
-        );
+        assert!(extra == leftover, "`Parser.tag_hij` consumed leftover input. leftover: {}", extra);
         assert!(
           output == consumed,
           "`Parser.tag_hij` doesn't return the string it consumed \
@@ -471,11 +455,7 @@ mod tests {
     let (_, res) = p.tag_ijk(input);
     match res {
       Ok((extra, output)) => {
-        assert!(
-          extra == leftover,
-          "`Parser.tag_ijk` consumed leftover input. leftover: {}",
-          extra
-        );
+        assert!(extra == leftover, "`Parser.tag_ijk` consumed leftover input. leftover: {}", extra);
         assert!(
           output == consumed,
           "`Parser.tag_ijk` doesn't return the string it consumed \
@@ -531,11 +511,7 @@ mod tests {
     p = tmp;
     match res {
       Ok((extra, output)) => {
-        assert!(
-          extra == leftover,
-          "`Parser.use_apply` consumed leftover input. leftover: {}",
-          extra
-        );
+        assert!(extra == leftover, "`Parser.use_apply` consumed leftover input. leftover: {}", extra);
         assert!(
           output == consumed,
           "`Parser.use_apply` doesn't return the string it was supposed to \
@@ -565,11 +541,7 @@ mod tests {
     let (_, res) = p.simple_peek(input);
     match res {
       Ok((extra, output)) => {
-        assert!(
-          extra == input,
-          "`Parser.simple_peek` consumed leftover input. leftover: {}",
-          extra
-        );
+        assert!(extra == input, "`Parser.simple_peek` consumed leftover input. leftover: {}", extra);
         assert!(
           output == consumed,
           "`Parser.simple_peek` doesn't return the string it consumed \

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -1031,10 +1031,10 @@ macro_rules! fold_many_m_n(
 #[cfg(test)]
 mod tests {
   use internal::{Err, IResult, Needed};
-  use nom::{digit, be_u16, be_u8, le_u16};
   use lib::std::str::{self, FromStr};
   #[cfg(feature = "alloc")]
   use lib::std::vec::Vec;
+  use nom::{digit, be_u16, be_u8, le_u16};
   use util::ErrorKind;
 
   // reproduce the tag and take macros, because of module import order
@@ -1111,10 +1111,7 @@ mod tests {
     let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
     assert_eq!(multi(b), Ok((&b"ef"[..], res2)));
     assert_eq!(multi(c), Ok((&b"azerty"[..], Vec::new())));
-    assert_eq!(
-      multi_empty(d),
-      Err(Err::Error(error_position!(d, ErrorKind::SeparatedList)))
-    );
+    assert_eq!(multi_empty(d), Err(Err::Error(error_position!(d, ErrorKind::SeparatedList))));
     //let res3 = vec![&b""[..], &b""[..], &b""[..]];
     //assert_eq!(multi_empty(d),Ok((&b"abc"[..], res3)));
     let res4 = vec![&b"abcd"[..], &b"abcd"[..]];
@@ -1139,14 +1136,8 @@ mod tests {
     let f = &b"123"[..];
 
     assert_eq!(multi(a), Ok((&b";"[..], vec![&a[..a.len() - 1]])));
-    assert_eq!(
-      multi(b),
-      Ok((&b";"[..], vec![&b"abcd"[..], &b"abcdef"[..]]))
-    );
-    assert_eq!(
-      multi(c),
-      Ok((&b";"[..], vec![&b"abcd"[..], &b"abcd"[..], &b"ef"[..]]))
-    );
+    assert_eq!(multi(b), Ok((&b";"[..], vec![&b"abcd"[..], &b"abcdef"[..]])));
+    assert_eq!(multi(c), Ok((&b";"[..], vec![&b"abcd"[..], &b"abcd"[..], &b"ef"[..]])));
     assert_eq!(multi(d), Ok((&b"."[..], vec![&b"abc"[..]])));
     assert_eq!(multi(e), Ok((&b"."[..], vec![&b"abcd"[..], &b"ef"[..]])));
     assert_eq!(multi(f), Ok((&b"123"[..], Vec::new())));
@@ -1171,10 +1162,7 @@ mod tests {
     assert_eq!(multi(a), Ok((&b"ef"[..], res1)));
     let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
     assert_eq!(multi(b), Ok((&b"ef"[..], res2)));
-    assert_eq!(
-      multi(c),
-      Err(Err::Error(error_position!(c, ErrorKind::Tag)))
-    );
+    assert_eq!(multi(c), Err(Err::Error(error_position!(c, ErrorKind::Tag))));
     let res3 = vec![&b"abcd"[..], &b"abcd"[..]];
     assert_eq!(multi(d), Ok((&b",ef"[..], res3)));
 
@@ -1197,20 +1185,11 @@ mod tests {
     let f = &b"123"[..];
 
     assert_eq!(multi(a), Ok((&b";"[..], vec![&a[..a.len() - 1]])));
-    assert_eq!(
-      multi(b),
-      Ok((&b";"[..], vec![&b"abcd"[..], &b"abcdef"[..]]))
-    );
-    assert_eq!(
-      multi(c),
-      Ok((&b";"[..], vec![&b"abcd"[..], &b"abcd"[..], &b"ef"[..]]))
-    );
+    assert_eq!(multi(b), Ok((&b";"[..], vec![&b"abcd"[..], &b"abcdef"[..]])));
+    assert_eq!(multi(c), Ok((&b";"[..], vec![&b"abcd"[..], &b"abcd"[..], &b"ef"[..]])));
     assert_eq!(multi(d), Ok((&b"."[..], vec![&b"abc"[..]])));
     assert_eq!(multi(e), Ok((&b"."[..], vec![&b"abcd"[..], &b"ef"[..]])));
-    assert_eq!(
-      multi(f),
-      Err(Err::Error(error_position!(&b"123"[..], ErrorKind::Alpha)))
-    );
+    assert_eq!(multi(f), Err(Err::Error(error_position!(&b"123"[..], ErrorKind::Alpha))));
   }
 
   #[test]
@@ -1222,20 +1201,14 @@ mod tests {
     named!( multi_empty<&[u8],Vec<&[u8]> >, many0!(tag_empty) );
 
     assert_eq!(multi(&b"abcdef"[..]), Ok((&b"ef"[..], vec![&b"abcd"[..]])));
-    assert_eq!(
-      multi(&b"abcdabcdefgh"[..]),
-      Ok((&b"efgh"[..], vec![&b"abcd"[..], &b"abcd"[..]]))
-    );
+    assert_eq!(multi(&b"abcdabcdefgh"[..]), Ok((&b"efgh"[..], vec![&b"abcd"[..], &b"abcd"[..]])));
     assert_eq!(multi(&b"azerty"[..]), Ok((&b"azerty"[..], Vec::new())));
     assert_eq!(multi(&b"abcdab"[..]), Err(Err::Incomplete(Needed::Size(4))));
     assert_eq!(multi(&b"abcd"[..]), Err(Err::Incomplete(Needed::Size(4))));
     assert_eq!(multi(&b""[..]), Err(Err::Incomplete(Needed::Size(4))));
     assert_eq!(
       multi_empty(&b"abcdef"[..]),
-      Err(Err::Error(error_position!(
-        &b"abcdef"[..],
-        ErrorKind::Many0
-      )))
+      Err(Err::Error(error_position!(&b"abcdef"[..], ErrorKind::Many0)))
     );
   }
 
@@ -1263,10 +1236,7 @@ mod tests {
     assert_eq!(multi(a), Ok((&b"ef"[..], res1)));
     let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
     assert_eq!(multi(b), Ok((&b"efgh"[..], res2)));
-    assert_eq!(
-      multi(c),
-      Err(Err::Error(error_position!(c, ErrorKind::Many1)))
-    );
+    assert_eq!(multi(c), Err(Err::Error(error_position!(c, ErrorKind::Many1))));
     assert_eq!(multi(d), Err(Err::Incomplete(Needed::Size(4))));
   }
 
@@ -1308,10 +1278,7 @@ mod tests {
 
     named!(multi1<&[u8],Vec<&[u8]> >, many1!(tst));
     let a = &b"abcdef"[..];
-    assert_eq!(
-      multi1(a),
-      Err(Err::Error(error_position!(a, ErrorKind::Many1)))
-    );
+    assert_eq!(multi1(a), Err(Err::Error(error_position!(a, ErrorKind::Many1))));
   }
 
   #[test]
@@ -1325,10 +1292,7 @@ mod tests {
     let d = &b"AbcdAbcdAbcdAbcdAbcdefgh"[..];
     let e = &b"AbcdAb"[..];
 
-    assert_eq!(
-      multi(a),
-      Err(Err::Error(error_position!(a, ErrorKind::ManyMN)))
-    );
+    assert_eq!(multi(a), Err(Err::Error(error_position!(a, ErrorKind::ManyMN))));
     let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
     assert_eq!(multi(b), Ok((&b"efgh"[..], res1)));
     let res2 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
@@ -1345,29 +1309,17 @@ mod tests {
     named!(tag_abc, tag!("abc"));
     named!( cnt_2<&[u8], Vec<&[u8]> >, count!(tag_abc, TIMES ) );
 
-    assert_eq!(
-      cnt_2(&b"abcabcabcdef"[..]),
-      Ok((&b"abcdef"[..], vec![&b"abc"[..], &b"abc"[..]]))
-    );
+    assert_eq!(cnt_2(&b"abcabcabcdef"[..]), Ok((&b"abcdef"[..], vec![&b"abc"[..], &b"abc"[..]])));
     assert_eq!(cnt_2(&b"ab"[..]), Err(Err::Incomplete(Needed::Size(3))));
     assert_eq!(cnt_2(&b"abcab"[..]), Err(Err::Incomplete(Needed::Size(3))));
-    assert_eq!(
-      cnt_2(&b"xxx"[..]),
-      Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Count)))
-    );
+    assert_eq!(cnt_2(&b"xxx"[..]), Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Count))));
     assert_eq!(
       cnt_2(&b"xxxabcabcdef"[..]),
-      Err(Err::Error(error_position!(
-        &b"xxxabcabcdef"[..],
-        ErrorKind::Count
-      )))
+      Err(Err::Error(error_position!(&b"xxxabcabcdef"[..], ErrorKind::Count)))
     );
     assert_eq!(
       cnt_2(&b"abcxxxabcdef"[..]),
-      Err(Err::Error(error_position!(
-        &b"abcxxxabcdef"[..],
-        ErrorKind::Count
-      )))
+      Err(Err::Error(error_position!(&b"abcxxxabcdef"[..], ErrorKind::Count)))
     );
   }
 
@@ -1396,14 +1348,8 @@ mod tests {
     let error_2_remain = &b"abcxxxabcdef"[..];
 
     assert_eq!(counter_2(done), Ok((rest, parsed_done)));
-    assert_eq!(
-      counter_2(incomplete_1),
-      Ok((incomplete_1, parsed_incompl_1))
-    );
-    assert_eq!(
-      counter_2(incomplete_2),
-      Ok((incomplete_2, parsed_incompl_2))
-    );
+    assert_eq!(counter_2(incomplete_1), Ok((incomplete_1, parsed_incompl_1)));
+    assert_eq!(counter_2(incomplete_2), Ok((incomplete_2, parsed_incompl_2)));
     assert_eq!(counter_2(error), Ok((error_remain, parsed_err)));
     assert_eq!(counter_2(error_1), Ok((error_1_remain, parsed_err_1)));
     assert_eq!(counter_2(error_2), Ok((error_2_remain, parsed_err_2)));
@@ -1415,38 +1361,23 @@ mod tests {
     named!(tag_abc, tag!("abc"));
     named!( cnt_2<&[u8], [&[u8]; TIMES] >, count_fixed!(&[u8], tag_abc, TIMES ) );
 
-    assert_eq!(
-      cnt_2(&b"abcabcabcdef"[..]),
-      Ok((&b"abcdef"[..], [&b"abc"[..], &b"abc"[..]]))
-    );
+    assert_eq!(cnt_2(&b"abcabcabcdef"[..]), Ok((&b"abcdef"[..], [&b"abc"[..], &b"abc"[..]])));
     assert_eq!(cnt_2(&b"ab"[..]), Err(Err::Incomplete(Needed::Size(3))));
     assert_eq!(cnt_2(&b"abcab"[..]), Err(Err::Incomplete(Needed::Size(3))));
-    assert_eq!(
-      cnt_2(&b"xxx"[..]),
-      Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Count)))
-    );
+    assert_eq!(cnt_2(&b"xxx"[..]), Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Count))));
     assert_eq!(
       cnt_2(&b"xxxabcabcdef"[..]),
-      Err(Err::Error(error_position!(
-        &b"xxxabcabcdef"[..],
-        ErrorKind::Count
-      )))
+      Err(Err::Error(error_position!(&b"xxxabcabcdef"[..], ErrorKind::Count)))
     );
     assert_eq!(
       cnt_2(&b"abcxxxabcdef"[..]),
-      Err(Err::Error(error_position!(
-        &b"abcxxxabcdef"[..],
-        ErrorKind::Count
-      )))
+      Err(Err::Error(error_position!(&b"abcxxxabcdef"[..], ErrorKind::Count)))
     );
   }
 
   #[allow(dead_code)]
   pub fn compile_count_fixed(input: &[u8]) -> IResult<&[u8], ()> {
-    do_parse!(
-      input,
-      tag!("abcd") >> count_fixed!(u16, le_u16, 4) >> eof!() >> ()
-    )
+    do_parse!(input, tag!("abcd") >> count_fixed!(u16, le_u16, 4) >> eof!() >> ())
   }
 
   #[derive(Debug, Clone, PartialEq)]
@@ -1477,31 +1408,16 @@ mod tests {
     let error_2_remain = &b"abcxxxabcdef"[..];
 
     assert_eq!(counter_2(done), Ok((rest, parsed_main)));
-    assert_eq!(
-      counter_2(incomplete_1),
-      Err(Err::Incomplete(Needed::Size(3)))
-    );
-    assert_eq!(
-      counter_2(incomplete_2),
-      Err(Err::Incomplete(Needed::Size(3)))
-    );
-    assert_eq!(
-      counter_2(error),
-      Err(Err::Error(error_position!(error, ErrorKind::Count)))
-    );
+    assert_eq!(counter_2(incomplete_1), Err(Err::Incomplete(Needed::Size(3))));
+    assert_eq!(counter_2(incomplete_2), Err(Err::Incomplete(Needed::Size(3))));
+    assert_eq!(counter_2(error), Err(Err::Error(error_position!(error, ErrorKind::Count))));
     assert_eq!(
       counter_2(error_1),
-      Err(Err::Error(error_position!(
-        error_1_remain,
-        ErrorKind::Count
-      )))
+      Err(Err::Error(error_position!(error_1_remain, ErrorKind::Count)))
     );
     assert_eq!(
       counter_2(error_2),
-      Err(Err::Error(error_position!(
-        error_2_remain,
-        ErrorKind::Count
-      )))
+      Err(Err::Error(error_position!(error_2_remain, ErrorKind::Count)))
     );
   }
 
@@ -1519,22 +1435,13 @@ mod tests {
     named!(tag_abc, tag!(&b"abc"[..]));
     named!( cnt<&[u8], Vec<&[u8]> >, length_count!(number, tag_abc) );
 
-    assert_eq!(
-      cnt(&b"2abcabcabcdef"[..]),
-      Ok((&b"abcdef"[..], vec![&b"abc"[..], &b"abc"[..]]))
-    );
+    assert_eq!(cnt(&b"2abcabcabcdef"[..]), Ok((&b"abcdef"[..], vec![&b"abc"[..], &b"abc"[..]])));
     assert_eq!(cnt(&b"2ab"[..]), Err(Err::Incomplete(Needed::Size(3))));
     assert_eq!(cnt(&b"3abcab"[..]), Err(Err::Incomplete(Needed::Size(3))));
-    assert_eq!(
-      cnt(&b"xxx"[..]),
-      Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Digit)))
-    );
+    assert_eq!(cnt(&b"xxx"[..]), Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Digit))));
     assert_eq!(
       cnt(&b"2abcxxx"[..]),
-      Err(Err::Error(error_position!(
-        &b"abcxxx"[..],
-        ErrorKind::Count
-      )))
+      Err(Err::Error(error_position!(&b"abcxxx"[..], ErrorKind::Count)))
     );
   }
 
@@ -1542,15 +1449,9 @@ mod tests {
   fn length_data() {
     named!( take<&[u8], &[u8]>, length_data!(number) );
 
-    assert_eq!(
-      take(&b"6abcabcabcdef"[..]),
-      Ok((&b"abcdef"[..], &b"abcabc"[..]))
-    );
+    assert_eq!(take(&b"6abcabcabcdef"[..]), Ok((&b"abcdef"[..], &b"abcabc"[..])));
     assert_eq!(take(&b"3ab"[..]), Err(Err::Incomplete(Needed::Size(3))));
-    assert_eq!(
-      take(&b"xxx"[..]),
-      Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Digit)))
-    );
+    assert_eq!(take(&b"xxx"[..]), Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Digit))));
     assert_eq!(take(&b"2abcxxx"[..]), Ok((&b"cxxx"[..], &b"ab"[..])));
   }
 
@@ -1560,14 +1461,8 @@ mod tests {
     named!(length_value_2<&[u8], (u8, u8) >, length_value!(be_u8, tuple!(be_u8, be_u8)));
 
     let i1 = [0, 5, 6];
-    assert_eq!(
-      length_value_1(&i1),
-      Err(Err::Error(error_position!(&b""[..], ErrorKind::Complete)))
-    );
-    assert_eq!(
-      length_value_2(&i1),
-      Err(Err::Error(error_position!(&b""[..], ErrorKind::Complete)))
-    );
+    assert_eq!(length_value_1(&i1), Err(Err::Error(error_position!(&b""[..], ErrorKind::Complete))));
+    assert_eq!(length_value_2(&i1), Err(Err::Error(error_position!(&b""[..], ErrorKind::Complete))));
 
     let i2 = [1, 5, 6, 3];
     assert_eq!(
@@ -1601,20 +1496,14 @@ mod tests {
     named!( multi_empty<&[u8],Vec<&[u8]> >, fold_many0!(tag_empty, Vec::new(), fold_into_vec) );
 
     assert_eq!(multi(&b"abcdef"[..]), Ok((&b"ef"[..], vec![&b"abcd"[..]])));
-    assert_eq!(
-      multi(&b"abcdabcdefgh"[..]),
-      Ok((&b"efgh"[..], vec![&b"abcd"[..], &b"abcd"[..]]))
-    );
+    assert_eq!(multi(&b"abcdabcdefgh"[..]), Ok((&b"efgh"[..], vec![&b"abcd"[..], &b"abcd"[..]])));
     assert_eq!(multi(&b"azerty"[..]), Ok((&b"azerty"[..], Vec::new())));
     assert_eq!(multi(&b"abcdab"[..]), Err(Err::Incomplete(Needed::Size(4))));
     assert_eq!(multi(&b"abcd"[..]), Err(Err::Incomplete(Needed::Size(4))));
     assert_eq!(multi(&b""[..]), Err(Err::Incomplete(Needed::Size(4))));
     assert_eq!(
       multi_empty(&b"abcdef"[..]),
-      Err(Err::Error(error_position!(
-        &b"abcdef"[..],
-        ErrorKind::Many0
-      )))
+      Err(Err::Error(error_position!(&b"abcdef"[..], ErrorKind::Many0)))
     );
   }
 
@@ -1636,10 +1525,7 @@ mod tests {
     assert_eq!(multi(a), Ok((&b"ef"[..], res1)));
     let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
     assert_eq!(multi(b), Ok((&b"efgh"[..], res2)));
-    assert_eq!(
-      multi(c),
-      Err(Err::Error(error_position!(c, ErrorKind::Many1)))
-    );
+    assert_eq!(multi(c), Err(Err::Error(error_position!(c, ErrorKind::Many1))));
     assert_eq!(multi(d), Err(Err::Incomplete(Needed::Size(4))));
   }
 
@@ -1658,10 +1544,7 @@ mod tests {
     let d = &b"AbcdAbcdAbcdAbcdAbcdefgh"[..];
     let e = &b"AbcdAb"[..];
 
-    assert_eq!(
-      multi(a),
-      Err(Err::Error(error_position!(a, ErrorKind::ManyMN)))
-    );
+    assert_eq!(multi(a), Err(Err::Error(error_position!(a, ErrorKind::ManyMN))));
     let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
     assert_eq!(multi(b), Ok((&b"efgh"[..], res1)));
     let res2 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -9,15 +9,15 @@
 #[cfg(feature = "alloc")]
 use lib::std::boxed::Box;
 
+use internal::*;
 #[cfg(feature = "std")]
 use lib::std::fmt::Debug;
-use internal::*;
+use lib::std::mem::transmute;
+use lib::std::ops::{Range, RangeFrom, RangeTo};
 use traits::{AsChar, InputIter, InputLength, InputTakeAtPosition};
 use traits::{need_more, need_more_err, AtEof};
-use lib::std::ops::{Range, RangeFrom, RangeTo};
 use traits::{Compare, CompareResult, Offset, Slice};
 use util::ErrorKind;
-use lib::std::mem::transmute;
 
 #[cfg(feature = "alloc")]
 #[inline]
@@ -650,11 +650,7 @@ pub fn hex_u32(input: &[u8]) -> IResult<&[u8], u32> {
     Err(e) => Err(e),
     Ok((i, o)) => {
       // Do not parse more than 8 characters for a u32
-      let (parsed, remaining) = if o.len() <= 8 {
-        (o, i)
-      } else {
-        (&input[..8], &input[8..])
-      };
+      let (parsed, remaining) = if o.len() <= 8 { (o, i) } else { (&input[..8], &input[8..]) };
 
       let res = parsed
         .iter()
@@ -767,13 +763,7 @@ mod tests {
     assert_eq!(r, Ok((&b"abcdefgh"[..], &b"abcd"[..])));
 
     let r2 = x(&b"abcefgh"[..]);
-    assert_eq!(
-      r2,
-      Err(Err::Error(error_position!(
-        &b"abcefgh"[..],
-        ErrorKind::TagClosure
-      ),))
-    );
+    assert_eq!(r2, Err(Err::Error(error_position!(&b"abcefgh"[..], ErrorKind::TagClosure),)));
   }
 
   #[test]
@@ -786,33 +776,15 @@ mod tests {
     let e: &[u8] = b" ";
     let f: &[u8] = b" ;";
     assert_eq!(alpha(a), Err(Err::Incomplete(Needed::Size(1))));
-    assert_eq!(
-      alpha(CompleteByteSlice(a)),
-      Ok((CompleteByteSlice(empty), CompleteByteSlice(a)))
-    );
-    assert_eq!(
-      alpha(b),
-      Err(Err::Error(error_position!(b, ErrorKind::Alpha)))
-    );
+    assert_eq!(alpha(CompleteByteSlice(a)), Ok((CompleteByteSlice(empty), CompleteByteSlice(a))));
+    assert_eq!(alpha(b), Err(Err::Error(error_position!(b, ErrorKind::Alpha))));
     assert_eq!(alpha(c), Ok((&c[1..], &b"a"[..])));
     assert_eq!(alpha(d), Ok(("é12".as_bytes(), &b"az"[..])));
-    assert_eq!(
-      digit(a),
-      Err(Err::Error(error_position!(a, ErrorKind::Digit)))
-    );
+    assert_eq!(digit(a), Err(Err::Error(error_position!(a, ErrorKind::Digit))));
     assert_eq!(digit(b), Err(Err::Incomplete(Needed::Size(1))));
-    assert_eq!(
-      digit(CompleteByteSlice(b)),
-      Ok((CompleteByteSlice(empty), CompleteByteSlice(b)))
-    );
-    assert_eq!(
-      digit(c),
-      Err(Err::Error(error_position!(c, ErrorKind::Digit)))
-    );
-    assert_eq!(
-      digit(d),
-      Err(Err::Error(error_position!(d, ErrorKind::Digit)))
-    );
+    assert_eq!(digit(CompleteByteSlice(b)), Ok((CompleteByteSlice(empty), CompleteByteSlice(b))));
+    assert_eq!(digit(c), Err(Err::Error(error_position!(c, ErrorKind::Digit))));
+    assert_eq!(digit(d), Err(Err::Error(error_position!(d, ErrorKind::Digit))));
     assert_eq!(hex_digit(a), Err(Err::Incomplete(Needed::Size(1))));
     assert_eq!(
       hex_digit(CompleteByteSlice(a)),
@@ -829,27 +801,15 @@ mod tests {
       Ok((CompleteByteSlice(empty), CompleteByteSlice(c)))
     );
     assert_eq!(hex_digit(d), Ok(("zé12".as_bytes(), &b"a"[..])));
-    assert_eq!(
-      hex_digit(e),
-      Err(Err::Error(error_position!(e, ErrorKind::HexDigit)))
-    );
-    assert_eq!(
-      oct_digit(a),
-      Err(Err::Error(error_position!(a, ErrorKind::OctDigit)))
-    );
+    assert_eq!(hex_digit(e), Err(Err::Error(error_position!(e, ErrorKind::HexDigit))));
+    assert_eq!(oct_digit(a), Err(Err::Error(error_position!(a, ErrorKind::OctDigit))));
     assert_eq!(oct_digit(b), Err(Err::Incomplete(Needed::Size(1))));
     assert_eq!(
       oct_digit(CompleteByteSlice(b)),
       Ok((CompleteByteSlice(empty), CompleteByteSlice(b)))
     );
-    assert_eq!(
-      oct_digit(c),
-      Err(Err::Error(error_position!(c, ErrorKind::OctDigit)))
-    );
-    assert_eq!(
-      oct_digit(d),
-      Err(Err::Error(error_position!(d, ErrorKind::OctDigit)))
-    );
+    assert_eq!(oct_digit(c), Err(Err::Error(error_position!(c, ErrorKind::OctDigit))));
+    assert_eq!(oct_digit(d), Err(Err::Error(error_position!(d, ErrorKind::OctDigit))));
     assert_eq!(alphanumeric(a), Err(Err::Incomplete(Needed::Size(1))));
     assert_eq!(
       alphanumeric(CompleteByteSlice(a)),
@@ -863,15 +823,9 @@ mod tests {
     );
     assert_eq!(alphanumeric(d), Ok(("é12".as_bytes(), &b"az"[..])));
     assert_eq!(space(e), Err(Err::Incomplete(Needed::Size(1))));
-    assert_eq!(
-      space(CompleteByteSlice(e)),
-      Ok((CompleteByteSlice(empty), CompleteByteSlice(b" ")))
-    );
+    assert_eq!(space(CompleteByteSlice(e)), Ok((CompleteByteSlice(empty), CompleteByteSlice(b" "))));
     assert_eq!(space(f), Ok((&b";"[..], &b" "[..])));
-    assert_eq!(
-      space(CompleteByteSlice(f)),
-      Ok((CompleteByteSlice(b";"), CompleteByteSlice(b" ")))
-    );
+    assert_eq!(space(CompleteByteSlice(f)), Ok((CompleteByteSlice(b";"), CompleteByteSlice(b" "))));
   }
 
   #[cfg(feature = "alloc")]
@@ -884,86 +838,35 @@ mod tests {
     let d = "azé12";
     let e = " ";
     assert_eq!(alpha(a), Err(Err::Incomplete(Needed::Size(1))));
-    assert_eq!(
-      alpha(CompleteStr(a)),
-      Ok((CompleteStr(empty), CompleteStr(a)))
-    );
-    assert_eq!(
-      alpha(b),
-      Err(Err::Error(error_position!(b, ErrorKind::Alpha)))
-    );
+    assert_eq!(alpha(CompleteStr(a)), Ok((CompleteStr(empty), CompleteStr(a))));
+    assert_eq!(alpha(b), Err(Err::Error(error_position!(b, ErrorKind::Alpha))));
     assert_eq!(alpha(c), Ok((&c[1..], &"a"[..])));
     assert_eq!(alpha(d), Ok(("12", &"azé"[..])));
-    assert_eq!(
-      digit(a),
-      Err(Err::Error(error_position!(a, ErrorKind::Digit)))
-    );
+    assert_eq!(digit(a), Err(Err::Error(error_position!(a, ErrorKind::Digit))));
     assert_eq!(digit(b), Err(Err::Incomplete(Needed::Size(1))));
-    assert_eq!(
-      digit(CompleteStr(b)),
-      Ok((CompleteStr(empty), CompleteStr(b)))
-    );
-    assert_eq!(
-      digit(c),
-      Err(Err::Error(error_position!(c, ErrorKind::Digit)))
-    );
-    assert_eq!(
-      digit(d),
-      Err(Err::Error(error_position!(d, ErrorKind::Digit)))
-    );
+    assert_eq!(digit(CompleteStr(b)), Ok((CompleteStr(empty), CompleteStr(b))));
+    assert_eq!(digit(c), Err(Err::Error(error_position!(c, ErrorKind::Digit))));
+    assert_eq!(digit(d), Err(Err::Error(error_position!(d, ErrorKind::Digit))));
     assert_eq!(hex_digit(a), Err(Err::Incomplete(Needed::Size(1))));
-    assert_eq!(
-      hex_digit(CompleteStr(a)),
-      Ok((CompleteStr(empty), CompleteStr(a)))
-    );
+    assert_eq!(hex_digit(CompleteStr(a)), Ok((CompleteStr(empty), CompleteStr(a))));
     assert_eq!(hex_digit(b), Err(Err::Incomplete(Needed::Size(1))));
-    assert_eq!(
-      hex_digit(CompleteStr(b)),
-      Ok((CompleteStr(empty), CompleteStr(b)))
-    );
+    assert_eq!(hex_digit(CompleteStr(b)), Ok((CompleteStr(empty), CompleteStr(b))));
     assert_eq!(hex_digit(c), Err(Err::Incomplete(Needed::Size(1))));
-    assert_eq!(
-      hex_digit(CompleteStr(c)),
-      Ok((CompleteStr(empty), CompleteStr(c)))
-    );
+    assert_eq!(hex_digit(CompleteStr(c)), Ok((CompleteStr(empty), CompleteStr(c))));
     assert_eq!(hex_digit(d), Ok(("zé12", &"a"[..])));
-    assert_eq!(
-      hex_digit(e),
-      Err(Err::Error(error_position!(e, ErrorKind::HexDigit)))
-    );
-    assert_eq!(
-      oct_digit(a),
-      Err(Err::Error(error_position!(a, ErrorKind::OctDigit)))
-    );
+    assert_eq!(hex_digit(e), Err(Err::Error(error_position!(e, ErrorKind::HexDigit))));
+    assert_eq!(oct_digit(a), Err(Err::Error(error_position!(a, ErrorKind::OctDigit))));
     assert_eq!(oct_digit(b), Err(Err::Incomplete(Needed::Size(1))));
-    assert_eq!(
-      oct_digit(CompleteStr(b)),
-      Ok((CompleteStr(empty), CompleteStr(b)))
-    );
-    assert_eq!(
-      oct_digit(c),
-      Err(Err::Error(error_position!(c, ErrorKind::OctDigit)))
-    );
-    assert_eq!(
-      oct_digit(d),
-      Err(Err::Error(error_position!(d, ErrorKind::OctDigit)))
-    );
+    assert_eq!(oct_digit(CompleteStr(b)), Ok((CompleteStr(empty), CompleteStr(b))));
+    assert_eq!(oct_digit(c), Err(Err::Error(error_position!(c, ErrorKind::OctDigit))));
+    assert_eq!(oct_digit(d), Err(Err::Error(error_position!(d, ErrorKind::OctDigit))));
     assert_eq!(alphanumeric(a), Err(Err::Incomplete(Needed::Size(1))));
-    assert_eq!(
-      alphanumeric(CompleteStr(a)),
-      Ok((CompleteStr(empty), CompleteStr(a)))
-    );
+    assert_eq!(alphanumeric(CompleteStr(a)), Ok((CompleteStr(empty), CompleteStr(a))));
     //assert_eq!(fix_error!(b,(), alphanumeric), Ok((empty, b)));
     assert_eq!(alphanumeric(c), Err(Err::Incomplete(Needed::Size(1))));
-    assert_eq!(
-      alphanumeric(CompleteStr(c)),
-      Ok((CompleteStr(empty), CompleteStr(c)))
-    );
+    assert_eq!(alphanumeric(CompleteStr(c)), Ok((CompleteStr(empty), CompleteStr(c))));
     assert_eq!(alphanumeric(d), Err(Err::Incomplete(Needed::Size(1))));
-    assert_eq!(
-      alphanumeric(CompleteStr(d)),
-      Ok((CompleteStr(""), CompleteStr("azé12")))
-    );
+    assert_eq!(alphanumeric(CompleteStr(d)), Ok((CompleteStr(""), CompleteStr("azé12"))));
     assert_eq!(space(e), Err(Err::Incomplete(Needed::Size(1))));
   }
 
@@ -1027,16 +930,10 @@ mod tests {
     assert_eq!(not_line_ending(a), Ok((&b"\nefgh"[..], &b"ab12cd"[..])));
 
     let b: &[u8] = b"ab12cd\nefgh\nijkl";
-    assert_eq!(
-      not_line_ending(b),
-      Ok((&b"\nefgh\nijkl"[..], &b"ab12cd"[..]))
-    );
+    assert_eq!(not_line_ending(b), Ok((&b"\nefgh\nijkl"[..], &b"ab12cd"[..])));
 
     let c: &[u8] = b"ab12cd\r\nefgh\nijkl";
-    assert_eq!(
-      not_line_ending(c),
-      Ok((&b"\r\nefgh\nijkl"[..], &b"ab12cd"[..]))
-    );
+    assert_eq!(not_line_ending(c), Ok((&b"\r\nefgh\nijkl"[..], &b"ab12cd"[..])));
 
     let d = CompleteByteSlice(b"ab12cd");
     assert_eq!(not_line_ending(d), Ok((CompleteByteSlice(b""), d)));
@@ -1065,10 +962,7 @@ mod tests {
     */
 
     let f = "βèƒôřè\rÂßÇáƒƭèř";
-    assert_eq!(
-      not_line_ending(f),
-      Err(Err::Error(error_position!(f, ErrorKind::Tag)))
-    );
+    assert_eq!(not_line_ending(f), Err(Err::Error(error_position!(f, ErrorKind::Tag))));
 
     let g = CompleteStr("ab12cd");
     assert_eq!(not_line_ending(g), Ok((CompleteStr(""), g)));
@@ -1131,31 +1025,19 @@ mod tests {
   #[test]
   fn i32_tests() {
     assert_eq!(be_i32(&[0x00, 0x00, 0x00, 0x00]), Ok((&b""[..], 0)));
-    assert_eq!(
-      be_i32(&[0x7f, 0xff, 0xff, 0xff]),
-      Ok((&b""[..], 2_147_483_647_i32))
-    );
+    assert_eq!(be_i32(&[0x7f, 0xff, 0xff, 0xff]), Ok((&b""[..], 2_147_483_647_i32)));
     assert_eq!(be_i32(&[0xff, 0xff, 0xff, 0xff]), Ok((&b""[..], -1)));
-    assert_eq!(
-      be_i32(&[0x80, 0x00, 0x00, 0x00]),
-      Ok((&b""[..], -2_147_483_648_i32))
-    );
+    assert_eq!(be_i32(&[0x80, 0x00, 0x00, 0x00]), Ok((&b""[..], -2_147_483_648_i32)));
   }
 
   #[test]
   fn i64_tests() {
-    assert_eq!(
-      be_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-      Ok((&b""[..], 0))
-    );
+    assert_eq!(be_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), Ok((&b""[..], 0)));
     assert_eq!(
       be_i64(&[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
       Ok((&b""[..], 9_223_372_036_854_775_807_i64))
     );
-    assert_eq!(
-      be_i64(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
-      Ok((&b""[..], -1))
-    );
+    assert_eq!(be_i64(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]), Ok((&b""[..], -1)));
     assert_eq!(
       be_i64(&[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
       Ok((&b""[..], -9_223_372_036_854_775_808_i64))
@@ -1195,31 +1077,19 @@ mod tests {
   #[test]
   fn le_i32_tests() {
     assert_eq!(le_i32(&[0x00, 0x00, 0x00, 0x00]), Ok((&b""[..], 0)));
-    assert_eq!(
-      le_i32(&[0xff, 0xff, 0xff, 0x7f]),
-      Ok((&b""[..], 2_147_483_647_i32))
-    );
+    assert_eq!(le_i32(&[0xff, 0xff, 0xff, 0x7f]), Ok((&b""[..], 2_147_483_647_i32)));
     assert_eq!(le_i32(&[0xff, 0xff, 0xff, 0xff]), Ok((&b""[..], -1)));
-    assert_eq!(
-      le_i32(&[0x00, 0x00, 0x00, 0x80]),
-      Ok((&b""[..], -2_147_483_648_i32))
-    );
+    assert_eq!(le_i32(&[0x00, 0x00, 0x00, 0x80]), Ok((&b""[..], -2_147_483_648_i32)));
   }
 
   #[test]
   fn le_i64_tests() {
-    assert_eq!(
-      le_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-      Ok((&b""[..], 0))
-    );
+    assert_eq!(le_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), Ok((&b""[..], 0)));
     assert_eq!(
       le_i64(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f]),
       Ok((&b""[..], 9_223_372_036_854_775_807_i64))
     );
-    assert_eq!(
-      le_i64(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
-      Ok((&b""[..], -1))
-    );
+    assert_eq!(le_i64(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]), Ok((&b""[..], -1)));
     assert_eq!(
       le_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80]),
       Ok((&b""[..], -9_223_372_036_854_775_808_i64))
@@ -1229,18 +1099,12 @@ mod tests {
   #[test]
   fn be_f32_tests() {
     assert_eq!(be_f32(&[0x00, 0x00, 0x00, 0x00]), Ok((&b""[..], 0_f32)));
-    assert_eq!(
-      be_f32(&[0x4d, 0x31, 0x1f, 0xd8]),
-      Ok((&b""[..], 185_728_392_f32))
-    );
+    assert_eq!(be_f32(&[0x4d, 0x31, 0x1f, 0xd8]), Ok((&b""[..], 185_728_392_f32)));
   }
 
   #[test]
   fn be_f64_tests() {
-    assert_eq!(
-      be_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-      Ok((&b""[..], 0_f64))
-    );
+    assert_eq!(be_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), Ok((&b""[..], 0_f64)));
     assert_eq!(
       be_f64(&[0x41, 0xa6, 0x23, 0xfb, 0x10, 0x00, 0x00, 0x00]),
       Ok((&b""[..], 185_728_392_f64))
@@ -1250,18 +1114,12 @@ mod tests {
   #[test]
   fn le_f32_tests() {
     assert_eq!(le_f32(&[0x00, 0x00, 0x00, 0x00]), Ok((&b""[..], 0_f32)));
-    assert_eq!(
-      le_f32(&[0xd8, 0x1f, 0x31, 0x4d]),
-      Ok((&b""[..], 185_728_392_f32))
-    );
+    assert_eq!(le_f32(&[0xd8, 0x1f, 0x31, 0x4d]), Ok((&b""[..], 185_728_392_f32)));
   }
 
   #[test]
   fn le_f64_tests() {
-    assert_eq!(
-      le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-      Ok((&b""[..], 0_f64))
-    );
+    assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), Ok((&b""[..], 0_f64)));
     assert_eq!(
       le_f64(&[0x00, 0x00, 0x00, 0x10, 0xfb, 0x23, 0xa6, 0x41]),
       Ok((&b""[..], 185_728_392_f64))
@@ -1270,19 +1128,13 @@ mod tests {
 
   #[test]
   fn hex_u32_tests() {
-    assert_eq!(
-      hex_u32(&b";"[..]),
-      Err(Err::Error(error_position!(&b";"[..], ErrorKind::IsA)))
-    );
+    assert_eq!(hex_u32(&b";"[..]), Err(Err::Error(error_position!(&b";"[..], ErrorKind::IsA))));
     assert_eq!(hex_u32(&b"ff;"[..]), Ok((&b";"[..], 255)));
     assert_eq!(hex_u32(&b"1be2;"[..]), Ok((&b";"[..], 7138)));
     assert_eq!(hex_u32(&b"c5a31be2;"[..]), Ok((&b";"[..], 3_315_801_058)));
     assert_eq!(hex_u32(&b"C5A31be2;"[..]), Ok((&b";"[..], 3_315_801_058)));
     assert_eq!(hex_u32(&b"00c5a31be2;"[..]), Ok((&b"e2;"[..], 12_952_347)));
-    assert_eq!(
-      hex_u32(&b"c5a31be201;"[..]),
-      Ok((&b"01;"[..], 3_315_801_058))
-    );
+    assert_eq!(hex_u32(&b"c5a31be201;"[..]), Ok((&b"01;"[..], 3_315_801_058)));
     assert_eq!(hex_u32(&b"ffffffff;"[..]), Ok((&b";"[..], 4_294_967_295)));
     assert_eq!(hex_u32(&b"0x1be2;"[..]), Ok((&b"x1be2;"[..], 0)));
   }
@@ -1325,14 +1177,8 @@ mod tests {
 
     named!(be_tst32<u32>, u32!(Endianness::Big));
     named!(le_tst32<u32>, u32!(Endianness::Little));
-    assert_eq!(
-      be_tst32(&[0x12, 0x00, 0x60, 0x00]),
-      Ok((&b""[..], 302_014_464_u32))
-    );
-    assert_eq!(
-      le_tst32(&[0x12, 0x00, 0x60, 0x00]),
-      Ok((&b""[..], 6_291_474_u32))
-    );
+    assert_eq!(be_tst32(&[0x12, 0x00, 0x60, 0x00]), Ok((&b""[..], 302_014_464_u32)));
+    assert_eq!(le_tst32(&[0x12, 0x00, 0x60, 0x00]), Ok((&b""[..], 6_291_474_u32)));
 
     named!(be_tst64<u64>, u64!(Endianness::Big));
     named!(le_tst64<u64>, u64!(Endianness::Little));
@@ -1352,14 +1198,8 @@ mod tests {
 
     named!(be_tsti32<i32>, i32!(Endianness::Big));
     named!(le_tsti32<i32>, i32!(Endianness::Little));
-    assert_eq!(
-      be_tsti32(&[0x00, 0x12, 0x60, 0x00]),
-      Ok((&b""[..], 1_204_224_i32))
-    );
-    assert_eq!(
-      le_tsti32(&[0x00, 0x12, 0x60, 0x00]),
-      Ok((&b""[..], 6_296_064_i32))
-    );
+    assert_eq!(be_tsti32(&[0x00, 0x12, 0x60, 0x00]), Ok((&b""[..], 1_204_224_i32)));
+    assert_eq!(le_tsti32(&[0x00, 0x12, 0x60, 0x00]), Ok((&b""[..], 6_296_064_i32)));
 
     named!(be_tsti64<i64>, i64!(Endianness::Big));
     named!(le_tsti64<i64>, i64!(Endianness::Little));
@@ -1377,11 +1217,7 @@ mod tests {
   #[cfg(feature = "std")]
   fn manual_configurable_endianness_test() {
     let x = 1;
-    let int_parse: Box<Fn(&[u8]) -> IResult<&[u8], u16>> = if x == 2 {
-      Box::new(be_u16)
-    } else {
-      Box::new(le_u16)
-    };
+    let int_parse: Box<Fn(&[u8]) -> IResult<&[u8], u16>> = if x == 2 { Box::new(be_u16) } else { Box::new(le_u16) };
     println!("{:?}", int_parse(&b"3"[..]));
     assert_eq!(int_parse(&[0x80, 0x00]), Ok((&b""[..], 128_u16)));
   }
@@ -1405,16 +1241,10 @@ mod tests {
     assert_eq!(hex_digit(i), Ok((&b";"[..], &i[..i.len() - 1])));
 
     let i = &b"g"[..];
-    assert_eq!(
-      hex_digit(i),
-      Err(Err::Error(error_position!(i, ErrorKind::HexDigit)))
-    );
+    assert_eq!(hex_digit(i), Err(Err::Error(error_position!(i, ErrorKind::HexDigit))));
 
     let i = &b"G"[..];
-    assert_eq!(
-      hex_digit(i),
-      Err(Err::Error(error_position!(i, ErrorKind::HexDigit)))
-    );
+    assert_eq!(hex_digit(i), Err(Err::Error(error_position!(i, ErrorKind::HexDigit))));
 
     assert!(is_hex_digit(b'0'));
     assert!(is_hex_digit(b'9'));
@@ -1436,10 +1266,7 @@ mod tests {
     assert_eq!(oct_digit(i), Ok((&b";"[..], &i[..i.len() - 1])));
 
     let i = &b"8"[..];
-    assert_eq!(
-      oct_digit(i),
-      Err(Err::Error(error_position!(i, ErrorKind::OctDigit)))
-    );
+    assert_eq!(oct_digit(i), Err(Err::Error(error_position!(i, ErrorKind::OctDigit))));
 
     assert!(is_oct_digit(b'0'));
     assert!(is_oct_digit(b'7'));
@@ -1455,10 +1282,7 @@ mod tests {
 
   #[test]
   fn full_line_windows() {
-    named!(
-      take_full_line<(&[u8], &[u8])>,
-      tuple!(not_line_ending, line_ending)
-    );
+    named!(take_full_line<(&[u8], &[u8])>, tuple!(not_line_ending, line_ending));
     let input = b"abc\r\n";
     let output = take_full_line(input);
     assert_eq!(output, Ok((&b""[..], (&b"abc"[..], &b"\r\n"[..]))));
@@ -1466,10 +1290,7 @@ mod tests {
 
   #[test]
   fn full_line_unix() {
-    named!(
-      take_full_line<(&[u8], &[u8])>,
-      tuple!(not_line_ending, line_ending)
-    );
+    named!(take_full_line<(&[u8], &[u8])>, tuple!(not_line_ending, line_ending));
     let input = b"abc\n";
     let output = take_full_line(input);
     assert_eq!(output, Ok((&b""[..], (&b"abc"[..], &b"\n"[..]))));
@@ -1493,17 +1314,11 @@ mod tests {
   fn cr_lf() {
     assert_eq!(crlf(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
     assert_eq!(crlf(&b"\r"[..]), Err(Err::Incomplete(Needed::Size(2))));
-    assert_eq!(
-      crlf(&b"\ra"[..]),
-      Err(Err::Error(error_position!(&b"\ra"[..], ErrorKind::CrLf)))
-    );
+    assert_eq!(crlf(&b"\ra"[..]), Err(Err::Error(error_position!(&b"\ra"[..], ErrorKind::CrLf))));
 
     assert_eq!(crlf("\r\na"), Ok(("a", "\r\n")));
     assert_eq!(crlf("\r"), Err(Err::Incomplete(Needed::Size(2))));
-    assert_eq!(
-      crlf("\ra"),
-      Err(Err::Error(error_position!("\ra", ErrorKind::CrLf)))
-    );
+    assert_eq!(crlf("\ra"), Err(Err::Error(error_position!("\ra", ErrorKind::CrLf))));
   }
 
   #[test]
@@ -1511,18 +1326,12 @@ mod tests {
     assert_eq!(eol(&b"\na"[..]), Ok((&b"a"[..], &b"\n"[..])));
     assert_eq!(eol(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
     assert_eq!(eol(&b"\r"[..]), Err(Err::Incomplete(Needed::Size(2))));
-    assert_eq!(
-      eol(&b"\ra"[..]),
-      Err(Err::Error(error_position!(&b"\ra"[..], ErrorKind::CrLf)))
-    );
+    assert_eq!(eol(&b"\ra"[..]), Err(Err::Error(error_position!(&b"\ra"[..], ErrorKind::CrLf))));
 
     assert_eq!(eol("\na"), Ok(("a", "\n")));
     assert_eq!(eol("\r\na"), Ok(("a", "\r\n")));
     assert_eq!(eol("\r"), Err(Err::Incomplete(Needed::Size(2))));
-    assert_eq!(
-      eol("\ra"),
-      Err(Err::Error(error_position!("\ra", ErrorKind::CrLf)))
-    );
+    assert_eq!(eol("\ra"), Err(Err::Error(error_position!("\ra", ErrorKind::CrLf))));
   }
 
   #[test]
@@ -1552,10 +1361,7 @@ mod tests {
 
       println!("now parsing: {} -> {}", test, expected32);
 
-      assert_eq!(
-        recognize_float(CompleteStr(test)),
-        Ok((CompleteStr(""), CompleteStr(test)))
-      );
+      assert_eq!(recognize_float(CompleteStr(test)), Ok((CompleteStr(""), CompleteStr(test))));
       let larger = format!("{};", test);
       assert_eq!(recognize_float(&larger[..]), Ok((";", test)));
 
@@ -1567,10 +1373,7 @@ mod tests {
     }
 
     let remaining_exponent = "-1.234E-";
-    assert_eq!(
-      recognize_float(remaining_exponent),
-      Err(Err::Incomplete(Needed::Size(1)))
-    );
+    assert_eq!(recognize_float(remaining_exponent), Err(Err::Incomplete(Needed::Size(1))));
   }
 
   #[allow(dead_code)]

--- a/src/regexp.rs
+++ b/src/regexp.rs
@@ -560,10 +560,10 @@ macro_rules! re_bytes_captures_static (
 );
 #[cfg(test)]
 mod tests {
+  use internal::Err;
   #[cfg(feature = "alloc")]
   use lib::std::vec::Vec;
   use util::ErrorKind;
-  use internal::Err;
 
   #[test]
   fn re_match() {
@@ -571,10 +571,7 @@ mod tests {
     assert_eq!(rm("2015-09-07"), Ok(("", "2015-09-07")));
     assert_eq!(
       rm("blah"),
-      Err(Err::Error(error_position!(
-        &"blah"[..],
-        ErrorKind::RegexpMatch::<u32>
-      ),))
+      Err(Err::Error(error_position!(&"blah"[..], ErrorKind::RegexpMatch::<u32>),))
     );
     assert_eq!(rm("2015-09-07blah"), Ok(("", "2015-09-07blah")));
   }
@@ -586,10 +583,7 @@ mod tests {
     assert_eq!(rm("2015-09-07"), Ok(("", "2015-09-07")));
     assert_eq!(
       rm("blah"),
-      Err(Err::Error(error_position!(
-        &"blah"[..],
-        ErrorKind::RegexpMatch::<u32>
-      ),))
+      Err(Err::Error(error_position!(&"blah"[..], ErrorKind::RegexpMatch::<u32>),))
     );
     assert_eq!(rm("2015-09-07blah"), Ok(("", "2015-09-07blah")));
   }
@@ -600,10 +594,7 @@ mod tests {
     assert_eq!(rm("2015-09-07"), Ok(("", "2015-09-07")));
     assert_eq!(
       rm("blah"),
-      Err(Err::Error(error_position!(
-        &"blah"[..],
-        ErrorKind::RegexpFind::<u32>
-      ),))
+      Err(Err::Error(error_position!(&"blah"[..], ErrorKind::RegexpFind::<u32>),))
     );
     assert_eq!(rm("2015-09-07blah"), Ok(("blah", "2015-09-07")));
   }
@@ -615,10 +606,7 @@ mod tests {
     assert_eq!(rm("2015-09-07"), Ok(("", "2015-09-07")));
     assert_eq!(
       rm("blah"),
-      Err(Err::Error(error_position!(
-        &"blah"[..],
-        ErrorKind::RegexpFind::<u32>
-      ),))
+      Err(Err::Error(error_position!(&"blah"[..], ErrorKind::RegexpFind::<u32>),))
     );
     assert_eq!(rm("2015-09-07blah"), Ok(("blah", "2015-09-07")));
   }
@@ -630,10 +618,7 @@ mod tests {
     assert_eq!(rm("2015-09-07"), Ok(("", vec!["2015-09-07"])));
     assert_eq!(
       rm("blah"),
-      Err(Err::Error(error_position!(
-        &"blah"[..],
-        ErrorKind::RegexpMatches::<u32>
-      )))
+      Err(Err::Error(error_position!(&"blah"[..], ErrorKind::RegexpMatches::<u32>)))
     );
     assert_eq!(
       rm("aaa2015-09-07blah2015-09-09pouet"),
@@ -649,10 +634,7 @@ mod tests {
     assert_eq!(rm("2015-09-07"), Ok(("", vec!["2015-09-07"])));
     assert_eq!(
       rm("blah"),
-      Err(Err::Error(error_position!(
-        &"blah"[..],
-        ErrorKind::RegexpMatches::<u32>
-      )))
+      Err(Err::Error(error_position!(&"blah"[..], ErrorKind::RegexpMatches::<u32>)))
     );
     assert_eq!(
       rm("aaa2015-09-07blah2015-09-09pouet"),
@@ -670,17 +652,11 @@ mod tests {
     );
     assert_eq!(
       rm("blah"),
-      Err(Err::Error(error_position!(
-        &"blah"[..],
-        ErrorKind::RegexpCapture::<u32>
-      )))
+      Err(Err::Error(error_position!(&"blah"[..], ErrorKind::RegexpCapture::<u32>)))
     );
     assert_eq!(
       rm("hello nom 0.3.11 world regex 0.1.41"),
-      Ok((
-        " world regex 0.1.41",
-        vec!["nom 0.3.11", "nom", "0.3.11", "0", "3", "11"]
-      ))
+      Ok((" world regex 0.1.41", vec!["nom 0.3.11", "nom", "0.3.11", "0", "3", "11"]))
     );
   }
 
@@ -695,17 +671,11 @@ mod tests {
     );
     assert_eq!(
       rm("blah"),
-      Err(Err::Error(error_position!(
-        &"blah"[..],
-        ErrorKind::RegexpCapture::<u32>
-      )))
+      Err(Err::Error(error_position!(&"blah"[..], ErrorKind::RegexpCapture::<u32>)))
     );
     assert_eq!(
       rm("hello nom 0.3.11 world regex 0.1.41"),
-      Ok((
-        " world regex 0.1.41",
-        vec!["nom 0.3.11", "nom", "0.3.11", "0", "3", "11"]
-      ))
+      Ok((" world regex 0.1.41", vec!["nom 0.3.11", "nom", "0.3.11", "0", "3", "11"]))
     );
   }
 
@@ -715,17 +685,11 @@ mod tests {
     named!(rm< &str,Vec<Vec<&str>> >, re_captures!(r"([[:alpha:]]+)\s+((\d+).(\d+).(\d+))"));
     assert_eq!(
       rm("blah nom 0.3.11pouet"),
-      Ok((
-        "pouet",
-        vec![vec!["nom 0.3.11", "nom", "0.3.11", "0", "3", "11"]]
-      ))
+      Ok(("pouet", vec![vec!["nom 0.3.11", "nom", "0.3.11", "0", "3", "11"]]))
     );
     assert_eq!(
       rm("blah"),
-      Err(Err::Error(error_position!(
-        &"blah"[..],
-        ErrorKind::RegexpCapture::<u32>
-      )))
+      Err(Err::Error(error_position!(&"blah"[..], ErrorKind::RegexpCapture::<u32>)))
     );
     assert_eq!(
       rm("hello nom 0.3.11 world regex 0.1.41 aaa"),
@@ -746,17 +710,11 @@ mod tests {
     named!(rm< &str,Vec<Vec<&str>> >, re_captures_static!(r"([[:alpha:]]+)\s+((\d+).(\d+).(\d+))"));
     assert_eq!(
       rm("blah nom 0.3.11pouet"),
-      Ok((
-        "pouet",
-        vec![vec!["nom 0.3.11", "nom", "0.3.11", "0", "3", "11"]]
-      ))
+      Ok(("pouet", vec![vec!["nom 0.3.11", "nom", "0.3.11", "0", "3", "11"]]))
     );
     assert_eq!(
       rm("blah"),
-      Err(Err::Error(error_position!(
-        &"blah"[..],
-        ErrorKind::RegexpCapture::<u32>
-      )))
+      Err(Err::Error(error_position!(&"blah"[..], ErrorKind::RegexpCapture::<u32>)))
     );
     assert_eq!(
       rm("hello nom 0.3.11 world regex 0.1.41 aaa"),
@@ -776,15 +734,9 @@ mod tests {
     assert_eq!(rm(&b"2015-09-07"[..]), Ok((&b""[..], &b"2015-09-07"[..])));
     assert_eq!(
       rm(&b"blah"[..]),
-      Err(Err::Error(error_position!(
-        &b"blah"[..],
-        ErrorKind::RegexpMatch::<u32>
-      )))
+      Err(Err::Error(error_position!(&b"blah"[..], ErrorKind::RegexpMatch::<u32>)))
     );
-    assert_eq!(
-      rm(&b"2015-09-07blah"[..]),
-      Ok((&b""[..], &b"2015-09-07blah"[..]))
-    );
+    assert_eq!(rm(&b"2015-09-07blah"[..]), Ok((&b""[..], &b"2015-09-07blah"[..])));
   }
 
   #[cfg(feature = "regexp_macros")]
@@ -794,15 +746,9 @@ mod tests {
     assert_eq!(rm(&b"2015-09-07"[..]), Ok((&b""[..], &b"2015-09-07"[..])));
     assert_eq!(
       rm(&b"blah"[..]),
-      Err(Err::Error(error_position!(
-        &b"blah"[..],
-        ErrorKind::RegexpMatch::<u32>
-      )))
+      Err(Err::Error(error_position!(&b"blah"[..], ErrorKind::RegexpMatch::<u32>)))
     );
-    assert_eq!(
-      rm(&b"2015-09-07blah"[..]),
-      Ok((&b""[..], &b"2015-09-07blah"[..]))
-    );
+    assert_eq!(rm(&b"2015-09-07blah"[..]), Ok((&b""[..], &b"2015-09-07blah"[..])));
   }
 
   #[test]
@@ -811,15 +757,9 @@ mod tests {
     assert_eq!(rm(&b"2015-09-07"[..]), Ok((&b""[..], &b"2015-09-07"[..])));
     assert_eq!(
       rm(&b"blah"[..]),
-      Err(Err::Error(error_position!(
-        &b"blah"[..],
-        ErrorKind::RegexpFind::<u32>
-      )))
+      Err(Err::Error(error_position!(&b"blah"[..], ErrorKind::RegexpFind::<u32>)))
     );
-    assert_eq!(
-      rm(&b"2015-09-07blah"[..]),
-      Ok((&b"blah"[..], &b"2015-09-07"[..]))
-    );
+    assert_eq!(rm(&b"2015-09-07blah"[..]), Ok((&b"blah"[..], &b"2015-09-07"[..])));
   }
 
   #[cfg(feature = "regexp_macros")]
@@ -829,31 +769,19 @@ mod tests {
     assert_eq!(rm(&b"2015-09-07"[..]), Ok((&b""[..], &b"2015-09-07"[..])));
     assert_eq!(
       rm(&b"blah"[..]),
-      Err(Err::Error(error_position!(
-        &b"blah"[..],
-        ErrorKind::RegexpFind::<u32>
-      )))
+      Err(Err::Error(error_position!(&b"blah"[..], ErrorKind::RegexpFind::<u32>)))
     );
-    assert_eq!(
-      rm(&b"2015-09-07blah"[..]),
-      Ok((&b"blah"[..], &b"2015-09-07"[..]))
-    );
+    assert_eq!(rm(&b"2015-09-07blah"[..]), Ok((&b"blah"[..], &b"2015-09-07"[..])));
   }
 
   #[cfg(feature = "alloc")]
   #[test]
   fn re_bytes_matches() {
     named!(rm<Vec<&[u8]>>, re_bytes_matches!(r"\d{4}-\d{2}-\d{2}"));
-    assert_eq!(
-      rm(&b"2015-09-07"[..]),
-      Ok((&b""[..], vec![&b"2015-09-07"[..]]))
-    );
+    assert_eq!(rm(&b"2015-09-07"[..]), Ok((&b""[..], vec![&b"2015-09-07"[..]])));
     assert_eq!(
       rm(&b"blah"[..]),
-      Err(Err::Error(error_position!(
-        &b"blah"[..],
-        ErrorKind::RegexpMatches::<u32>
-      )))
+      Err(Err::Error(error_position!(&b"blah"[..], ErrorKind::RegexpMatches::<u32>)))
     );
     assert_eq!(
       rm(&b"aaa2015-09-07blah2015-09-09pouet"[..]),
@@ -865,20 +793,11 @@ mod tests {
   #[cfg(feature = "regexp_macros")]
   #[test]
   fn re_bytes_matches_static() {
-    named!(
-      rm<Vec<&[u8]>>,
-      re_bytes_matches_static!(r"\d{4}-\d{2}-\d{2}")
-    );
-    assert_eq!(
-      rm(&b"2015-09-07"[..]),
-      Ok((&b""[..], vec![&b"2015-09-07"[..]]))
-    );
+    named!(rm<Vec<&[u8]>>, re_bytes_matches_static!(r"\d{4}-\d{2}-\d{2}"));
+    assert_eq!(rm(&b"2015-09-07"[..]), Ok((&b""[..], vec![&b"2015-09-07"[..]])));
     assert_eq!(
       rm(&b"blah"[..]),
-      Err(Err::Error(error_position!(
-        &b"blah"[..],
-        ErrorKind::RegexpMatches::<u32>
-      )))
+      Err(Err::Error(error_position!(&b"blah"[..], ErrorKind::RegexpMatches::<u32>)))
     );
     assert_eq!(
       rm(&b"aaa2015-09-07blah2015-09-09pouet"[..]),
@@ -889,43 +808,23 @@ mod tests {
   #[cfg(feature = "alloc")]
   #[test]
   fn re_bytes_capture() {
-    named!(
-      rm<Vec<&[u8]>>,
-      re_bytes_capture!(r"([[:alpha:]]+)\s+((\d+).(\d+).(\d+))")
-    );
+    named!(rm<Vec<&[u8]>>, re_bytes_capture!(r"([[:alpha:]]+)\s+((\d+).(\d+).(\d+))"));
     assert_eq!(
       rm(&b"blah nom 0.3.11pouet"[..]),
       Ok((
         &b"pouet"[..],
-        vec![
-          &b"nom 0.3.11"[..],
-          &b"nom"[..],
-          &b"0.3.11"[..],
-          &b"0"[..],
-          &b"3"[..],
-          &b"11"[..],
-        ]
+        vec![&b"nom 0.3.11"[..], &b"nom"[..], &b"0.3.11"[..], &b"0"[..], &b"3"[..], &b"11"[..]]
       ))
     );
     assert_eq!(
       rm(&b"blah"[..]),
-      Err(Err::Error(error_position!(
-        &b"blah"[..],
-        ErrorKind::RegexpCapture::<u32>
-      )))
+      Err(Err::Error(error_position!(&b"blah"[..], ErrorKind::RegexpCapture::<u32>)))
     );
     assert_eq!(
       rm(&b"hello nom 0.3.11 world regex 0.1.41"[..]),
       Ok((
         &b" world regex 0.1.41"[..],
-        vec![
-          &b"nom 0.3.11"[..],
-          &b"nom"[..],
-          &b"0.3.11"[..],
-          &b"0"[..],
-          &b"3"[..],
-          &b"11"[..],
-        ]
+        vec![&b"nom 0.3.11"[..], &b"nom"[..], &b"0.3.11"[..], &b"0"[..], &b"3"[..], &b"11"[..]]
       ))
     );
   }
@@ -934,43 +833,23 @@ mod tests {
   #[cfg(feature = "regexp_macros")]
   #[test]
   fn re_bytes_capture_static() {
-    named!(
-      rm<Vec<&[u8]>>,
-      re_bytes_capture_static!(r"([[:alpha:]]+)\s+((\d+).(\d+).(\d+))")
-    );
+    named!(rm<Vec<&[u8]>>, re_bytes_capture_static!(r"([[:alpha:]]+)\s+((\d+).(\d+).(\d+))"));
     assert_eq!(
       rm(&b"blah nom 0.3.11pouet"[..]),
       Ok((
         &b"pouet"[..],
-        vec![
-          &b"nom 0.3.11"[..],
-          &b"nom"[..],
-          &b"0.3.11"[..],
-          &b"0"[..],
-          &b"3"[..],
-          &b"11"[..],
-        ]
+        vec![&b"nom 0.3.11"[..], &b"nom"[..], &b"0.3.11"[..], &b"0"[..], &b"3"[..], &b"11"[..]]
       ))
     );
     assert_eq!(
       rm(&b"blah"[..]),
-      Err(Err::Error(error_position!(
-        &b"blah"[..],
-        ErrorKind::RegexpCapture::<u32>
-      )))
+      Err(Err::Error(error_position!(&b"blah"[..], ErrorKind::RegexpCapture::<u32>)))
     );
     assert_eq!(
       rm(&b"hello nom 0.3.11 world regex 0.1.41"[..]),
       Ok((
         &b" world regex 0.1.41"[..],
-        vec![
-          &b"nom 0.3.11"[..],
-          &b"nom"[..],
-          &b"0.3.11"[..],
-          &b"0"[..],
-          &b"3"[..],
-          &b"11"[..],
-        ]
+        vec![&b"nom 0.3.11"[..], &b"nom"[..], &b"0.3.11"[..], &b"0"[..], &b"3"[..], &b"11"[..]]
       ))
     );
   }
@@ -978,46 +857,26 @@ mod tests {
   #[cfg(feature = "alloc")]
   #[test]
   fn re_bytes_captures() {
-    named!(
-      rm<Vec<Vec<&[u8]>>>,
-      re_bytes_captures!(r"([[:alpha:]]+)\s+((\d+).(\d+).(\d+))")
-    );
+    named!(rm<Vec<Vec<&[u8]>>>, re_bytes_captures!(r"([[:alpha:]]+)\s+((\d+).(\d+).(\d+))"));
     assert_eq!(
       rm(&b"blah nom 0.3.11pouet"[..]),
       Ok((
         &b"pouet"[..],
         vec![
-          vec![
-            &b"nom 0.3.11"[..],
-            &b"nom"[..],
-            &b"0.3.11"[..],
-            &b"0"[..],
-            &b"3"[..],
-            &b"11"[..],
-          ],
+          vec![&b"nom 0.3.11"[..], &b"nom"[..], &b"0.3.11"[..], &b"0"[..], &b"3"[..], &b"11"[..]],
         ]
       ))
     );
     assert_eq!(
       rm(&b"blah"[..]),
-      Err(Err::Error(error_position!(
-        &b"blah"[..],
-        ErrorKind::RegexpCapture::<u32>
-      )))
+      Err(Err::Error(error_position!(&b"blah"[..], ErrorKind::RegexpCapture::<u32>)))
     );
     assert_eq!(
       rm(&b"hello nom 0.3.11 world regex 0.1.41 aaa"[..]),
       Ok((
         &b" aaa"[..],
         vec![
-          vec![
-            &b"nom 0.3.11"[..],
-            &b"nom"[..],
-            &b"0.3.11"[..],
-            &b"0"[..],
-            &b"3"[..],
-            &b"11"[..],
-          ],
+          vec![&b"nom 0.3.11"[..], &b"nom"[..], &b"0.3.11"[..], &b"0"[..], &b"3"[..], &b"11"[..]],
           vec![
             &b"regex 0.1.41"[..],
             &b"regex"[..],
@@ -1044,37 +903,20 @@ mod tests {
       Ok((
         &b"pouet"[..],
         vec![
-          vec![
-            &b"nom 0.3.11"[..],
-            &b"nom"[..],
-            &b"0.3.11"[..],
-            &b"0"[..],
-            &b"3"[..],
-            &b"11"[..],
-          ],
+          vec![&b"nom 0.3.11"[..], &b"nom"[..], &b"0.3.11"[..], &b"0"[..], &b"3"[..], &b"11"[..]],
         ]
       ))
     );
     assert_eq!(
       rm(&b"blah"[..]),
-      Err(Err::Error(error_position!(
-        &b"blah"[..],
-        ErrorKind::RegexpCapture::<u32>
-      )))
+      Err(Err::Error(error_position!(&b"blah"[..], ErrorKind::RegexpCapture::<u32>)))
     );
     assert_eq!(
       rm(&b"hello nom 0.3.11 world regex 0.1.41 aaa"[..]),
       Ok((
         &b" aaa"[..],
         vec![
-          vec![
-            &b"nom 0.3.11"[..],
-            &b"nom"[..],
-            &b"0.3.11"[..],
-            &b"0"[..],
-            &b"3"[..],
-            &b"11"[..],
-          ],
+          vec![&b"nom 0.3.11"[..], &b"nom"[..], &b"0.3.11"[..], &b"0"[..], &b"3"[..], &b"11"[..]],
           vec![
             &b"regex 0.1.41"[..],
             &b"regex"[..],

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -439,11 +439,11 @@ macro_rules! do_parse (
 #[cfg(test)]
 mod tests {
   use internal::{Err, IResult, Needed};
-  use util::ErrorKind;
-  use nom::be_u16;
   #[cfg(feature = "alloc")]
   #[cfg(feature = "verbose-errors")]
   use lib::std::vec::Vec;
+  use nom::be_u16;
+  use util::ErrorKind;
 
   // reproduce the tag and take macros, because of module import order
   macro_rules! tag (
@@ -699,18 +699,9 @@ mod tests {
     named!(tag_def, tag!("def"));
     named!( pair_abc_def<&[u8],(&[u8], &[u8])>, pair!(tag_abc, tag_def) );
 
-    assert_eq!(
-      pair_abc_def(&b"abcdefghijkl"[..]),
-      Ok((&b"ghijkl"[..], (&b"abc"[..], &b"def"[..])))
-    );
-    assert_eq!(
-      pair_abc_def(&b"ab"[..]),
-      Err(Err::Incomplete(Needed::Size(3)))
-    );
-    assert_eq!(
-      pair_abc_def(&b"abcd"[..]),
-      Err(Err::Incomplete(Needed::Size(3)))
-    );
+    assert_eq!(pair_abc_def(&b"abcdefghijkl"[..]), Ok((&b"ghijkl"[..], (&b"abc"[..], &b"def"[..]))));
+    assert_eq!(pair_abc_def(&b"ab"[..]), Err(Err::Incomplete(Needed::Size(3))));
+    assert_eq!(pair_abc_def(&b"abcd"[..]), Err(Err::Incomplete(Needed::Size(3))));
     assert_eq!(
       pair_abc_def(&b"xxx"[..]),
       Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
@@ -736,14 +727,8 @@ mod tests {
       sep_pair_abc_def(&b"abc,defghijkl"[..]),
       Ok((&b"ghijkl"[..], (&b"abc"[..], &b"def"[..])))
     );
-    assert_eq!(
-      sep_pair_abc_def(&b"ab"[..]),
-      Err(Err::Incomplete(Needed::Size(3)))
-    );
-    assert_eq!(
-      sep_pair_abc_def(&b"abc,d"[..]),
-      Err(Err::Incomplete(Needed::Size(3)))
-    );
+    assert_eq!(sep_pair_abc_def(&b"ab"[..]), Err(Err::Incomplete(Needed::Size(3))));
+    assert_eq!(sep_pair_abc_def(&b"abc,d"[..]), Err(Err::Incomplete(Needed::Size(3))));
     assert_eq!(
       sep_pair_abc_def(&b"xxx"[..]),
       Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
@@ -764,18 +749,9 @@ mod tests {
     named!(tag_efgh, tag!("efgh"));
     named!( preceded_abcd_efgh<&[u8], &[u8]>, preceded!(tag_abcd, tag_efgh) );
 
-    assert_eq!(
-      preceded_abcd_efgh(&b"abcdefghijkl"[..]),
-      Ok((&b"ijkl"[..], &b"efgh"[..]))
-    );
-    assert_eq!(
-      preceded_abcd_efgh(&b"ab"[..]),
-      Err(Err::Incomplete(Needed::Size(4)))
-    );
-    assert_eq!(
-      preceded_abcd_efgh(&b"abcde"[..]),
-      Err(Err::Incomplete(Needed::Size(4)))
-    );
+    assert_eq!(preceded_abcd_efgh(&b"abcdefghijkl"[..]), Ok((&b"ijkl"[..], &b"efgh"[..])));
+    assert_eq!(preceded_abcd_efgh(&b"ab"[..]), Err(Err::Incomplete(Needed::Size(4))));
+    assert_eq!(preceded_abcd_efgh(&b"abcde"[..]), Err(Err::Incomplete(Needed::Size(4))));
     assert_eq!(
       preceded_abcd_efgh(&b"xxx"[..]),
       Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
@@ -796,18 +772,9 @@ mod tests {
     named!(tag_efgh, tag!("efgh"));
     named!( terminated_abcd_efgh<&[u8], &[u8]>, terminated!(tag_abcd, tag_efgh) );
 
-    assert_eq!(
-      terminated_abcd_efgh(&b"abcdefghijkl"[..]),
-      Ok((&b"ijkl"[..], &b"abcd"[..]))
-    );
-    assert_eq!(
-      terminated_abcd_efgh(&b"ab"[..]),
-      Err(Err::Incomplete(Needed::Size(4)))
-    );
-    assert_eq!(
-      terminated_abcd_efgh(&b"abcde"[..]),
-      Err(Err::Incomplete(Needed::Size(4)))
-    );
+    assert_eq!(terminated_abcd_efgh(&b"abcdefghijkl"[..]), Ok((&b"ijkl"[..], &b"abcd"[..])));
+    assert_eq!(terminated_abcd_efgh(&b"ab"[..]), Err(Err::Incomplete(Needed::Size(4))));
+    assert_eq!(terminated_abcd_efgh(&b"abcde"[..]), Err(Err::Incomplete(Needed::Size(4))));
     assert_eq!(
       terminated_abcd_efgh(&b"xxx"[..]),
       Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
@@ -829,32 +796,17 @@ mod tests {
     named!(tag_ghi, tag!("ghi"));
     named!( delimited_abc_def_ghi<&[u8], &[u8]>, delimited!(tag_abc, tag_def, tag_ghi) );
 
-    assert_eq!(
-      delimited_abc_def_ghi(&b"abcdefghijkl"[..]),
-      Ok((&b"jkl"[..], &b"def"[..]))
-    );
-    assert_eq!(
-      delimited_abc_def_ghi(&b"ab"[..]),
-      Err(Err::Incomplete(Needed::Size(3)))
-    );
-    assert_eq!(
-      delimited_abc_def_ghi(&b"abcde"[..]),
-      Err(Err::Incomplete(Needed::Size(3)))
-    );
-    assert_eq!(
-      delimited_abc_def_ghi(&b"abcdefgh"[..]),
-      Err(Err::Incomplete(Needed::Size(3)))
-    );
+    assert_eq!(delimited_abc_def_ghi(&b"abcdefghijkl"[..]), Ok((&b"jkl"[..], &b"def"[..])));
+    assert_eq!(delimited_abc_def_ghi(&b"ab"[..]), Err(Err::Incomplete(Needed::Size(3))));
+    assert_eq!(delimited_abc_def_ghi(&b"abcde"[..]), Err(Err::Incomplete(Needed::Size(3))));
+    assert_eq!(delimited_abc_def_ghi(&b"abcdefgh"[..]), Err(Err::Incomplete(Needed::Size(3))));
     assert_eq!(
       delimited_abc_def_ghi(&b"xxx"[..]),
       Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
     );
     assert_eq!(
       delimited_abc_def_ghi(&b"xxxdefghi"[..]),
-      Err(Err::Error(error_position!(
-        &b"xxxdefghi"[..],
-        ErrorKind::Tag
-      ),))
+      Err(Err::Error(error_position!(&b"xxxdefghi"[..], ErrorKind::Tag),))
     );
     assert_eq!(
       delimited_abc_def_ghi(&b"abcxxxghi"[..]),
@@ -871,15 +823,9 @@ mod tests {
     named!(tuple_3<&[u8], (u16, &[u8], &[u8]) >,
     tuple!( be_u16 , take!(3), tag!("fg") ) );
 
-    assert_eq!(
-      tuple_3(&b"abcdefgh"[..]),
-      Ok((&b"h"[..], (0x6162u16, &b"cde"[..], &b"fg"[..])))
-    );
+    assert_eq!(tuple_3(&b"abcdefgh"[..]), Ok((&b"h"[..], (0x6162u16, &b"cde"[..], &b"fg"[..]))));
     assert_eq!(tuple_3(&b"abcd"[..]), Err(Err::Incomplete(Needed::Size(3))));
-    assert_eq!(
-      tuple_3(&b"abcde"[..]),
-      Err(Err::Incomplete(Needed::Size(2)))
-    );
+    assert_eq!(tuple_3(&b"abcde"[..]), Err(Err::Incomplete(Needed::Size(2))));
     assert_eq!(
       tuple_3(&b"abcdejk"[..]),
       Err(Err::Error(error_position!(&b"jk"[..], ErrorKind::Tag)))
@@ -915,19 +861,10 @@ mod tests {
 
     //trace_macros!(false);
 
-    assert_eq!(
-      do_parser(&b"abcdabcdefghefghX"[..]),
-      Ok((&b"X"[..], (1, 2)))
-    );
+    assert_eq!(do_parser(&b"abcdabcdefghefghX"[..]), Ok((&b"X"[..], (1, 2))));
     assert_eq!(do_parser(&b"abcdefghefghX"[..]), Ok((&b"X"[..], (1, 2))));
-    assert_eq!(
-      do_parser(&b"abcdab"[..]),
-      Err(Err::Incomplete(Needed::Size(4)))
-    );
-    assert_eq!(
-      do_parser(&b"abcdefghef"[..]),
-      Err(Err::Incomplete(Needed::Size(4)))
-    );
+    assert_eq!(do_parser(&b"abcdab"[..]), Err(Err::Incomplete(Needed::Size(4))));
+    assert_eq!(do_parser(&b"abcdefghef"[..]), Err(Err::Incomplete(Needed::Size(4))));
   }
 
   #[cfg_attr(rustfmt, rustfmt_skip)]

--- a/src/simple_errors.rs
+++ b/src/simple_errors.rs
@@ -13,8 +13,8 @@
 //! you can know precisely which parser got to which part of the input.
 //! The main drawback is that it is a lot slower than default error
 //! management.
-use util::{Convert, ErrorKind};
 use lib::std::convert::From;
+use util::{Convert, ErrorKind};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Context<I, E = u32> {

--- a/src/str.rs
+++ b/src/str.rs
@@ -261,10 +261,7 @@ mod test {
 
     match test(INPUT) {
       Ok((extra, output)) => {
-        assert!(
-          extra == " World!",
-          "Parser `tag_s` consumed leftover input."
-        );
+        assert!(extra == " World!", "Parser `tag_s` consumed leftover input.");
         assert!(
           output == TAG,
           "Parser `tag_s` doesn't return the tag it matched on success. \
@@ -306,10 +303,7 @@ mod test {
     match tag_s!(INPUT, TAG) {
       Err(Err::Error(_)) => (),
       other => {
-        panic!(
-          "Parser `tag_s` didn't fail when it should have. Got `{:?}`.`",
-          other
-        );
+        panic!("Parser `tag_s` didn't fail when it should have. Got `{:?}`.`", other);
       }
     };
   }
@@ -322,11 +316,7 @@ mod test {
 
     match take_s!(INPUT, 9) {
       Ok((extra, output)) => {
-        assert!(
-          extra == LEFTOVER,
-          "Parser `take_s` consumed leftover input. Leftover `{}`.",
-          extra
-        );
+        assert!(extra == LEFTOVER, "Parser `take_s` consumed leftover input. Leftover `{}`.", extra);
         assert!(
           output == CONSUMED,
           "Parser `take_s` doens't return the string it consumed on success. Expected `{}`, got `{}`.",
@@ -417,10 +407,7 @@ mod test {
     assert_eq!(f(&a[..]), Err(Err::Incomplete(Needed::Size(1))));
     assert_eq!(f(&b[..]), Err(Err::Incomplete(Needed::Size(1))));
     assert_eq!(f(&c[..]), Ok((&"123"[..], &b[..])));
-    assert_eq!(
-      f(&d[..]),
-      Err(Err::Error(error_position!(&d[..], ErrorKind::TakeWhile1)))
-    );
+    assert_eq!(f(&d[..]), Err(Err::Error(error_position!(&d[..], ErrorKind::TakeWhile1))));
   }
 
   #[test]
@@ -436,10 +423,7 @@ mod test {
     }
     match test(INPUT) {
       Ok((extra, output)) => {
-        assert!(
-          extra == LEFTOVER,
-          "Parser `take_till_s` consumed leftover input."
-        );
+        assert!(extra == LEFTOVER, "Parser `take_till_s` consumed leftover input.");
         assert!(
           output == CONSUMED,
           "Parser `take_till_s` doesn't return the string it consumed on success. \
@@ -469,10 +453,7 @@ mod test {
     }
     match test(INPUT) {
       Ok((extra, output)) => {
-        assert!(
-          extra == LEFTOVER,
-          "Parser `take_while_s` consumed leftover input."
-        );
+        assert!(extra == LEFTOVER, "Parser `take_while_s` consumed leftover input.");
         assert!(
           output == CONSUMED,
           "Parser `take_while_s` doesn't return the string it consumed on success. \
@@ -564,10 +545,7 @@ mod test {
     }
     match test(INPUT) {
       Ok((extra, output)) => {
-        assert!(
-          extra == LEFTOVER,
-          "Parser `take_while_s` consumed leftover input."
-        );
+        assert!(extra == LEFTOVER, "Parser `take_while_s` consumed leftover input.");
         assert!(
           output == CONSUMED,
           "Parser `take_while_s` doesn't return the string it consumed on success. \
@@ -593,10 +571,7 @@ mod test {
     }
     match test(INPUT) {
       Err(Err::Error(_)) => (),
-      other => panic!(
-        "Parser `is_not_s` didn't fail when it should have. Got `{:?}`.",
-        other
-      ),
+      other => panic!("Parser `is_not_s` didn't fail when it should have. Got `{:?}`.", other),
     };
   }
 
@@ -613,10 +588,7 @@ mod test {
     }
     match test(INPUT) {
       Ok((extra, output)) => {
-        assert!(
-          extra == LEFTOVER,
-          "Parser `take_while1_s` consumed leftover input."
-        );
+        assert!(extra == LEFTOVER, "Parser `take_while1_s` consumed leftover input.");
         assert!(
           output == CONSUMED,
           "Parser `take_while1_s` doesn't return the string it consumed on success. \
@@ -674,11 +646,7 @@ mod test {
     }
     match test(INPUT) {
       Ok((extra, output)) => {
-        assert!(
-          extra == LEFTOVER,
-          "Parser `is_a_s` consumed leftover input. Leftover `{}`.",
-          extra
-        );
+        assert!(extra == LEFTOVER, "Parser `is_a_s` consumed leftover input. Leftover `{}`.", extra);
         assert!(
           output == CONSUMED,
           "Parser `is_a_s` doens't return the string it consumed on success. Expected `{}`, got `{}`.",
@@ -722,10 +690,7 @@ mod test {
     }
     match test(INPUT) {
       Err(Err::Error(_)) => (),
-      other => panic!(
-        "Parser `is_a_s` didn't fail when it should have. Got `{:?}`.",
-        other
-      ),
+      other => panic!("Parser `is_a_s` didn't fail when it should have. Got `{:?}`.", other),
     };
   }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,13 +1,13 @@
 //! Traits input types have to implement to work with nom combinators
 //!
 use internal::{Err, IResult, Needed};
-use lib::std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 use lib::std::iter::Enumerate;
-use lib::std::slice::Iter;
 use lib::std::iter::Map;
+use lib::std::ops::{Range, RangeFrom, RangeFull, RangeTo};
+use lib::std::slice::Iter;
 
-use lib::std::str::Chars;
 use lib::std::str::CharIndices;
+use lib::std::str::Chars;
 use lib::std::str::FromStr;
 use lib::std::str::from_utf8;
 #[cfg(feature = "alloc")]
@@ -17,10 +17,10 @@ use lib::std::vec::Vec;
 
 use memchr;
 
-#[cfg(feature = "verbose-errors")]
-use verbose_errors::Context;
 #[cfg(not(feature = "verbose-errors"))]
 use simple_errors::Context;
+#[cfg(feature = "verbose-errors")]
+use verbose_errors::Context;
 
 use util::ErrorKind;
 
@@ -460,8 +460,8 @@ impl<'a> InputTake for &'a str {
 /// `InputTakeAtPosition` (like the one for `&[u8]`).
 pub trait UnspecializedInput {}
 
-use types::CompleteStr;
 use types::CompleteByteSlice;
+use types::CompleteStr;
 
 /// methods to take as much input as possible until the provided function returns true for the current element
 ///
@@ -551,10 +551,7 @@ impl<'a> InputTakeAtPosition for CompleteByteSlice<'a> {
     P: Fn(Self::Item) -> bool,
   {
     match (0..self.0.len()).find(|b| predicate(self.0[*b])) {
-      Some(i) => Ok((
-        CompleteByteSlice(&self.0[i..]),
-        CompleteByteSlice(&self.0[..i]),
-      )),
+      Some(i) => Ok((CompleteByteSlice(&self.0[i..]), CompleteByteSlice(&self.0[..i]))),
       None => {
         let (i, o) = self.0.take_split(self.0.len());
         Ok((CompleteByteSlice(i), CompleteByteSlice(o)))
@@ -568,18 +565,12 @@ impl<'a> InputTakeAtPosition for CompleteByteSlice<'a> {
   {
     match (0..self.0.len()).find(|b| predicate(self.0[*b])) {
       Some(0) => Err(Err::Error(Context::Code(CompleteByteSlice(self.0), e))),
-      Some(i) => Ok((
-        CompleteByteSlice(&self.0[i..]),
-        CompleteByteSlice(&self.0[..i]),
-      )),
+      Some(i) => Ok((CompleteByteSlice(&self.0[i..]), CompleteByteSlice(&self.0[..i]))),
       None => {
         if self.0.len() == 0 {
           Err(Err::Error(Context::Code(CompleteByteSlice(self.0), e)))
         } else {
-          Ok((
-            CompleteByteSlice(&self.0[self.0.len()..]),
-            CompleteByteSlice(self.0),
-          ))
+          Ok((CompleteByteSlice(&self.0[self.0.len()..]), CompleteByteSlice(self.0)))
         }
       }
     }
@@ -917,31 +908,31 @@ macro_rules! impl_fn_slice {
 }
 
 macro_rules! slice_range_impl {
-    ( [ $for_type:ident ], $ty:ty ) => {
-        impl<'a, $for_type> Slice<$ty> for &'a [$for_type] {
-            impl_fn_slice!( $ty );
-        }
-    };
-    ( $for_type:ty, $ty:ty ) => {
-        impl<'a> Slice<$ty> for &'a $for_type {
-            impl_fn_slice!( $ty );
-        }
+  ([$for_type:ident], $ty:ty) => {
+    impl<'a, $for_type> Slice<$ty> for &'a [$for_type] {
+      impl_fn_slice!($ty);
     }
+  };
+  ($for_type:ty, $ty:ty) => {
+    impl<'a> Slice<$ty> for &'a $for_type {
+      impl_fn_slice!($ty);
+    }
+  };
 }
 
 macro_rules! slice_ranges_impl {
-    ( [ $for_type:ident ] ) => {
-        slice_range_impl! {[$for_type], Range<usize>}
-        slice_range_impl! {[$for_type], RangeTo<usize>}
-        slice_range_impl! {[$for_type], RangeFrom<usize>}
-        slice_range_impl! {[$for_type], RangeFull}
-    };
-    ( $for_type:ty ) => {
-        slice_range_impl! {$for_type, Range<usize>}
-        slice_range_impl! {$for_type, RangeTo<usize>}
-        slice_range_impl! {$for_type, RangeFrom<usize>}
-        slice_range_impl! {$for_type, RangeFull}
-    }
+  ([$for_type:ident]) => {
+    slice_range_impl! {[$for_type], Range<usize>}
+    slice_range_impl! {[$for_type], RangeTo<usize>}
+    slice_range_impl! {[$for_type], RangeFrom<usize>}
+    slice_range_impl! {[$for_type], RangeFull}
+  };
+  ($for_type:ty) => {
+    slice_range_impl! {$for_type, Range<usize>}
+    slice_range_impl! {$for_type, RangeTo<usize>}
+    slice_range_impl! {$for_type, RangeFrom<usize>}
+    slice_range_impl! {$for_type, RangeFull}
+  };
 }
 
 slice_ranges_impl! {str}

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,12 +6,12 @@ use traits::{AsBytes, AtEof, Compare, CompareResult, FindSubstring, FindToken, I
 #[cfg(feature = "alloc")]
 use traits::ExtendInto;
 
+use lib::std::convert::From;
+use lib::std::fmt::{Display, Formatter, Result};
 use lib::std::iter::{Enumerate, Map};
 use lib::std::ops::{Deref, Range, RangeFrom, RangeFull, RangeTo};
 use lib::std::slice::Iter;
 use lib::std::str::{self, CharIndices, Chars, FromStr};
-use lib::std::convert::From;
-use lib::std::fmt::{Display, Formatter, Result};
 #[cfg(feature = "alloc")]
 use lib::std::string::String;
 

--- a/src/verbose_errors.rs
+++ b/src/verbose_errors.rs
@@ -13,10 +13,10 @@
 //! you can know precisely which parser got to which part of the input.
 //! The main drawback is that it is a lot slower than default error
 //! management.
-use util::{Convert, ErrorKind};
 use lib::std::convert::From;
 #[cfg(feature = "alloc")]
 use lib::std::vec::Vec;
+use util::{Convert, ErrorKind};
 
 /// Contains the error that a parser can return
 ///
@@ -37,11 +37,7 @@ impl<I, F, E: From<F>> Convert<Context<I, F>> for Context<I, E> {
   fn convert(c: Context<I, F>) -> Self {
     match c {
       Context::Code(i, e) => Context::Code(i, ErrorKind::convert(e)),
-      Context::List(mut v) => Context::List(
-        v.drain(..)
-          .map(|(i, e)| (i, ErrorKind::convert(e)))
-          .collect(),
-      ),
+      Context::List(mut v) => Context::List(v.drain(..).map(|(i, e)| (i, ErrorKind::convert(e))).collect()),
     }
   }
 }

--- a/src/whitespace.rs
+++ b/src/whitespace.rs
@@ -896,12 +896,12 @@ macro_rules! ws (
 #[cfg(test)]
 #[allow(dead_code)]
 mod tests {
+  use super::sp;
+  use internal::{Err, IResult, Needed};
   #[cfg(feature = "alloc")]
   use lib::std::string::{String, ToString};
-  use internal::{Err, IResult, Needed};
-  use super::sp;
-  use util::ErrorKind;
   use types::CompleteStr;
+  use util::ErrorKind;
 
   #[test]
   fn spaaaaace() {
@@ -921,10 +921,7 @@ mod tests {
       ws!(pair!( take!(3), tag!("de") ))
     );
 
-    assert_eq!(
-      pair_2(&b" \t abc de fg"[..]),
-      Ok((&b"fg"[..], (&b"abc"[..], &b"de"[..])))
-    );
+    assert_eq!(pair_2(&b" \t abc de fg"[..]), Ok((&b"fg"[..], (&b"abc"[..], &b"de"[..]))));
   }
 
   #[test]
@@ -953,10 +950,7 @@ mod tests {
     );
     //trace_macros!(false);
 
-    assert_eq!(
-      tuple_2(&b" \t abc de fg"[..]),
-      Ok((&b"fg"[..], (&b"abc"[..], &b"de"[..])))
-    );
+    assert_eq!(tuple_2(&b" \t abc de fg"[..]), Ok((&b"fg"[..], (&b"abc"[..], &b"de"[..]))));
   }
 
   #[test]
@@ -997,22 +991,10 @@ mod tests {
 
     //trace_macros!(false);
 
-    assert_eq!(
-      do_parser(&b"abcd abcd\tefghefghX"[..]),
-      Ok((&b"X"[..], (1, 2)))
-    );
-    assert_eq!(
-      do_parser(&b"abcd\tefgh      efgh X"[..]),
-      Ok((&b"X"[..], (1, 2)))
-    );
-    assert_eq!(
-      do_parser(&b"abcd  ab"[..]),
-      Err(Err::Incomplete(Needed::Size(4)))
-    );
-    assert_eq!(
-      do_parser(&b" abcd\tefgh\tef"[..]),
-      Err(Err::Incomplete(Needed::Size(4)))
-    );
+    assert_eq!(do_parser(&b"abcd abcd\tefghefghX"[..]), Ok((&b"X"[..], (1, 2))));
+    assert_eq!(do_parser(&b"abcd\tefgh      efgh X"[..]), Ok((&b"X"[..], (1, 2))));
+    assert_eq!(do_parser(&b"abcd  ab"[..]), Err(Err::Incomplete(Needed::Size(4))));
+    assert_eq!(do_parser(&b" abcd\tefgh\tef"[..]), Err(Err::Incomplete(Needed::Size(4))));
   }
 
   #[test]
@@ -1075,10 +1057,7 @@ mod tests {
     #[allow(unused_variables)]
     fn dont_work(input: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
       use Context;
-      Err(Err::Error(Context::Code(
-        &b""[..],
-        ErrorKind::Custom(ErrorStr("abcd".to_string())),
-      )))
+      Err(Err::Error(Context::Code(&b""[..], ErrorKind::Custom(ErrorStr("abcd".to_string())))))
     }
 
     fn work2(input: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
@@ -1096,22 +1075,13 @@ mod tests {
     }
 
     let a = &b"\tabcd"[..];
-    assert_eq!(
-      alt1(a),
-      Err(Err::Error(error_position!(a, ErrorKind::Alt::<ErrorStr>)))
-    );
+    assert_eq!(alt1(a), Err(Err::Error(error_position!(a, ErrorKind::Alt::<ErrorStr>))));
     assert_eq!(alt2(a), Ok((&b""[..], a)));
     assert_eq!(alt3(a), Ok((a, &b""[..])));
 
     named!(alt4<CompleteStr, CompleteStr>, ws!(alt!(tag!("abcd") | tag!("efgh"))));
-    assert_eq!(
-      alt4(CompleteStr("\tabcd")),
-      Ok((CompleteStr(""), CompleteStr(r"abcd")))
-    );
-    assert_eq!(
-      alt4(CompleteStr("  efgh ")),
-      Ok((CompleteStr(""), CompleteStr("efgh")))
-    );
+    assert_eq!(alt4(CompleteStr("\tabcd")), Ok((CompleteStr(""), CompleteStr(r"abcd"))));
+    assert_eq!(alt4(CompleteStr("  efgh ")), Ok((CompleteStr(""), CompleteStr("efgh"))));
 
     // test the alternative syntax
     named!(alt5<CompleteStr, bool>, ws!(alt!(tag!("abcd") => { |_| false } | tag!("efgh") => { |_| true })));
@@ -1151,13 +1121,7 @@ mod tests {
     let b = CompleteStr("\tefgh ijkl ");
     assert_eq!(sw(b), Ok((CompleteStr(""), CompleteStr("ijkl"))));
     let c = CompleteStr("afghijkl");
-    assert_eq!(
-      sw(c),
-      Err(Err::Error(error_position!(
-        CompleteStr("afghijkl"),
-        ErrorKind::Switch
-      )))
-    );
+    assert_eq!(sw(c), Err(Err::Error(error_position!(CompleteStr("afghijkl"), ErrorKind::Switch))));
   }
 
   named!(str_parse(&str) -> &str, ws!(tag!("test")));
@@ -1190,8 +1154,5 @@ mod tests {
   );
 
   #[cfg(feature = "alloc")]
-  named!(
-    fail<&[u8]>,
-    map!(many_till!(take!(1), ws!(tag!("."))), |(r, _)| r[0])
-  );
+  named!(fail<&[u8]>, map!(many_till!(take!(1), ws!(tag!("."))), |(r, _)| r[0]));
 }

--- a/tests/arithmetic.rs
+++ b/tests/arithmetic.rs
@@ -64,32 +64,20 @@ fn factor_test() {
 #[test]
 fn term_test() {
   assert_eq!(term(CompleteStr(" 12 *2 /  3")), Ok((CompleteStr(""), 8)));
-  assert_eq!(
-    term(CompleteStr(" 2* 3  *2 *2 /  3")),
-    Ok((CompleteStr(""), 8))
-  );
+  assert_eq!(term(CompleteStr(" 2* 3  *2 *2 /  3")), Ok((CompleteStr(""), 8)));
   assert_eq!(term(CompleteStr(" 48 /  3/2")), Ok((CompleteStr(""), 8)));
 }
 
 #[test]
 fn expr_test() {
   assert_eq!(expr(CompleteStr(" 1 +  2 ")), Ok((CompleteStr(""), 3)));
-  assert_eq!(
-    expr(CompleteStr(" 12 + 6 - 4+  3")),
-    Ok((CompleteStr(""), 17))
-  );
+  assert_eq!(expr(CompleteStr(" 12 + 6 - 4+  3")), Ok((CompleteStr(""), 17)));
   assert_eq!(expr(CompleteStr(" 1 + 2*3 + 4")), Ok((CompleteStr(""), 11)));
 }
 
 #[test]
 fn parens_test() {
   assert_eq!(expr(CompleteStr(" (  2 )")), Ok((CompleteStr(""), 2)));
-  assert_eq!(
-    expr(CompleteStr(" 2* (  3 + 4 ) ")),
-    Ok((CompleteStr(""), 14))
-  );
-  assert_eq!(
-    expr(CompleteStr("  2*2 / ( 5 - 1) + 3")),
-    Ok((CompleteStr(""), 4))
-  );
+  assert_eq!(expr(CompleteStr(" 2* (  3 + 4 ) ")), Ok((CompleteStr(""), 14)));
+  assert_eq!(expr(CompleteStr("  2*2 / ( 5 - 1) + 3")), Ok((CompleteStr(""), 4)));
 }

--- a/tests/arithmetic_ast.rs
+++ b/tests/arithmetic_ast.rs
@@ -6,8 +6,8 @@ use std::fmt::{Debug, Display, Formatter};
 
 use std::str::FromStr;
 
-use nom::{digit, multispace};
 use nom::types::CompleteStr;
+use nom::{digit, multispace};
 
 pub enum Expr {
   Value(i64),

--- a/tests/complete_arithmetic.rs
+++ b/tests/complete_arithmetic.rs
@@ -33,10 +33,12 @@ complete_named!(
         fold_many0!(
           pair!(alt!(tag!("*") | tag!("/")), factor),
           init,
-          |acc, (op, val): (CompleteStr, i64)| if (op.0.chars().next().unwrap() as char) == '*' {
-            acc * val
-          } else {
-            acc / val
+          |acc, (op, val): (CompleteStr, i64)| {
+            if (op.0.chars().next().unwrap() as char) == '*' {
+              acc * val
+            } else {
+              acc / val
+            }
           }
         ) >> (res)
   )
@@ -50,10 +52,12 @@ complete_named!(
         fold_many0!(
           pair!(alt!(tag!("+") | tag!("-")), term),
           init,
-          |acc, (op, val): (CompleteStr, i64)| if (op.0.chars().next().unwrap() as char) == '+' {
-            acc + val
-          } else {
-            acc - val
+          |acc, (op, val): (CompleteStr, i64)| {
+            if (op.0.chars().next().unwrap() as char) == '+' {
+              acc + val
+            } else {
+              acc - val
+            }
           }
         ) >> (res)
   )
@@ -87,9 +91,6 @@ fn parens_test() {
   let input3 = CompleteStr("  2*2 / ( 5 - 1) +   ");
   assert_eq!(
     root_expr(input3),
-    Err(nom::Err::Error(error_position!(
-      CompleteStr("+   "),
-      ErrorKind::Eof
-    )))
+    Err(nom::Err::Error(error_position!(CompleteStr("+   "), ErrorKind::Eof)))
   );
 }

--- a/tests/complete_float.rs
+++ b/tests/complete_float.rs
@@ -32,49 +32,27 @@ complete_named!(
   float<f32>,
   map!(
     pair!(opt!(alt!(tag!("+") | tag!("-"))), unsigned_float),
-    |(sign, value): (Option<CompleteStr>, f32)| sign
-      .and_then(|s| s.0.chars().next())
-      .and_then(|c| if c == '-' { Some(-1f32) } else { None })
-      .unwrap_or(1f32) * value
+    |(sign, value): (Option<CompleteStr>, f32)| {
+      sign
+        .and_then(|s| s.0.chars().next())
+        .and_then(|c| if c == '-' { Some(-1f32) } else { None })
+        .unwrap_or(1f32) * value
+    }
   )
 );
 
 #[test]
 fn unsigned_float_test() {
-  assert_eq!(
-    unsigned_float(CompleteStr("123.456")),
-    Ok((CompleteStr(""), 123.456))
-  );
-  assert_eq!(
-    unsigned_float(CompleteStr("0.123")),
-    Ok((CompleteStr(""), 0.123))
-  );
-  assert_eq!(
-    unsigned_float(CompleteStr("123.0")),
-    Ok((CompleteStr(""), 123.0))
-  );
-  assert_eq!(
-    unsigned_float(CompleteStr("123.")),
-    Ok((CompleteStr(""), 123.0))
-  );
-  assert_eq!(
-    unsigned_float(CompleteStr(".123")),
-    Ok((CompleteStr(""), 0.123))
-  );
+  assert_eq!(unsigned_float(CompleteStr("123.456")), Ok((CompleteStr(""), 123.456)));
+  assert_eq!(unsigned_float(CompleteStr("0.123")), Ok((CompleteStr(""), 0.123)));
+  assert_eq!(unsigned_float(CompleteStr("123.0")), Ok((CompleteStr(""), 123.0)));
+  assert_eq!(unsigned_float(CompleteStr("123.")), Ok((CompleteStr(""), 123.0)));
+  assert_eq!(unsigned_float(CompleteStr(".123")), Ok((CompleteStr(""), 0.123)));
 }
 
 #[test]
 fn float_test() {
-  assert_eq!(
-    float(CompleteStr("123.456")),
-    Ok((CompleteStr(""), 123.456))
-  );
-  assert_eq!(
-    float(CompleteStr("+123.456")),
-    Ok((CompleteStr(""), 123.456))
-  );
-  assert_eq!(
-    float(CompleteStr("-123.456")),
-    Ok((CompleteStr(""), -123.456))
-  );
+  assert_eq!(float(CompleteStr("123.456")), Ok((CompleteStr(""), 123.456)));
+  assert_eq!(float(CompleteStr("+123.456")), Ok((CompleteStr(""), 123.456)));
+  assert_eq!(float(CompleteStr("-123.456")), Ok((CompleteStr(""), -123.456)));
 }

--- a/tests/custom_errors.rs
+++ b/tests/custom_errors.rs
@@ -25,9 +25,7 @@ fn test2(input: &str) -> IResult<&str, &str, CustomError> {
 }
 
 fn test3(input: &str) -> IResult<&str, &str, CustomError> {
-  verify!(input, test1, |s: &str| {
-    s.starts_with("abcd")
-  })
+  verify!(input, test1, |s: &str| s.starts_with("abcd"))
 }
 
 #[cfg(feature = "alloc")]

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -23,9 +23,7 @@ named!(
   float<f32>,
   map!(
     pair!(opt!(alt!(tag!("+") | tag!("-"))), unsigned_float),
-    |(sign, value): (Option<&[u8]>, f32)| sign
-      .and_then(|s| if s[0] == b'-' { Some(-1f32) } else { None })
-      .unwrap_or(1f32) * value
+    |(sign, value): (Option<&[u8]>, f32)| sign.and_then(|s| if s[0] == b'-' { Some(-1f32) } else { None }).unwrap_or(1f32) * value
   )
 );
 

--- a/tests/inference.rs
+++ b/tests/inference.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate nom;
 
-use std::str;
 use nom::{alpha, is_digit};
+use std::str;
 
 // issue #617
 named!(multi<&[u8], () >, fold_many0!( take_while1!( is_digit ), (), |_, _| {}));
@@ -25,10 +25,7 @@ named!(
         many_m_n!(
           0,
           1,
-          separated_list!(
-            tag!("\n\t"),
-            map_res!(take_while!(call!(|c| c != b'\n')), std::str::from_utf8)
-          )
+          separated_list!(tag!("\n\t"), map_res!(take_while!(call!(|c| c != b'\n')), std::str::from_utf8))
         ) >> (rest)
   )
 );

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -1,11 +1,11 @@
 #[macro_use]
 extern crate nom;
 
-use nom::{alphanumeric, multispace, space};
 use nom::types::CompleteByteSlice;
+use nom::{alphanumeric, multispace, space};
 
-use std::str;
 use std::collections::HashMap;
+use std::str;
 
 named!(category<CompleteByteSlice, &str>, map_res!(
     delimited!(

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -6,8 +6,8 @@
 extern crate nom;
 extern crate regex;
 
+use nom::types::{CompleteByteSlice, CompleteStr};
 use nom::{space, Err, IResult, Needed, le_u64};
-use nom::types::{CompleteStr, CompleteByteSlice};
 
 #[allow(dead_code)]
 struct Range {
@@ -136,10 +136,7 @@ fn take_till_issue() {
   assert_eq!(nothing(b"abc"), Ok((&b"abc"[..], &b""[..])));
 }
 
-named!(
-  issue_498<Vec<&[u8]>>,
-  separated_nonempty_list!(opt!(space), tag!("abcd"))
-);
+named!(issue_498<Vec<&[u8]>>, separated_nonempty_list!(opt!(space), tag!("abcd")));
 
 named!(issue_308(&str) -> bool,
     do_parse! (
@@ -186,26 +183,16 @@ fn issue_667() {
       alt!(alpha | is_a!("_"))
     )
   );
-  assert_eq!(
-    foo(CompleteByteSlice(b"")),
-    Ok((CompleteByteSlice(b""), vec![]))
-  );
+  assert_eq!(foo(CompleteByteSlice(b"")), Ok((CompleteByteSlice(b""), vec![])));
   assert_eq!(
     foo(CompleteByteSlice(b"loremipsum")),
-    Ok((
-      CompleteByteSlice(b""),
-      vec![CompleteByteSlice(b"loremipsum")]
-    ))
+    Ok((CompleteByteSlice(b""), vec![CompleteByteSlice(b"loremipsum")]))
   );
   assert_eq!(
     foo(CompleteByteSlice(b"lorem_ipsum")),
     Ok((
       CompleteByteSlice(b""),
-      vec![
-        CompleteByteSlice(b"lorem"),
-        CompleteByteSlice(b"_"),
-        CompleteByteSlice(b"ipsum"),
-      ]
+      vec![CompleteByteSlice(b"lorem"), CompleteByteSlice(b"_"), CompleteByteSlice(b"ipsum")]
     ))
   );
   assert_eq!(
@@ -220,10 +207,7 @@ fn issue_667() {
       ]
     ))
   );
-  assert_eq!(
-    foo(CompleteByteSlice(b"!@#$")),
-    Ok((CompleteByteSlice(b"!@#$"), vec![]))
-  );
+  assert_eq!(foo(CompleteByteSlice(b"!@#$")), Ok((CompleteByteSlice(b"!@#$"), vec![])));
 }
 
 #[test]

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -6,8 +6,8 @@ extern crate nom;
 
 use nom::{is_alphanumeric, recognize_float};
 
-use std::str;
 use std::collections::HashMap;
+use std::str;
 
 #[derive(Debug, PartialEq)]
 pub enum JsonValue {
@@ -25,27 +25,17 @@ named!(
   delimited!(
     tag!("\""),
     //map_res!(escaped!(call!(alphanumeric), '\\', is_a!("\"n\\")), str::from_utf8),
-    map_res!(
-      escaped!(take_while1!(is_alphanumeric), '\\', one_of!("\"n\\")),
-      str::from_utf8
-    ),
+    map_res!(escaped!(take_while1!(is_alphanumeric), '\\', one_of!("\"n\\")), str::from_utf8),
     tag!("\"")
   )
 );
 
 named!(
   array<Vec<JsonValue>>,
-  ws!(delimited!(
-    tag!("["),
-    separated_list!(tag!(","), value),
-    tag!("]")
-  ))
+  ws!(delimited!(tag!("["), separated_list!(tag!(","), value), tag!("]")))
 );
 
-named!(
-  key_value<(&str, JsonValue)>,
-  ws!(separated_pair!(string, tag!(":"), value))
-);
+named!(key_value<(&str, JsonValue)>, ws!(separated_pair!(string, tag!(":"), value)));
 
 named!(
   hash<HashMap<String, JsonValue>>,

--- a/tests/multiline.rs
+++ b/tests/multiline.rs
@@ -1,9 +1,9 @@
 #[macro_use]
 extern crate nom;
 
+use nom::IResult;
 use nom::types::CompleteStr;
 use nom::{alphanumeric, eol};
-use nom::IResult;
 
 pub fn end_of_line(input: CompleteStr) -> IResult<CompleteStr, CompleteStr> {
   alt!(input, eof!() | eol)
@@ -20,10 +20,7 @@ pub fn read_lines(input: CompleteStr) -> IResult<CompleteStr, Vec<CompleteStr>> 
 #[cfg(feature = "alloc")]
 #[test]
 fn read_lines_test() {
-  let res = Ok((
-    CompleteStr(""),
-    vec![CompleteStr("Duck"), CompleteStr("Dog"), CompleteStr("Cow")],
-  ));
+  let res = Ok((CompleteStr(""), vec![CompleteStr("Duck"), CompleteStr("Dog"), CompleteStr("Cow")]));
 
   assert_eq!(read_lines(CompleteStr("Duck\nDog\nCow\n")), res);
   assert_eq!(read_lines(CompleteStr("Duck\nDog\nCow")), res);

--- a/tests/named_args.rs
+++ b/tests/named_args.rs
@@ -85,68 +85,29 @@ named!(expr <CompleteByteSlice, i64>, do_parse!(
 
 #[test]
 fn factor_test() {
-  assert_eq!(
-    factor(CompleteByteSlice(b"3")),
-    Ok((CompleteByteSlice(b""), 3))
-  );
-  assert_eq!(
-    factor(CompleteByteSlice(b" 12")),
-    Ok((CompleteByteSlice(b""), 12))
-  );
-  assert_eq!(
-    factor(CompleteByteSlice(b"537  ")),
-    Ok((CompleteByteSlice(b""), 537))
-  );
-  assert_eq!(
-    factor(CompleteByteSlice(b"  24   ")),
-    Ok((CompleteByteSlice(b""), 24))
-  );
+  assert_eq!(factor(CompleteByteSlice(b"3")), Ok((CompleteByteSlice(b""), 3)));
+  assert_eq!(factor(CompleteByteSlice(b" 12")), Ok((CompleteByteSlice(b""), 12)));
+  assert_eq!(factor(CompleteByteSlice(b"537  ")), Ok((CompleteByteSlice(b""), 537)));
+  assert_eq!(factor(CompleteByteSlice(b"  24   ")), Ok((CompleteByteSlice(b""), 24)));
 }
 
 #[test]
 fn term_test() {
-  assert_eq!(
-    term(CompleteByteSlice(b" 12 *2 /  3")),
-    Ok((CompleteByteSlice(b""), 8))
-  );
-  assert_eq!(
-    term(CompleteByteSlice(b" 2* 3  *2 *2 /  3")),
-    Ok((CompleteByteSlice(b""), 8))
-  );
-  assert_eq!(
-    term(CompleteByteSlice(b" 48 /  3/2")),
-    Ok((CompleteByteSlice(b""), 8))
-  );
+  assert_eq!(term(CompleteByteSlice(b" 12 *2 /  3")), Ok((CompleteByteSlice(b""), 8)));
+  assert_eq!(term(CompleteByteSlice(b" 2* 3  *2 *2 /  3")), Ok((CompleteByteSlice(b""), 8)));
+  assert_eq!(term(CompleteByteSlice(b" 48 /  3/2")), Ok((CompleteByteSlice(b""), 8)));
 }
 
 #[test]
 fn expr_test() {
-  assert_eq!(
-    expr(CompleteByteSlice(b" 1 +  2 ")),
-    Ok((CompleteByteSlice(b""), 3))
-  );
-  assert_eq!(
-    expr(CompleteByteSlice(b" 12 + 6 - 4+  3")),
-    Ok((CompleteByteSlice(b""), 17))
-  );
-  assert_eq!(
-    expr(CompleteByteSlice(b" 1 + 2*3 + 4")),
-    Ok((CompleteByteSlice(b""), 11))
-  );
+  assert_eq!(expr(CompleteByteSlice(b" 1 +  2 ")), Ok((CompleteByteSlice(b""), 3)));
+  assert_eq!(expr(CompleteByteSlice(b" 12 + 6 - 4+  3")), Ok((CompleteByteSlice(b""), 17)));
+  assert_eq!(expr(CompleteByteSlice(b" 1 + 2*3 + 4")), Ok((CompleteByteSlice(b""), 11)));
 }
 
 #[test]
 fn parens_test() {
-  assert_eq!(
-    expr(CompleteByteSlice(b" (  2 )")),
-    Ok((CompleteByteSlice(b""), 2))
-  );
-  assert_eq!(
-    expr(CompleteByteSlice(b" 2* (  3 + 4 ) ")),
-    Ok((CompleteByteSlice(b""), 14))
-  );
-  assert_eq!(
-    expr(CompleteByteSlice(b"  2*2 / ( 5 - 1) + 3")),
-    Ok((CompleteByteSlice(b""), 4))
-  );
+  assert_eq!(expr(CompleteByteSlice(b" (  2 )")), Ok((CompleteByteSlice(b""), 2)));
+  assert_eq!(expr(CompleteByteSlice(b" 2* (  3 + 4 ) ")), Ok((CompleteByteSlice(b""), 14)));
+  assert_eq!(expr(CompleteByteSlice(b"  2*2 / ( 5 - 1) + 3")), Ok((CompleteByteSlice(b""), 4)));
 }

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -26,18 +26,12 @@ named!(parser02<&[u8],(&[u8],&[u8])>,
 
 #[test]
 fn overflow_incomplete_do_parse() {
-  assert_eq!(
-    parser01(&b"3"[..]),
-    Err(Err::Incomplete(Needed::Size(18446744073709551615)))
-  );
+  assert_eq!(parser01(&b"3"[..]), Err(Err::Incomplete(Needed::Size(18446744073709551615))));
 }
 
 #[test]
 fn overflow_incomplete_tuple() {
-  assert_eq!(
-    parser02(&b"3"[..]),
-    Err(Err::Incomplete(Needed::Size(18446744073709551615)))
-  );
+  assert_eq!(parser02(&b"3"[..]), Err(Err::Incomplete(Needed::Size(18446744073709551615))));
 }
 
 #[test]
@@ -113,10 +107,7 @@ fn overflow_incomplete_count() {
 
 #[test]
 fn overflow_incomplete_count_fixed() {
-  named!(
-    counter<[&[u8]; 2]>,
-    count_fixed!(&[u8], length_bytes!(be_u64), 2)
-  );
+  named!(counter<[&[u8]; 2]>, count_fixed!(&[u8], length_bytes!(be_u64), 2));
 
   assert_eq!(
     counter(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef\xaa"[..]),


### PR DESCRIPTION
This is stable, 1.26.0, installed using `rustup component add rustfmt-preview` and ran using `cargo +stable fmt`. `struct_field_align_threshold` option was removed from `rustfmt.toml`, as it's not supported on stable.