### PR TITLE
Nuke AtEof

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -58,10 +58,7 @@ macro_rules! bits_impl (
           Err(Err::Failure((i.slice(b/8..), kind)))
         },
         Err(Err::Incomplete(Needed::Unknown)) => Err(Err::Incomplete(Needed::Unknown)),
-        Err(Err::Incomplete(Needed::Size(i))) => {
-          //println!("bits parser returned Needed::Size({})", i);
-          $crate::need_more($i, $crate::Needed::Size(i / 8 + 1))
-        },
+        Err(Err::Incomplete(Needed::Size(i))) => Err(Err::Incomplete(Needed::Size(i / 8 + 1))),
         Ok(((i, bit_index), o))             => {
           let byte_index = bit_index / 8 + if bit_index % 8 == 0 { 0 } else { 1 } ;
           //println!("bit index=={} => byte index=={}", bit_index, byte_index);
@@ -166,7 +163,7 @@ macro_rules! take_bits (
   ($i:expr, $t:ty, $count:expr) => (
     {
       use $crate::lib::std::result::Result::*;
-      use $crate::{Needed,IResult};
+      use $crate::{Err,Needed,IResult};
 
       use $crate::lib::std::ops::Div;
       use $crate::lib::std::convert::Into;
@@ -179,7 +176,7 @@ macro_rules! take_bits (
         let cnt = ($count as usize + bit_offset).div(8);
         if input.len() * 8 < $count as usize + bit_offset {
           //println!("returning incomplete: {}", $count as usize + bit_offset);
-          $crate::need_more($i, Needed::Size($count as usize))
+          Err(Err::Incomplete(Needed::Size($count as usize)))
         } else {
           let mut acc:$t            = (0 as u8).into();
           let mut offset: usize     = bit_offset;

--- a/src/branch/macros.rs
+++ b/src/branch/macros.rs
@@ -880,7 +880,6 @@ mod tests {
   macro_rules! tag_bytes (
     ($i:expr, $bytes: expr) => (
       {
-        use $crate::need_more;
         use $crate::lib::std::cmp::min;
 
         let len = $i.len();
@@ -893,9 +892,7 @@ mod tests {
           let e: ErrorKind = ErrorKind::Tag;
           Err(Err::Error(error_position!($i, e)))
         } else if m < blen {
-          //let e:Err<&[u8], u32> = need_more($i, Needed::Size(blen));
-          //Err(e)
-          need_more($i, Needed::Size(blen))
+          Err(Err::Incomplete(Needed::Size(blen)))
         } else {
           Ok((&$i[blen..], reduced))
         };
@@ -907,11 +904,9 @@ mod tests {
   macro_rules! take(
     ($i:expr, $count:expr) => (
       {
-        use $crate::need_more;
-
         let cnt = $count as usize;
         let res:IResult<&[u8],&[u8],_> = if $i.len() < cnt {
-          need_more($i, Needed::Size(cnt))
+          Err(Err::Incomplete(Needed::Size(cnt)))
         } else {
           Ok((&$i[cnt..],&$i[0..cnt]))
         };

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -3,7 +3,7 @@
 use lib::std::result::Result::*;
 use ::lib::std::ops::RangeFrom;
 use traits::{
-  AtEof, Compare, CompareResult, FindSubstring, FindToken, InputIter, InputLength, InputTake,
+  Compare, CompareResult, FindSubstring, FindToken, InputIter, InputLength, InputTake,
   InputTakeAtPosition, Slice, ToUsize,
 };
 use internal::{Err, IResult, Needed};
@@ -92,7 +92,7 @@ where
 
 pub fn take_while_m_n<F, Input, Error: ParseError<Input>>(m: usize, n: usize, cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
-  Input: InputTake + AtEof + InputIter + InputLength + Slice<RangeFrom<usize>>,
+  Input: InputTake + InputIter + InputLength + Slice<RangeFrom<usize>>,
   F: Fn(<Input as InputIter>::RawItem) -> bool,
 {
   move |i: Input| {
@@ -119,17 +119,12 @@ where
           let res: IResult<_, _, Error> = Ok(input.take_split(n));
           res
         } else {
-          if input.at_eof() {
-            if len >= m && len <= n {
-              let res: IResult<_, _, Error> = Ok((input.slice(len..), input));
-              res
-            } else {
-              let e = ErrorKind::TakeWhileMN;
-              Err(Err::Error(Error::from_error_kind(input, e)))
-            }
+          if len >= m && len <= n {
+            let res: IResult<_, _, Error> = Ok((input.slice(len..), input));
+            res
           } else {
-            let needed = if m > len { m - len } else { 1 };
-            Err(Err::Incomplete(Needed::Size(needed)))
+            let e = ErrorKind::TakeWhileMN;
+            Err(Err::Error(Error::from_error_kind(input, e)))
           }
         }
       }

--- a/src/bytes/macros.rs
+++ b/src/bytes/macros.rs
@@ -112,7 +112,7 @@ macro_rules! escaped (
   (__impl $i: expr, $normal:ident!(  $($args:tt)* ), $control_char: expr, $escapable:ident!(  $($args2:tt)* )) => (
     {
       use $crate::lib::std::result::Result::*;
-      use $crate::{Err,Needed,IResult,error::ErrorKind,need_more};
+      use $crate::{Err,Needed,IResult,error::ErrorKind};
       use $crate::AsChar;
       use $crate::InputIter;
       use $crate::InputLength;
@@ -144,7 +144,7 @@ macro_rules! escaped (
               if input.iter_elements().next().unwrap().as_char() == control_char {
                 let next = control_char.len_utf8();
                 if next >= input.input_len() {
-                  return need_more($i, Needed::Size(next - input.input_len() + 1));
+                  return Err(Err::Incomplete(Needed::Size(next - input.input_len() + 1)));
                 } else {
                   match $escapable!(input.slice(next..), $($args2)*) {
                     Ok((i,_)) => {
@@ -249,7 +249,6 @@ macro_rules! escaped_transform (
       use $crate::InputLength;
       use $crate::Needed;
       use $crate::Slice;
-      use $crate::need_more;
 
       let cl = || -> $crate::IResult<_,_,_> {
         use $crate::Offset;
@@ -281,7 +280,7 @@ macro_rules! escaped_transform (
                 let input_len = $i.input_len();
 
                 if next >= input_len {
-                  return need_more($i, Needed::Size(next - input_len + 1));
+                  return Err(Err::Incomplete(Needed::Size(next - input_len + 1)));
                 } else {
                   match $transform!($i.slice(next..), $($args2)*) {
                     Ok((i,o)) => {
@@ -584,7 +583,7 @@ macro_rules! take_until1 (
     {
       use $crate::lib::std::result::Result::*;
       use $crate::lib::std::option::Option::*;
-      use $crate::{Err,Needed,IResult,need_more_err,error::ErrorKind};
+      use $crate::{Err,Needed,IResult,error::ErrorKind};
       use $crate::InputLength;
       use $crate::FindSubstring;
       use $crate::InputTake;
@@ -592,7 +591,7 @@ macro_rules! take_until1 (
 
       let res: IResult<_,_> = match input.find_substring($substr) {
         None => {
-          need_more_err($i, Needed::Size(1 + $substr.input_len()), ErrorKind::TakeUntil)
+          Err(Err::Incomplete(Needed::Size(1 + $substr.input_len())))
         },
         Some(0) => {
           let e = ErrorKind::TakeUntil;

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -143,8 +143,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("ab\r\nc"), Ok(("\r\nc", "ab")));
-/// assert_eq!(parser("abc"), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(parser(""), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(parser("abc"), Ok(("", "abc")));
+/// assert_eq!(parser(""), Ok(("", "")));
 /// # }
 /// ```
 pub fn not_line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
@@ -929,7 +929,7 @@ mod tests {
     );
 
     let d: &[u8] = b"ab12cd";
-    assert_eq!(not_line_ending::<_, (_, ErrorKind)>(d), Err(Err::Incomplete(Needed::Unknown)));
+    assert_eq!(not_line_ending::<_, (_, ErrorKind)>(d), Ok((&[][..], &d[..])));
   }
 
   #[test]
@@ -959,7 +959,7 @@ mod tests {
     );
 
     let g2: &str = "ab12cd";
-    assert_eq!(not_line_ending::<_, (_, ErrorKind)>(g2), Err(Err::Incomplete(Needed::Unknown)));
+    assert_eq!(not_line_ending::<_, (_, ErrorKind)>(g2), Ok(("", g2)));
   }
 
   #[test]

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -5,7 +5,7 @@
 use internal::{Err, IResult, Needed};
 use error::ParseError;
 use ::lib::std::ops::{Range, RangeFrom, RangeTo};
-use traits::{AsChar, AtEof, FindToken, InputIter, InputLength, InputTakeAtPosition, Slice};
+use traits::{AsChar, FindToken, InputIter, InputLength, InputTakeAtPosition, Slice};
 use traits::{Compare, CompareResult};
 use error::ErrorKind;
 
@@ -150,7 +150,7 @@ where
 pub fn not_line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
   T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
-  T: InputIter + InputLength + AtEof,
+  T: InputIter + InputLength,
   T: Compare<&'static str>,
   <T as InputIter>::Item: AsChar,
   <T as InputIter>::RawItem: AsChar,
@@ -160,11 +160,7 @@ where
     c == '\r' || c == '\n'
   }) {
     None => {
-      if input.at_eof() {
-        Ok((input.slice(input.input_len()..), input))
-      } else {
-        Err(Err::Incomplete(Needed::Unknown))
-      }
+      Ok((input.slice(input.input_len()..), input))
     }
     Some(index) => {
       let mut it = input.slice(index..).iter_elements();

--- a/src/combinator/macros.rs
+++ b/src/combinator/macros.rs
@@ -1307,7 +1307,6 @@ macro_rules! eof (
       if ($i).input_len() == 0 {
         Ok(($i, $i))
       } else {
-        //FIXME what do we do with need_more?
         Err(Err::Error(error_position!($i, ErrorKind::Eof)))
       }
     }
@@ -1374,7 +1373,7 @@ mod tests {
     ($i:expr, $tag: expr) => ({
       use $crate::lib::std::result::Result::*;
       use $crate::{Err,Needed,IResult,error::ErrorKind};
-      use $crate::{Compare,CompareResult,InputLength,Slice,need_more};
+      use $crate::{Compare,CompareResult,InputLength,Slice};
 
       let res: IResult<_,_> = match ($i).compare($tag) {
         CompareResult::Ok => {
@@ -1382,7 +1381,7 @@ mod tests {
           Ok(($i.slice(blen..), $i.slice(..blen)))
         },
         CompareResult::Incomplete => {
-          need_more($i, Needed::Size($tag.input_len()))
+          Err(Err::Incomplete(Needed::Size($tag.input_len())))
         },
         CompareResult::Error => {
           let e:ErrorKind = ErrorKind::Tag;
@@ -1398,7 +1397,7 @@ mod tests {
       {
         let cnt = $count as usize;
         let res:IResult<&[u8],&[u8]> = if $i.len() < cnt {
-          $crate::need_more($i, $crate::Needed::Size(cnt))
+          Err($crate::Err::Incomplete($crate::Needed::Size(cnt)))
         } else {
           Ok((&$i[cnt..],&$i[0..cnt]))
         };

--- a/src/combinator/macros.rs
+++ b/src/combinator/macros.rs
@@ -1292,11 +1292,7 @@ macro_rules! tap (
 
 /// `eof!()` returns its input if it is at the end of input data
 ///
-/// This combinator works with the `AtEof` trait that input types must implement.
-/// If an input type's `at_eof` method returns true, it means there will be no
-/// more refills (like what happens when buffering big files).
-///
-/// When we're at the end of the data and `at_eof` returns true, this combinator
+/// When we're at the end of the data, this combinator
 /// will succeed
 ///
 /// TODO: example
@@ -1305,10 +1301,10 @@ macro_rules! eof (
   ($i:expr,) => (
     {
       use $crate::lib::std::result::Result::*;
-      use $crate::{AtEof,Err,error::ErrorKind};
+      use $crate::{Err,error::ErrorKind};
 
       use $crate::InputLength;
-      if ($i).at_eof() && ($i).input_len() == 0 {
+      if ($i).input_len() == 0 {
         Ok(($i, $i))
       } else {
         //FIXME what do we do with need_more?
@@ -1319,10 +1315,6 @@ macro_rules! eof (
 );
 
 /// `exact!()` will fail if the child parser does not consume the whole data
-///
-/// This combinator works with the `AtEof` trait that input types must implement.
-/// If an input type's `at_eof` method returns true, it means there will be no
-/// more refills (like what happens when buffering big files).
 ///
 /// TODO: example
 #[macro_export(local_inner_macros)]

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -10,7 +10,7 @@ use lib::std::fmt::Debug;
 use internal::*;
 use error::ParseError;
 use traits::{AsChar, InputIter, InputLength, InputTakeAtPosition};
-use traits::{need_more, need_more_err, AtEof, ParseTo};
+use traits::{need_more, need_more_err, ParseTo};
 use lib::std::ops::{Range, RangeFrom, RangeTo};
 use traits::{Compare, CompareResult, Offset, Slice};
 use error::ErrorKind;
@@ -64,7 +64,7 @@ pub fn sized_buffer<'a, E: ParseError<&'a[u8]>>(input: &'a[u8]) -> IResult<&'a[u
 pub fn non_empty<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
   T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
-  T: InputLength + AtEof,
+  T: InputLength,
 {
   if input.input_len() == 0 {
     return need_more_err(input, Needed::Unknown, ErrorKind::NonEmpty);

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -9,8 +9,7 @@ use lib::std::boxed::Box;
 use lib::std::fmt::Debug;
 use internal::*;
 use error::ParseError;
-use traits::{AsChar, InputIter, InputLength, InputTakeAtPosition};
-use traits::{need_more, need_more_err, ParseTo};
+use traits::{AsChar, InputIter, InputLength, InputTakeAtPosition, ParseTo};
 use lib::std::ops::{Range, RangeFrom, RangeTo};
 use traits::{Compare, CompareResult, Offset, Slice};
 use error::ErrorKind;
@@ -46,7 +45,7 @@ pub fn begin(input: &[u8]) -> IResult<(), &[u8]> {
 
 pub fn sized_buffer<'a, E: ParseError<&'a[u8]>>(input: &'a[u8]) -> IResult<&'a[u8], &'a[u8], E> {
   if input.is_empty() {
-    return need_more(input, Needed::Unknown);
+    return Err(Err::Incomplete(Needed::Unknown));
   }
 
   let len = input[0] as usize;
@@ -54,7 +53,7 @@ pub fn sized_buffer<'a, E: ParseError<&'a[u8]>>(input: &'a[u8]) -> IResult<&'a[u
   if input.len() >= len + 1 {
     Ok((&input[len + 1..], &input[1..len + 1]))
   } else {
-    need_more(input, Needed::Size(1 + len))
+    Err(Err::Incomplete(Needed::Size(1 + len)))
   }
 }
 
@@ -67,7 +66,7 @@ where
   T: InputLength,
 {
   if input.input_len() == 0 {
-    return need_more_err(input, Needed::Unknown, ErrorKind::NonEmpty);
+    return Err(Err::Incomplete(Needed::Unknown));
   } else {
     Ok((input.slice(input.input_len()..), input))
   }

--- a/src/multi/macros.rs
+++ b/src/multi/macros.rs
@@ -554,11 +554,9 @@ mod tests {
   macro_rules! take(
     ($i:expr, $count:expr) => (
       {
-        use $crate::need_more;
-
         let cnt = $count as usize;
         let res:IResult<&[u8],&[u8],_> = if $i.len() < cnt {
-          need_more($i, Needed::Size(cnt))
+          Err(Err::Incomplete(Needed::Size(cnt)))
         } else {
           Ok((&$i[cnt..],&$i[0..cnt]))
         };

--- a/src/sequence/macros.rs
+++ b/src/sequence/macros.rs
@@ -440,7 +440,6 @@ mod tests {
   macro_rules! tag_bytes (
     ($i:expr, $bytes: expr) => (
       {
-        use $crate::need_more;
         use $crate::lib::std::cmp::min;
 
         let len = $i.len();
@@ -452,7 +451,7 @@ mod tests {
         let res: IResult<_,_,_> = if reduced != b {
           Err($crate::Err::Error(error_position!($i, $crate::error::ErrorKind::Tag)))
         } else if m < blen {
-          need_more($i, Needed::Size(blen))
+          Err($crate::Err::Incomplete(Needed::Size(blen)))
         } else {
           Ok((&$i[blen..], reduced))
         };
@@ -464,10 +463,9 @@ mod tests {
   macro_rules! take (
     ($i:expr, $count:expr) => (
       {
-        use $crate::need_more;
         let cnt = $count as usize;
         let res:IResult<&[u8],&[u8],_> = if $i.len() < cnt {
-          need_more($i, Needed::Size(cnt))
+          Err($crate::Err::Incomplete(Needed::Size(cnt)))
         } else {
           Ok((&$i[cnt..],&$i[0..cnt]))
         };

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -909,40 +909,6 @@ macro_rules! slice_ranges_impl {
 slice_ranges_impl! {str}
 slice_ranges_impl! {[T]}
 
-/// indicates whether more data can come later in input
-///
-/// When working with complete data, like a file that was entirely loaded
-/// in memory, you should use input types like `CompleteByteSlice` and
-/// `CompleteStr` to wrap the data.  The `at_eof` method of those types
-/// always returns true, thus indicating to nom that it should not handle
-/// partial data cases.
-///
-/// When working will partial data, like data coming from the network in
-/// buffers, the `at_eof` method can indicate if we expect more data to come,
-/// and let nom know that some parsers could still handle more data
-pub trait AtEof {
-  fn at_eof(&self) -> bool;
-}
-
-// Tuple for bit parsing
-impl<I: AtEof, T> AtEof for (I, T) {
-  fn at_eof(&self) -> bool {
-    self.0.at_eof()
-  }
-}
-
-impl<'a, T> AtEof for &'a [T] {
-  fn at_eof(&self) -> bool {
-    false
-  }
-}
-
-impl<'a> AtEof for &'a str {
-  fn at_eof(&self) -> bool {
-    false
-  }
-}
-
 macro_rules! array_impls {
   ($($N:expr)+) => {
     $(

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -924,22 +924,6 @@ pub trait AtEof {
   fn at_eof(&self) -> bool;
 }
 
-pub fn need_more<I: AtEof, O, E: ParseError<I>>(input: I, needed: Needed) -> IResult<I, O, E> {
-  if input.at_eof() {
-    Err(Err::Error(E::from_error_kind(input, ErrorKind::Eof)))
-  } else {
-    Err(Err::Incomplete(needed))
-  }
-}
-
-pub fn need_more_err<I: AtEof, O, E: ParseError<I>>(input: I, needed: Needed, err: ErrorKind) -> IResult<I, O, E> {
-  if input.at_eof() {
-    Err(Err::Error(E::from_error_kind(input, err)))
-  } else {
-    Err(Err::Incomplete(needed))
-  }
-}
-
 // Tuple for bit parsing
 impl<I: AtEof, T> AtEof for (I, T) {
   fn at_eof(&self) -> bool {


### PR DESCRIPTION
AtEof doesn't make sense anymore with the new complete modules for managing complete parsers + the complete fn for managing complete combinators.
All of the implementors of AtEof returned false since the removal of the Complete* types.