### PR TITLE
Allow trailing '|' for switch! macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Add support for trailing `|` in `switch!` macro
+
 ### Fixed
 
 

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -371,7 +371,7 @@ macro_rules! alt_complete (
 ///  named!(sw,
 ///    switch!(take!(4),
 ///      b"abcd" => tag!("XYZ") |
-///      b"efgh" => tag!("123")
+///      b"efgh" => tag!("123") |
 ///    )
 ///  );
 ///
@@ -396,7 +396,7 @@ macro_rules! alt_complete (
 ///  named!(sw,
 ///    switch!(take!(4),
 ///      b"abcd" => tag!("XYZ") |
-///      _       => value!(&b"default"[..])
+///      _       => value!(&b"default"[..]) |
 ///    )
 ///  );
 ///
@@ -417,7 +417,7 @@ macro_rules! alt_complete (
 ///  named!(sw,
 ///    switch!(take!(4),
 ///      b"abcd" => xyz |
-///      b"efgh" => 123
+///      b"efgh" => 123 |
 ///    )
 ///  );
 /// ```
@@ -430,14 +430,14 @@ macro_rules! alt_complete (
 ///  named!(sw,
 ///    switch!(take!(4),
 ///      b"abcd" => call!(xyz) |
-///      b"efgh" => call!(num)
+///      b"efgh" => call!(num) |
 ///    )
 ///  );
 /// ```
 ///
 #[macro_export]
 macro_rules! switch (
-  (__impl $i:expr, $submac:ident!( $($args:tt)* ), $( $($p:pat)|+ => $subrule:ident!( $($args2:tt)* ))|* ) => (
+  (__impl $i:expr, $submac:ident!( $($args:tt)* ), $( $($p:pat)|+ => $subrule:ident!( $($args2:tt)* ))|*$(|)* ) => (
     {
       use $crate::lib::std::result::Result::*;
       use $crate::lib::std::option::Option::*;


### PR DESCRIPTION
Fixes #476 - `switch! should allow a trailing |`

This PR modifies the `switch!` macro to support a trailing `|`. The doc tests have been updated to include the trailing `|`.

The change adds `$(|)*` as a suffix to the macro definition. Ideally we would actually want this to be `$(|)?` to support only 1 or 0 trailing `|` characters. However, this feature is only available in nightly. For reference see the [rust-lang/rust#48075](https://github.com/rust-lang/rust/issues/48075).

