### PR TITLE
[nom5] Err: add is_incomplete

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -62,6 +62,16 @@ pub enum Err<E> {
   Failure(E),
 }
 
+impl<E> Err<E> {
+  pub fn is_incomplete(&self) -> bool {
+    if let Err::Incomplete(_) = self {
+      true
+    } else {
+      false
+    }
+  }
+}
+
 /*
 #[cfg(feature = "std")]
 use std::fmt;


### PR DESCRIPTION
This used to exist in nom 4 but doesn't exist anymore in nom 5 (yet)