### PR TITLE
Correct typo

### DIFF
--- a/doc/making_a_new_parser_from_scratch.md
+++ b/doc/making_a_new_parser_from_scratch.md
@@ -52,7 +52,7 @@ data is needed.
 ```rust
 pub type IResult<I, O, E = u32> = Result<(I, O), Err<I, E>>;
 
-#[derive(Debug, PartialEq, Eq, CLone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Needed {
   Unknown,
   Size(u32)


### PR DESCRIPTION
"CLone" -> "Clone"