### PR TITLE
Use docs.rs for reference docs

### DIFF
--- a/doc/home.md
+++ b/doc/home.md
@@ -5,7 +5,7 @@
 To get started using nom, you can include it in your Rust projects from
 [crates.io](https://crates.io/crates/nom). Here are a few links you will find useful:
 
-* [Reference documentation](http://rust.unhandledexpression.com/nom/)
+* [Reference documentation](https://docs.rs/nom/)
 * [Gitter chat room](https://gitter.im/Geal/nom). You can also go to the #nom IRC
 channel on irc.mozilla.org, or ping 'geal' on Mozilla, Freenode, Geeknode or oftc IRC
 * [Tutorial about parsing ISO8601 dates](https://github.com/badboy/iso8601/blob/338b3d1a9ca220372292f631a3bc2e5176cca331/docs/parsing-iso8601-dates-using-nom.md)


### PR DESCRIPTION
Current reference docs link is a 404; use docs.rs instead.