### PR TITLE
fix regression in 4.2.1

### DIFF
--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -301,7 +301,7 @@ macro_rules! delimited(
 /// # }
 /// ```
 ///
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! do_parse (
   (__impl $i:expr, ( $($rest:expr),* )) => (
     $crate::lib::std::result::Result::Ok(($i, ( $($rest),* )))


### PR DESCRIPTION
The following compiles with 4.2.0 but not 4.2.1.

```rust
use nom::{alpha, types::CompleteStr};
use nom::{do_parse, named};

named!(
    foo<CompleteStr<'_>, CompleteStr<'_>>,
    do_parse!(x: alpha >> (x))
);
```

This is because do_parse in 4.2.1 expects the `call!` macro to be defined.