### PR TITLE
count! should reserve Vec size.

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -583,6 +583,7 @@ macro_rules! count(
       let ret;
       let mut input = $i.clone();
       let mut res   = $crate::lib::std::vec::Vec::new();
+      res.reserve($count as usize);
 
       loop {
         if res.len() == $count {


### PR DESCRIPTION
This is my first rust PR, so I hope this change actually makes sense, but I figured since we know how many elements we're parsing, it would be good to pre-reserve the capacity upfront.