### PR TITLE
Simplify is_hex_digit() in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,7 @@ fn from_hex(input: &str) -> Result<u8, std::num::ParseIntError> {
 }
 
 fn is_hex_digit(c: char) -> bool {
-  match c {
-    '0'..='9' | 'a'..='f' | 'A'..='F' => true,
-    _ => false,
-  }
+  c.is_digit(16)
 }
 
 named!(hex_primary<&str, u8>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,7 @@
 //! }
 //!
 //! fn is_hex_digit(c: char) -> bool {
-//!   match c {
-//!     '0'..='9' | 'a'..='f' | 'A'..='F' => true,
-//!     _ => false,
-//!   }
+//!   c.is_digit(16)
 //! }
 //!
 //! named!(hex_primary<&str, u8>,

--- a/tests/css.rs
+++ b/tests/css.rs
@@ -13,10 +13,7 @@ fn from_hex(input: &str) -> Result<u8, std::num::ParseIntError> {
 }
 
 fn is_hex_digit(c: char) -> bool {
-  match c {
-    '0'..='9' | 'a'..='f' | 'A'..='F' => true,
-    _ => false,
-  }
+  c.is_digit(16)
 }
 
 named!(hex_primary<&str, u8>,


### PR DESCRIPTION
This simplifies the `is_hex_digit()` implementation in the example in the README file by referring to the core method `char::is_digit()`.  It's not really an important change, but I think it puts more focus on the bits of the code that are specific to nom.  (I'm not sure the function is needed at all, since there's also an `is_hex_digit()` built into nom now, but I wanted to keep the change minimal – I'm not really familiar with nom.)
