### PR TITLE
Replace transmute<uN, fN> with fN::from_bits

### DIFF
--- a/src/nom.rs
+++ b/src/nom.rs
@@ -703,7 +703,7 @@ macro_rules! i128 ( ($i:expr, $e:expr) => ( {if $crate::Endianness::Big == $e { 
 pub fn be_f32(input: &[u8]) -> IResult<&[u8], f32> {
   match be_u32(input) {
     Err(e) => Err(e),
-    Ok((i, o)) => unsafe { Ok((i, transmute::<u32, f32>(o))) },
+    Ok((i, o)) => Ok((i, f32::from_bits(o))),
   }
 }
 
@@ -712,7 +712,7 @@ pub fn be_f32(input: &[u8]) -> IResult<&[u8], f32> {
 pub fn be_f64(input: &[u8]) -> IResult<&[u8], f64> {
   match be_u64(input) {
     Err(e) => Err(e),
-    Ok((i, o)) => unsafe { Ok((i, transmute::<u64, f64>(o))) },
+    Ok((i, o)) => Ok((i, f64::from_bits(o))),
   }
 }
 
@@ -721,7 +721,7 @@ pub fn be_f64(input: &[u8]) -> IResult<&[u8], f64> {
 pub fn le_f32(input: &[u8]) -> IResult<&[u8], f32> {
   match le_u32(input) {
     Err(e) => Err(e),
-    Ok((i, o)) => unsafe { Ok((i, transmute::<u32, f32>(o))) },
+    Ok((i, o)) => Ok((i, f32::from_bits(o))),
   }
 }
 
@@ -730,7 +730,7 @@ pub fn le_f32(input: &[u8]) -> IResult<&[u8], f32> {
 pub fn le_f64(input: &[u8]) -> IResult<&[u8], f64> {
   match le_u64(input) {
     Err(e) => Err(e),
-    Ok((i, o)) => unsafe { Ok((i, transmute::<u64, f64>(o))) },
+    Ok((i, o)) => Ok((i, f64::from_bits(o))),
   }
 }
 


### PR DESCRIPTION
This removes 4 out of the 5 uses of unsafe in the codebase.
[This feature](https://doc.rust-lang.org/std/primitive.f32.html#method.from_bits) is stable since 1.20.0.