### PR TITLE
Added a more generic converter for errors

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -119,7 +119,7 @@ where
 
 use util::Convert;
 
-impl<I, F, E: From<F>> Convert<Err<I, F>> for Err<I, E> {
+impl<I, H: From<I>, F, E: From<F>> Convert<Err<I, F>> for Err<H, E> {
   fn convert(e: Err<I, F>) -> Self {
     match e {
       Err::Incomplete(n) => Err::Incomplete(n),

--- a/src/simple_errors.rs
+++ b/src/simple_errors.rs
@@ -13,19 +13,19 @@
 //! you can know precisely which parser got to which part of the input.
 //! The main drawback is that it is a lot slower than default error
 //! management.
-use util::{Convert, ErrorKind};
 use lib::std::convert::From;
+use util::{Convert, ErrorKind};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Context<I, E = u32> {
   Code(I, ErrorKind<E>),
 }
 
-impl<I, F, E: From<F>> Convert<Context<I, F>> for Context<I, E> {
+impl<I, H: From<I>, F, E: From<F>> Convert<Context<I, F>> for Context<H, E> {
   fn convert(c: Context<I, F>) -> Self {
     let Context::Code(i, e) = c;
 
-    Context::Code(i, ErrorKind::convert(e))
+    Context::Code(i.into(), ErrorKind::convert(e))
   }
 }
 

--- a/src/verbose_errors.rs
+++ b/src/verbose_errors.rs
@@ -33,13 +33,13 @@ pub enum Context<I, E = u32> {
   List(Vec<(I, ErrorKind<E>)>),
 }
 
-impl<I, F, E: From<F>> Convert<Context<I, F>> for Context<I, E> {
+impl<I, H: From<I>, F, E: From<F>> Convert<Context<I, F>> for Context<H, E> {
   fn convert(c: Context<I, F>) -> Self {
     match c {
-      Context::Code(i, e) => Context::Code(i, ErrorKind::convert(e)),
+      Context::Code(i, e) => Context::Code(i.into(), ErrorKind::convert(e)),
       Context::List(mut v) => Context::List(
         v.drain(..)
-          .map(|(i, e)| (i, ErrorKind::convert(e)))
+          .map(|(i, e)| (i.into(), ErrorKind::convert(e)))
           .collect(),
       ),
     }


### PR DESCRIPTION
## Reasoning

`nom` errors can be `Convert`ed already if the `Err` part is convertible, but its nice to be able to convert e.g. `Err<&str, u32>` to `Err<String, u32>` more ergonomically. This makes that possible.