### PR TITLE
[nom5] multi: make fold_* Fn instead of FnOnce

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -516,15 +516,16 @@ where
 /// * `g` The function that combines a result of `f` with
 ///       the current accumulator.
 //FIXME: streaming
-pub fn fold_many0<I, O, E, F, G, R>(f: F, init: R, g: G) -> impl FnOnce(I) -> IResult<I, R, E>
+pub fn fold_many0<I, O, E, F, G, R>(f: F, init: R, g: G) -> impl Fn(I) -> IResult<I, R, E>
 where
   I: Clone + PartialEq,
   F: Fn(I) -> IResult<I, O, E>,
   G: Fn(R, O) -> R,
   E: ParseError<I>,
+  R: Clone,
 {
   move |i: I| {
-    let mut res = init;
+    let mut res = init.clone();
     let mut input = i.clone();
 
     loop {
@@ -557,6 +558,7 @@ where
   F: Fn(I) -> IResult<I, O, E>,
   G: Fn(R, O) -> R,
   E: ParseError<I>,
+  R: Clone,
 {
   fold_many0(f, init, g)(i)
 }
@@ -571,15 +573,17 @@ where
 /// * `g` The function that combines a result of `f` with
 ///       the current accumulator.
 //FIXME: streaming
-pub fn fold_many1<I, O, E, F, G, R>(f: F, init: R, g: G) -> impl FnOnce(I) -> IResult<I, R, E>
+pub fn fold_many1<I, O, E, F, G, R>(f: F, init: R, g: G) -> impl Fn(I) -> IResult<I, R, E>
 where
   I: Clone + PartialEq,
   F: Fn(I) -> IResult<I, O, E>,
   G: Fn(R, O) -> R,
   E: ParseError<I>,
+  R: Clone,
 {
   move |i: I| {
     let _i = i.clone();
+    let init = init.clone();
     match f(_i) {
       Err(Err::Error(_)) => Err(Err::Error(E::from_error_kind(i, ErrorKind::Many1))),
       Err(e) => return Err(e),
@@ -618,6 +622,7 @@ where
   F: Fn(I) -> IResult<I, O, E>,
   G: Fn(R, O) -> R,
   E: ParseError<I>,
+  R: Clone,
 {
   fold_many1(f, init, g)(i)
 }
@@ -634,15 +639,16 @@ where
 /// * `g` The function that combines a result of `f` with
 ///       the current accumulator.
 //FIXME: streaming
-pub fn fold_many_m_n<I, O, E, F, G, R>(m: usize, n: usize, f: F, init: R, g: G) -> impl FnOnce(I) ->IResult<I, R, E>
+pub fn fold_many_m_n<I, O, E, F, G, R>(m: usize, n: usize, f: F, init: R, g: G) -> impl Fn(I) ->IResult<I, R, E>
 where
   I: Clone + PartialEq,
   F: Fn(I) -> IResult<I, O, E>,
   G: Fn(R, O) -> R,
   E: ParseError<I>,
+  R: Clone,
 {
   move |i: I| {
-    let mut acc = init;
+    let mut acc = init.clone();
     let mut input = i.clone();
     for count in 0..n {
       let _input = input.clone();
@@ -677,6 +683,7 @@ where
   F: Fn(I) -> IResult<I, O, E>,
   G: Fn(R, O) -> R,
   E: ParseError<I>,
+  R: Clone,
 {
   fold_many_m_n(m, n, f, init, g)(i)
 }


### PR DESCRIPTION
Allows reusing in other combinators

Supersedes #921 