### PR TITLE
Provide stability guarantees for older Rust versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rust:
   - nightly
   - beta
   - stable
+  - 1.20.0
 
 env:
   matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ default-features = false
 #git = "https://github.com/carllerche/bytes"
 #rev = "a7d38e29"
 
+[build-dependencies]
+version_check = "^0.1"
+
 [package.metadata.docs.rs]
 features = [ "alloc", "std", "regexp", "regexp_macros", "verbose-errors" ]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Build Status](https://travis-ci.org/Geal/nom.svg?branch=master)](https://travis-ci.org/Geal/nom)
 [![Coverage Status](https://coveralls.io/repos/Geal/nom/badge.svg?branch=master)](https://coveralls.io/r/Geal/nom?branch=master)
 [![Crates.io Version](https://img.shields.io/crates/v/nom.svg)](https://crates.io/crates/nom)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.20+-lightgray.svg)](#rust-version-requirements)
 
 nom is a parser combinators library written in Rust. Its goal is to provide tools to build safe parsers without compromising the speed or memory consumption. To that end, it uses extensively Rust's *strong typing* and *memory safety* to produce fast and correct parsers, and provides macros and traits to abstract most of the error prone plumbing.
 
@@ -175,6 +176,13 @@ nom parsers are for:
 - [x] **speed**: benchmarks have shown that nom parsers often outperform many parser combinators library like Parsec and attoparsec, some regular expression engines and even handwritten C parsers
 
 Some benchmarks are available on [Github](https://github.com/Geal/nom_benchmarks).
+
+## Rust version requirements
+
+The 4.0 series of nom requires **Rustc version 1.20 or greater**.
+
+Travis CI always has a build with a pinned version of Rustc matching the oldest supported Rust release.
+The current policy is that this will only be updated in the next major nom release.
 
 ## Installation
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+extern crate version_check;
+
+fn main() {
+  match version_check::is_min_version("1.26.0") {
+    Some((true, _actual_version)) => {
+      println!("cargo:rustc-cfg=stable_i128");
+    }
+    Some(_) => (),
+    None => {
+      eprintln!("couldn't query version info from rustc");
+    }
+  }
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -550,13 +550,19 @@ macro_rules! add_return_error (
         Ok((i, o))    => Ok((i, o)),
         Err(Err::Error(e))      => {
           unify_types(&e, &error_context);
-          let Context::Code(i, code) = error_context;
-          Err(Err::Error(error_node_position!(i, code, e)))
+          match error_context {
+            Context::Code(i, code) => Err(Err::Error(error_node_position!(i, code, e))),
+            #[cfg(feature = "verbose-errors")]
+            _ => unreachable!("`error_context` must be `Context::Code` in this macro"),
+          }
         },
         Err(Err::Failure(e))      => {
           unify_types(&e, &error_context);
-          let Context::Code(i, code) = error_context;
-          Err(Err::Failure(error_node_position!(i, code, e)))
+          match error_context {
+            Context::Code(i, code) => Err(Err::Failure(error_node_position!(i, code, e))),
+            #[cfg(feature = "verbose-errors")]
+            _ => unreachable!("`error_context` must be `Context::Code` in this macro"),
+          }
         },
         Err(e) => Err(e),
       }

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -464,6 +464,7 @@ pub fn be_u64(i: &[u8]) -> IResult<&[u8], u64, u32> {
 
 /// Recognizes big endian unsigned 16 bytes integer
 #[inline]
+#[cfg(stable_i128)]
 pub fn be_u128(i: &[u8]) -> IResult<&[u8], u128, u32> {
   if i.len() < 16 {
     need_more(i, Needed::Size(16))
@@ -525,6 +526,7 @@ pub fn be_i64(i: &[u8]) -> IResult<&[u8], i64> {
 
 /// Recognizes big endian signed 16 bytes integer
 #[inline]
+#[cfg(stable_i128)]
 pub fn be_i128(i: &[u8]) -> IResult<&[u8], i128> {
   map!(i, be_u128, |x| x as i128)
 }
@@ -586,6 +588,7 @@ pub fn le_u64(i: &[u8]) -> IResult<&[u8], u64> {
 
 /// Recognizes little endian unsigned 16 bytes integer
 #[inline]
+#[cfg(stable_i128)]
 pub fn le_u128(i: &[u8]) -> IResult<&[u8], u128, u32> {
   if i.len() < 16 {
     need_more(i, Needed::Size(16))
@@ -647,6 +650,7 @@ pub fn le_i64(i: &[u8]) -> IResult<&[u8], i64> {
 
 /// Recognizes little endian signed 16 bytes integer
 #[inline]
+#[cfg(stable_i128)]
 pub fn le_i128(i: &[u8]) -> IResult<&[u8], i128> {
   map!(i, le_u128, |x| x as i128)
 }
@@ -673,6 +677,7 @@ macro_rules! u64 ( ($i:expr, $e:expr) => ( {if $crate::Endianness::Big == $e { $
 /// if the parameter is nom::Endianness::Big, parse a big endian u128 integer,
 /// otherwise a little endian u128 integer
 #[macro_export]
+#[cfg(stable_i128)]
 macro_rules! u128 ( ($i:expr, $e:expr) => ( {if $crate::Endianness::Big == $e { $crate::be_u128($i) } else { $crate::le_u128($i) } } ););
 
 /// if the parameter is nom::Endianness::Big, parse a big endian i16 integer,
@@ -690,6 +695,7 @@ macro_rules! i64 ( ($i:expr, $e:expr) => ( {if $crate::Endianness::Big == $e { $
 /// if the parameter is nom::Endianness::Big, parse a big endian i64 integer,
 /// otherwise a little endian i64 integer
 #[macro_export]
+#[cfg(stable_i128)]
 macro_rules! i128 ( ($i:expr, $e:expr) => ( {if $crate::Endianness::Big == $e { $crate::be_i128($i) } else { $crate::le_i128($i) } } ););
 
 /// Recognizes big endian 4 bytes floating point number
@@ -1294,6 +1300,7 @@ mod tests {
   }
 
   #[test]
+  #[cfg(stable_i128)]
   fn i128_tests() {
     assert_eq!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
@@ -1378,6 +1385,7 @@ mod tests {
   }
 
   #[test]
+  #[cfg(stable_i128)]
   fn le_i128_tests() {
     assert_eq!(
       le_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
@@ -1747,8 +1755,11 @@ mod tests {
       assert_eq!(double(CompleteStr(test)), Ok((CompleteStr(""), expected64)));
 
       //deprecated functions
-      assert_eq!(float_s(&larger[..]), Ok((";", expected32)));
-      assert_eq!(double_s(&larger[..]), Ok((";", expected64)));
+      #[allow(deprecated)]
+      {
+        assert_eq!(float_s(&larger[..]), Ok((";", expected32)));
+        assert_eq!(double_s(&larger[..]), Ok((";", expected64)));
+      }
     }
 
     let remaining_exponent = "-1.234E-";

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -259,7 +259,7 @@ named!(issue_741_bytes<CompleteByteSlice, CompleteByteSlice>, re_bytes_match!(r"
 fn issue_752() {
     assert_eq!(
         Err::Error(nom::Context::Code("ab", nom::ErrorKind::ParseTo)),
-        parse_to!("ab", usize).unwrap_err(),
+        parse_to!("ab", usize).unwrap_err()
     )
 }
 


### PR DESCRIPTION
## Prerequisites

- related issue number: #841 (fixed along the way, but not the main issue)

## Motivation

It is a good idea to cover a large userbase which include those who don't want/can't update their Rust toolchain (e.g. if they stuck on an old OS and use Rust provided by a system-wide package manager).

Seeing that `nom` is a popular crate, I think the project needs to establish an explicitly stated policy regarding this issue.

## Overview

Pinning the minimum supported Rust version (MSRV) for CI builds is a stability guarantee mechanism used by many popular crates, like [`serde`](https://github.com/serde-rs/serde/blob/master/.travis.yml#L36), [`rand`](https://github.com/rust-random/rand/blob/master/.travis.yml#L66) or [`regex`](https://github.com/rust-lang/regex/blob/master/.travis.yml#L5), so there are positive precedents for adopting this approach.

## Impact on `nom` project in general

### Pros

- At least some releases older than current stable have a guarantee to work properly with `nom`.
- Maintainers of libraries that have `nom` in their dependency chain wouldn't need to actively chase down MSRV that can actually build their libraries --- just reading README/.travis.yml is enough (app maintainers, on the other hand, are generally less affected by all this MSRV-hunting because they tend to use relatively new Rusts).

### Middle ground

- Increase of build time due to compilation of build script and processing of additional `#[cfg]` attributes, which should be negligible thanks to simplicity of the build script and `#[cfg]`-processing being fast. Local tests show that the increase fall within the margin of error introduced by OS, so this should not be a problem at all.
- Increase of maintenance burden (can't use new features). Though `nom` 4.1.0 doesn't use anything that requires MSRV newer than 1.20 aside of 128-bit integers, so this may not be an issue too.

### Cons

- Increase of maintenance burden (have to watch out for dependencies that do update their MSRV). This one can become very messy if actual MSRV != documented MSRV for those dependencies (real case: https://github.com/rust-lang-nursery/lazy-static.rs/issues/114).
- +2 builds on Travis CI. From what I can see, the total time increase amounts to 5-6 minutes and the run time increase --- to 2-3 minutes (timing data here are for cached builds).

## Unresolved questions

- Is Rust 1.20 too restrictive for the needs of `nom` (most importantly, in long term)?
- There are different variations on versioning policy regarding MSRV employed by different projects:
  * Most conservative: increase MSRV between major versions --- as a result, `cargo update` will not break builds with caret-versioned `nom`.
  * Conservatively increase MSRV between minor releases --- `cargo update` will not break builds with tilde-versioned `nom`, but can break those with caret ones. "Conservatively" here means updating only to the oldest release that can build, but no more.
  * Track only latest stable minus N version. It is still advised to increase Rust version only between minor releases, as patch versions are, well, for bug-fixing patches.
  * Something else, which I am not aware of or I don't think of as suitable for `nom`.

  Which one `nom` should adopt? As a library developer, I prefer the first one (as written in pro number 2).
- Does the Rust version requirement need to be mentioned anywhere else from README?