### PR TITLE
Point iso8601 article to updated docu in repository

### DIFF
--- a/doc/home.md
+++ b/doc/home.md
@@ -8,7 +8,7 @@ To get started using nom, you can include it in your Rust projects from
 * [Reference documentation](http://rust.unhandledexpression.com/nom/)
 * [Gitter chat room](https://gitter.im/Geal/nom). You can also go to the #nom IRC
 channel on irc.mozilla.org, or ping 'geal' on Mozilla, Freenode, Geeknode or oftc IRC
-* [Tutorial about parsing ISO8601 dates](https://fnordig.de/2015/07/16/omnomnom-parsing-iso8601-dates-using-nom/)
+* [Tutorial about parsing ISO8601 dates](https://github.com/badboy/iso8601/blob/338b3d1a9ca220372292f631a3bc2e5176cca331/docs/parsing-iso8601-dates-using-nom.md)
 * [Making a new parser from scratch](making_a_new_parser_from_scratch.html)
 (general tips on writing a parser and code architecture)
 * [How to handle parser errors](error_management.html)


### PR DESCRIPTION
Hey,

the linked article was kinda outdated and so was iso8601. Thanks to @ccouzens there's now an updated article available, which I imported to the repository, so it's easier to update in the future as well. It's best to point there now.