### PR TITLE
Remove weird heading lines in migration guides.

### DIFF
--- a/doc/upgrading_to_nom_1.md
+++ b/doc/upgrading_to_nom_1.md
@@ -1,4 +1,4 @@
-% Upgrading to nom 1.0
+# Upgrading to nom 1.0
 
 The 1.0 release of nom is one of the biggest since the beginning of the project. Its goal was to rework some core parts to be more flexible, and clean code that was awkward or unclear. This resulted in breaking changes, that I hope will not happen again in the future (but hey, we are Rust developers, breaking changes are FUN for us!).
 

--- a/doc/upgrading_to_nom_2.md
+++ b/doc/upgrading_to_nom_2.md
@@ -1,5 +1,3 @@
-% Upgrading to nom 2.0
-
 # Upgrading to nom 2.0
 
 The 2.0 release of nom adds a lot of new features, but it was also time for a big cleanup of badly named functions and macros, awkwardly written features and redundant functionality. So this release has some breaking changes, but most of them are harmless.

--- a/doc/upgrading_to_nom_4.md
+++ b/doc/upgrading_to_nom_4.md
@@ -1,5 +1,3 @@
-% Upgrading to nom 4.0
-
 # Upgrading to nom 4.0
 
 The nom 4.0 is a nearly complete rewrite of nom's internal structures, along with a cleanup of a lot of parser and combinators whose semantics were unclear. Upgrading from previous nom versions can require a lot of changes, especially if you have a lot of unit tests. But most of those changes are pretty straightforward.


### PR DESCRIPTION
Not sure about the meaning of those lines. If you refuse the PR because
of them being useful, please explain to me; I’m curious!