### PR TITLE
Remove unused imports in cond_with_error

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -950,7 +950,6 @@ macro_rules! cond_with_error(
   ($i:expr, $cond:expr, $submac:ident!( $($args:tt)* )) => (
     {
       use $crate::lib::std::result::Result::*;
-      use $crate::{Convert,Err,Needed,IResult};
 
       if $cond {
         match $submac!($i, $($args)*) {


### PR DESCRIPTION
Since nom 4.0, using `cond_with_error` produces warnings of unused imports:

```
warning: unused imports: `Convert`, `Err`, `IResult`, `Needed`
...
4   |                     | use $ crate :: lib :: std :: result :: Result :: * ; use $ crate :: {
5   |                     | Convert , Err , Needed , IResult } ; if $ cond {
    |                     | ^^^^^^^   ^^^   ^^^^^^   ^^^^^^^
in this expansion of `cond_with_error!` (#6)

    = note: #[warn(unused_imports)] on by default
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```

(output stripped for readability)

This (trivial) PR removes the unused imports.