### PR TITLE
Adding documentation for bytes

### DIFF
--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -16,9 +16,12 @@ use traits::{Compare, CompareResult, FindSubstring, FindToken, InputIter, InputL
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::complete::tag;
-/// let parser = |s: &'static str| tag::<_, _, (_, ErrorKind)>("Hello")(s);
+///
+/// fn parser(s: &str) -> IResult<&str, &str> {
+///   tag("Hello")(s)
+/// }
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
 /// assert_eq!(parser("Something"), Err(Err::Error(("Something", ErrorKind::Tag))));
@@ -52,9 +55,12 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::complete::tag_no_case;
-/// let parser = |s: &'static str| tag_no_case::<_, _, (_, ErrorKind)>("hello")(s);
+///
+/// fn parser(s: &str) -> IResult<&str, &str> {
+///   tag_no_case("hello")(s)
+/// }
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
 /// assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
@@ -92,9 +98,12 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::complete::is_not;
-/// let not_space = |s: &'static str| is_not::<_, _, (_, ErrorKind)>(" \t\r\n")(s);
+///
+/// fn not_space(s: &str) -> IResult<&str, &str> {
+///   is_not(" \t\r\n")(s)
+/// }
 ///
 /// assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
 /// assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
@@ -122,9 +131,12 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::complete::is_a;
-/// let hex = |s: &'static str| is_a::<_, _, (_, ErrorKind)>("1234567890ABCDEF")(s);
+///
+/// fn hex(s: &str) -> IResult<&str, &str> {
+///   is_a("1234567890ABCDEF")(s)
+/// }
 ///
 /// assert_eq!(hex("123 and voila"), Ok((" and voila", "123")));
 /// assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
@@ -151,10 +163,13 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::complete::take_while;
 /// use nom::character::is_alphabetic;
-/// let alpha = |s: &'static [u8]| take_while::<_, _, (_, ErrorKind)>(is_alphabetic)(s);
+///
+/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+///   take_while(is_alphabetic)(s)
+/// }
 ///
 /// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(alpha(b"12345"), Ok((&b"12345"[..], &b""[..])));
@@ -179,10 +194,13 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::complete::take_while1;
 /// use nom::character::is_alphabetic;
-/// let alpha = |s: &'static [u8]| take_while1::<_, _, (_, ErrorKind)>(is_alphabetic)(s);
+///
+/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+///   take_while1(is_alphabetic)(s)
+/// }
 ///
 /// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
@@ -210,12 +228,13 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::complete::take_while_m_n;
 /// use nom::character::is_alphabetic;
-/// let short_alpha = |s: &'static [u8]| {
-///   take_while_m_n::<_, _, (_, ErrorKind)>(3, 6, is_alphabetic)(s)
-/// };
+///
+/// fn short_alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+///   take_while_m_n(3, 6, is_alphabetic)(s)
+/// }
 ///
 /// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
@@ -281,9 +300,12 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::complete::take_till;
-/// let till_colon = |s: &'static str| take_till::<_, _, (_, ErrorKind)>(|c| c == ':')(s);
+///
+/// fn till_colon(s: &str) -> IResult<&str, &str> {
+///   take_till(|c| c == ':')(s)
+/// }
 ///
 /// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
 /// assert_eq!(till_colon(":empty matched"), Ok((":empty matched", ""))); //allowed
@@ -309,9 +331,12 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::complete::take_till1;
-/// let till_colon = |s: &'static str| take_till1::<_, _, (_, ErrorKind)>(|c| c == ':')(s);
+///
+/// fn till_colon(s: &str) -> IResult<&str, &str> {
+///   take_till1(|c| c == ':')(s)
+/// }
 ///
 /// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
 /// assert_eq!(till_colon(":empty matched"), Err(Err::Error((":empty matched", ErrorKind::TakeTill1))));
@@ -336,9 +361,12 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::complete::take;
-/// let take6 = |s: &'static str| take::<_, _, (_, ErrorKind)>(6usize)(s);
+///
+/// fn take6(s: &str) -> IResult<&str, &str> {
+///   take(6usize)(s)
+/// }
 ///
 /// assert_eq!(take6("1234567"), Ok(("7", "123456")));
 /// assert_eq!(take6("things"), Ok(("", "things")));
@@ -365,11 +393,12 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::complete::take_until;
-/// let until_eof = |s: &'static str| {
-///   take_until::<_, _, (_, ErrorKind)>("eof")(s)
-/// };
+///
+/// fn until_eof(s: &str) -> IResult<&str, &str> {
+///   take_until("eof")(s)
+/// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
 /// assert_eq!(until_eof("hello, world"), Err(Err::Error(("hello, world", ErrorKind::TakeUntil))));
@@ -399,13 +428,14 @@ where
 /// # Example
 /// ```
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// # use nom::character::complete::digit1;
 /// use nom::bytes::complete::escaped;
 /// use nom::character::complete::one_of;
-/// let esc = |s: &'static str| {
-///   escaped::<&str, (_, ErrorKind), _, _, _, _>(digit1, '\\', one_of("\"n\\"))(s)
-/// };
+///
+/// fn esc(s: &str) -> IResult<&str, &str> {
+///   escaped(digit1, '\\', one_of("\"n\\"))(s)
+/// }
 ///
 /// assert_eq!(esc("123;"), Ok((";", "123")));
 /// assert_eq!(esc("12\\\"34;"), Ok((";", "12\\\"34")));

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -94,7 +94,7 @@ where
 ///
 /// It doesn't consume the matched character,
 ///
-/// It will return a `Err::Incomplete(Needed::Size(1))` if the pattern wasn't met
+/// It will return a `Err::Error(("", ErrorKind::IsNot))` if the pattern wasn't met
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -7,6 +7,23 @@ use lib::std::ops::RangeFrom;
 use lib::std::result::Result::*;
 use traits::{Compare, CompareResult, FindSubstring, FindToken, InputIter, InputLength, InputTake, InputTakeAtPosition, Slice, ToUsize};
 
+/// Recognizes a pattern
+///
+/// The input data will be compared to the tag combinator's argument and will return the part of
+/// the input that matches the argument
+///
+/// It will return `Err(Err::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern
+/// # Example
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// use nom::bytes::complete::tag;
+/// let parser = |s: &'static str| tag::<_, _, (_, ErrorKind)>("Hello")(s);
+///
+/// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
+/// assert_eq!(parser("Something"), Err(Err::Error(("Something", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
+/// ```
 pub fn tag<'a, T: 'a, Input: 'a, Error: ParseError<Input>>(tag: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTake + Compare<T>,
@@ -26,6 +43,25 @@ where
   }
 }
 
+/// Recognizes a case insensitive pattern
+///
+/// The input data will be compared to the tag combinator's argument and will return the part of
+/// the input that matches the argument with no regard to case
+///
+/// It will return `Err(Err::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern
+/// # Example
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// use nom::bytes::complete::tag_no_case;
+/// let parser = |s: &'static str| tag_no_case::<_, _, (_, ErrorKind)>("hello")(s);
+///
+/// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
+/// assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
+/// assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
+/// assert_eq!(parser("Something"), Err(Err::Error(("Something", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
+/// ```
 pub fn tag_no_case<T, Input, Error: ParseError<Input>>(tag: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTake + Compare<T>,
@@ -46,6 +82,25 @@ where
   }
 }
 
+/// Parse till certain characters are met
+///
+/// The parser will return the longest slice till one of the characters of the combinator's argument are met.
+///
+/// It doesn't consume the matched character,
+///
+/// It will return a `Err::Incomplete(Needed::Size(1))` if the pattern wasn't met
+/// # Example
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// use nom::bytes::complete::is_not;
+/// let not_space = |s: &'static str| is_not::<_, _, (_, ErrorKind)>(" \t\r\n")(s);
+///
+/// assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
+/// assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
+/// assert_eq!(not_space("Nospace"), Ok(("", "Nospace")));
+/// assert_eq!(not_space(""), Err(Err::Error(("", ErrorKind::IsNot))));
+/// ```
 pub fn is_not<T, Input, Error: ParseError<Input>>(arr: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
@@ -57,6 +112,26 @@ where
   }
 }
 
+/// Returns the longest slice of the matches the pattern
+///
+/// The parser will return the longest slice consisting of the characters in provided in the
+/// combinator's argument
+///
+/// It will return a `Err(Err::Error((_, ErrorKind::IsA)))` if the pattern wasn't met
+///
+/// # Example
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// use nom::bytes::complete::is_a;
+/// let hex = |s: &'static str| is_a::<_, _, (_, ErrorKind)>("1234567890ABCDEF")(s);
+///
+/// assert_eq!(hex("123 and voila"), Ok((" and voila", "123")));
+/// assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
+/// assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
+/// assert_eq!(hex("D15EA5E"), Ok(("", "D15EA5E")));
+/// assert_eq!(hex(""), Err(Err::Error(("", ErrorKind::IsA))));
+/// ```
 pub fn is_a<T, Input, Error: ParseError<Input>>(arr: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
@@ -68,6 +143,24 @@ where
   }
 }
 
+/// Returns the longest input slice (if any) that matches the predicate
+///
+/// The parser will return the longest slice that matches the given predicate *(a function that
+/// takes the input and returns a bool)*
+///
+/// # Example
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// use nom::bytes::complete::take_while;
+/// use nom::character::is_alphabetic;
+/// let alpha = |s: &'static [u8]| take_while::<_, _, (_, ErrorKind)>(is_alphabetic)(s);
+///
+/// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+/// assert_eq!(alpha(b"12345"), Ok((&b"12345"[..], &b""[..])));
+/// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
+/// assert_eq!(alpha(b""), Ok((&b""[..], &b""[..])));
+/// ```
 pub fn take_while<F, Input, Error: ParseError<Input>>(cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
@@ -76,6 +169,25 @@ where
   move |i: Input| i.split_at_position_complete(|c| !cond(c))
 }
 
+/// Returns the longest (atleast 1) input slice that matches the predicate
+///
+/// The parser will return the longest slice that matches the given predicate *(a function that
+/// takes the input and returns a bool)*
+///
+/// It will return an `Err(Err::Error((_, ErrorKind::TakeWhile1)))` if the pattern wasn't met
+///
+/// # Example
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// use nom::bytes::complete::take_while1;
+/// use nom::character::is_alphabetic;
+/// let alpha = |s: &'static [u8]| take_while1::<_, _, (_, ErrorKind)>(is_alphabetic)(s);
+///
+/// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+/// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
+/// assert_eq!(alpha(b"12345"), Err(Err::Error((&b"12345"[..], ErrorKind::TakeWhile1))));
+/// ```
 pub fn take_while1<F, Input, Error: ParseError<Input>>(cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
@@ -87,6 +199,30 @@ where
   }
 }
 
+/// Returns the longest (m <= len <= n) input slice  that matches the predicate
+///
+/// The parser will return the longest slice that matches the given predicate *(a function that
+/// takes the input and returns a bool)*
+///
+/// It will return an `Err::Error((_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
+/// of range (m <= len <= n)
+///
+/// # Example
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// use nom::bytes::complete::take_while_m_n;
+/// use nom::character::is_alphabetic;
+/// let short_alpha = |s: &'static [u8]| {
+///   take_while_m_n::<_, _, (_, ErrorKind)>(3, 6, is_alphabetic)(s)
+/// };
+///
+/// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+/// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
+/// assert_eq!(short_alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
+/// assert_eq!(short_alpha(b"ed"), Err(Err::Error((&b"ed"[..], ErrorKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(b"12345"), Err(Err::Error((&b"12345"[..], ErrorKind::TakeWhileMN))));
+/// ```
 pub fn take_while_m_n<F, Input, Error: ParseError<Input>>(m: usize, n: usize, cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTake + InputIter + InputLength + Slice<RangeFrom<usize>>,
@@ -137,6 +273,23 @@ where
   }
 }
 
+/// Returns the longest input slice (if any) till a predicate is met
+///
+/// The parser will return the longest slice till the given predicate *(a function that
+/// takes the input and returns a bool)*
+///
+/// # Example
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// use nom::bytes::complete::take_till;
+/// let till_colon = |s: &'static str| take_till::<_, _, (_, ErrorKind)>(|c| c == ':')(s);
+///
+/// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
+/// assert_eq!(till_colon(":empty matched"), Ok((":empty matched", ""))); //allowed
+/// assert_eq!(till_colon("12345"), Ok(("", "12345")));
+/// assert_eq!(till_colon(""), Ok(("", "")));
+/// ```
 pub fn take_till<F, Input, Error: ParseError<Input>>(cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
@@ -145,6 +298,26 @@ where
   move |i: Input| i.split_at_position_complete(|c| cond(c))
 }
 
+/// Returns the longest (atleast 1) input slice till a predicate is met
+///
+/// The parser will return the longest slice till the given predicate *(a function that
+/// takes the input and returns a bool)*
+///
+/// It will return `Err(Err::Error((_, ErrorKind::TakeTill1)))` if the input is empty or the
+/// predicate matches the first input
+///
+/// # Example
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// use nom::bytes::complete::take_till1;
+/// let till_colon = |s: &'static str| take_till1::<_, _, (_, ErrorKind)>(|c| c == ':')(s);
+///
+/// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
+/// assert_eq!(till_colon(":empty matched"), Err(Err::Error((":empty matched", ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon("12345"), Ok(("", "12345")));
+/// assert_eq!(till_colon(""), Err(Err::Error(("", ErrorKind::TakeTill1))));
+/// ```
 pub fn take_till1<F, Input, Error: ParseError<Input>>(cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
@@ -156,6 +329,22 @@ where
   }
 }
 
+/// Returns an input slice containing the first N input elements (Input[..N])
+/// 
+/// It will return `Err(Err::Error((_, ErrorKind::Eof)))` if the input is shorter than the argument
+///
+/// # Example
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// use nom::bytes::complete::take;
+/// let take6 = |s: &'static str| take::<_, _, (_, ErrorKind)>(6usize)(s);
+///
+/// assert_eq!(take6("1234567"), Ok(("7", "123456")));
+/// assert_eq!(take6("things"), Ok(("", "things")));
+/// assert_eq!(take6("short"), Err(Err::Error(("short", ErrorKind::Eof))));
+/// assert_eq!(take6(""), Err(Err::Error(("", ErrorKind::Eof))));
+/// ```
 pub fn take<C, Input, Error: ParseError<Input>>(count: C) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
   Input: InputIter + InputTake,
@@ -168,6 +357,24 @@ where
   }
 }
 
+/// Returns the longest input slice till it matches the pattern.
+///
+/// It doesn't consume the pattern. It will return `Err(Err::Error((_, ErrorKind::TakeUntil)))`
+/// if the pattern wasn't met
+///
+/// # Example
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// use nom::bytes::complete::take_until;
+/// let until_eof = |s: &'static str| {
+///   take_until::<_, _, (_, ErrorKind)>("eof")(s)
+/// };
+///
+/// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
+/// assert_eq!(until_eof("hello, world"), Err(Err::Error(("hello, world", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof(""), Err(Err::Error(("", ErrorKind::TakeUntil))));
+/// ```
 pub fn take_until<T, Input, Error: ParseError<Input>>(tag: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTake + FindSubstring<T>,
@@ -183,6 +390,27 @@ where
   }
 }
 
+/// Matches a byte string with escaped characters.
+///
+/// * The first argument matches the normal characters (it must not accept the control character),
+/// * the second argument is the control character (like `\` in most languages),
+/// * the third argument matches the escaped characters
+///
+/// # Example
+/// ```
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::character::complete::digit1;
+/// use nom::bytes::complete::escaped;
+/// use nom::character::complete::one_of;
+/// let esc = |s: &'static str| {
+///   escaped::<&str, (_, ErrorKind), _, _, _, _>(digit1, '\\', one_of("\"n\\"))(s)
+/// };
+///
+/// assert_eq!(esc("123;"), Ok((";", "123")));
+/// assert_eq!(esc("12\\\"34;"), Ok((";", "12\\\"34")));
+/// ```
+///
 pub fn escaped<Input, Error, F, G, O1, O2>(normal: F, control_char: char, escapable: G) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
   Input: Clone + ::traits::Offset + InputLength + InputTake + InputTakeAtPosition + Slice<RangeFrom<usize>> + InputIter,
@@ -250,6 +478,41 @@ where
   escaped(normal, control_char, escapable)(i)
 }
 
+/// Matches a byte string with escaped characters.
+///
+/// * The first argument matches the normal characters (it must not match the control character),
+/// * the second argument is the control character (like `\` in most languages),
+/// * the third argument matches the escaped characters and transforms them.
+///
+/// As an example, the chain `abc\tdef` could be `abc    def` (it also consumes the control character)
+///
+/// # Example
+/// ```
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use std::str::from_utf8;
+/// use nom::bytes::complete::escaped_transform;
+/// use nom::character::complete::alpha0;
+/// fn to_s(i:Vec<u8>) -> String {
+///   String::from_utf8_lossy(&i).into_owned()
+/// }
+/// named!(
+///   transform<String>,
+///   map!(
+///     escaped_transform!(
+///       alpha0,
+///       '\\',
+///       alt!(
+///           tag!("\\")       => { |_| &b"\\"[..] }
+///         | tag!("\"")       => { |_| &b"\""[..] }
+///         | tag!("n")        => { |_| &b"\n"[..] }
+///       )
+///     ),
+///     to_s
+///   )
+/// );
+///// assert_eq!(transform(&b"ab\\\"cd"[..]), Ok((&b""[..], String::from("ab\"cd"))));//
+/// ```
 pub fn escaped_transform<Input, Error, F, G, O1, O2, ExtendItem, Output>(
   normal: F,
   control_char: char,

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -487,32 +487,7 @@ where
 /// As an example, the chain `abc\tdef` could be `abc    def` (it also consumes the control character)
 ///
 /// # Example
-/// ```
-/// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use std::str::from_utf8;
-/// use nom::bytes::complete::escaped_transform;
-/// use nom::character::complete::alpha0;
-/// fn to_s(i:Vec<u8>) -> String {
-///   String::from_utf8_lossy(&i).into_owned()
-/// }
-/// named!(
-///   transform<String>,
-///   map!(
-///     escaped_transform!(
-///       alpha0,
-///       '\\',
-///       alt!(
-///           tag!("\\")       => { |_| &b"\\"[..] }
-///         | tag!("\"")       => { |_| &b"\""[..] }
-///         | tag!("n")        => { |_| &b"\n"[..] }
-///       )
-///     ),
-///     to_s
-///   )
-/// );
-///// assert_eq!(transform(&b"ab\\\"cd"[..]), Ok((&b""[..], String::from("ab\"cd"))));//
-/// ```
+/// Currently Unavailable
 pub fn escaped_transform<Input, Error, F, G, O1, O2, ExtendItem, Output>(
   normal: F,
   control_char: char,

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -14,9 +14,12 @@ use traits::{Compare, CompareResult, FindSubstring, FindToken, InputIter, InputL
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::streaming::tag;
-/// let parser = |s: &'static str| tag::<_, _, (_, ErrorKind)>("Hello")(s);
+///
+/// fn parser(s: &str) -> IResult<&str, &str> {
+///   tag("Hello")(s)
+/// }
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
 /// assert_eq!(parser("Something"), Err(Err::Error(("Something", ErrorKind::Tag))));
@@ -50,9 +53,12 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::streaming::tag_no_case;
-/// let parser = |s: &'static str| tag_no_case::<_, _, (_, ErrorKind)>("hello")(s);
+///
+/// fn parser(s: &str) -> IResult<&str, &str> {
+///   tag_no_case("hello")(s)
+/// }
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
 /// assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
@@ -91,9 +97,12 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::streaming::is_not;
-/// let not_space = |s: &'static str| is_not::<_, _, (_, ErrorKind)>(" \t\r\n")(s);
+///
+/// fn not_space(s: &str) -> IResult<&str, &str> {
+///   is_not(" \t\r\n")(s)
+/// }
 ///
 /// assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
 /// assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
@@ -122,9 +131,12 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::streaming::is_a;
-/// let hex = |s: &'static str| is_a::<_, _, (_, ErrorKind)>("1234567890ABCDEF")(s);
+///
+/// fn hex(s: &str) -> IResult<&str, &str> {
+///   is_a("1234567890ABCDEF")(s)
+/// }
 ///
 /// assert_eq!(hex("123 and voila"), Ok((" and voila", "123")));
 /// assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
@@ -153,10 +165,13 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::streaming::take_while;
 /// use nom::character::is_alphabetic;
-/// let alpha = |s: &'static [u8]| take_while::<_, _, (_, ErrorKind)>(is_alphabetic)(s);
+///
+/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+///   take_while(is_alphabetic)(s)
+/// }
 ///
 /// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(alpha(b"12345"), Ok((&b"12345"[..], &b""[..])));
@@ -183,10 +198,13 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::streaming::take_while1;
 /// use nom::character::is_alphabetic;
-/// let alpha = |s: &'static [u8]| take_while1::<_, _, (_, ErrorKind)>(is_alphabetic)(s);
+///
+/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+///   take_while1(is_alphabetic)(s)
+/// }
 ///
 /// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(alpha(b"latin"), Err(Err::Incomplete(Needed::Size(1))));
@@ -215,12 +233,13 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::streaming::take_while_m_n;
 /// use nom::character::is_alphabetic;
-/// let short_alpha = |s: &'static [u8]| {
-///   take_while_m_n::<_, _, (_, ErrorKind)>(3, 6, is_alphabetic)(s)
-/// };
+///
+/// fn short_alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+///   take_while_m_n(3, 6, is_alphabetic)(s)
+/// }
 ///
 /// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
@@ -285,9 +304,12 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::streaming::take_till;
-/// let till_colon = |s: &'static str| take_till::<_, _, (_, ErrorKind)>(|c| c == ':')(s);
+///
+/// fn till_colon(s: &str) -> IResult<&str, &str> {
+///   take_till(|c| c == ':')(s)
+/// }
 ///
 /// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
 /// assert_eq!(till_colon(":empty matched"), Ok((":empty matched", ""))); //allowed
@@ -313,9 +335,12 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::streaming::take_till1;
-/// let till_colon = |s: &'static str| take_till1::<_, _, (_, ErrorKind)>(|c| c == ':')(s);
+///
+/// fn till_colon(s: &str) -> IResult<&str, &str> {
+///   take_till1(|c| c == ':')(s)
+/// }
 ///
 /// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
 /// assert_eq!(till_colon(":empty matched"), Err(Err::Error((":empty matched", ErrorKind::TakeTill1))));
@@ -341,9 +366,12 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::streaming::take;
-/// let take6 = |s: &'static str| take::<_, _, (_, ErrorKind)>(6usize)(s);
+///
+/// fn take6(s: &str) -> IResult<&str, &str> {
+///   take(6usize)(s)
+/// }
 ///
 /// assert_eq!(take6("1234567"), Ok(("7", "123456")));
 /// assert_eq!(take6("things"), Ok(("", "things")));
@@ -372,11 +400,12 @@ where
 /// # Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::bytes::streaming::take_until;
-/// let until_eof = |s: &'static str| {
-///   take_until::<_, _, (_, ErrorKind)>("eof")(s)
-/// };
+///
+/// fn until_eof(s: &str) -> IResult<&str, &str> {
+///   take_until("eof")(s)
+/// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
 /// assert_eq!(until_eof("hello, world"), Err(Err::Incomplete(Needed::Size(3))));
@@ -408,13 +437,14 @@ where
 /// # Example
 /// ```
 /// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// # use nom::character::complete::digit1;
 /// use nom::bytes::streaming::escaped;
 /// use nom::character::streaming::one_of;
-/// let esc = |s: &'static str| {
-///   escaped::<&str, (_, ErrorKind), _, _, _, _>(digit1, '\\', one_of("\"n\\"))(s)
-/// };
+///
+/// fn esc(s: &str) -> IResult<&str, &str> {
+///   escaped(digit1, '\\', one_of("\"n\\"))(s)
+/// }
 ///
 /// assert_eq!(esc("123;"), Ok((";", "123")));
 /// assert_eq!(esc("12\\\"34;"), Ok((";", "12\\\"34")));

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -496,32 +496,7 @@ where
 /// As an example, the chain `abc\tdef` could be `abc    def` (it also consumes the control character)
 ///
 /// # Example
-/// ```
-/// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use std::str::from_utf8;
-/// use nom::bytes::streaming::escaped_transform;
-/// use nom::character::streaming::alpha0;
-/// fn to_s(i:Vec<u8>) -> String {
-///   String::from_utf8_lossy(&i).into_owned()
-/// }
-/// named!(
-///   transform<String>,
-///   map!(
-///     escaped_transform!(
-///       alpha0,
-///       '\\',
-///       alt!(
-///           tag!("\\")       => { |_| &b"\\"[..] }
-///         | tag!("\"")       => { |_| &b"\""[..] }
-///         | tag!("n")        => { |_| &b"\n"[..] }
-///       )
-///     ),
-///     to_s
-///   )
-/// );
-/// assert_eq!(transform(&b"ab\\\"cd"[..]), Ok((&b""[..], String::from("ab\"cd"))));//
-/// ```
+/// Currently Unavailable
 pub fn escaped_transform<Input, Error, F, G, O1, O2, ExtendItem, Output>(
   normal: F,
   control_char: char,

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -191,9 +191,10 @@ where
 /// The parser will return the longest slice that matches the given predicate *(a function that
 /// takes the input and returns a bool)*
 ///
+/// It will return an `Err(Err::Error((_, ErrorKind::TakeWhile1)))` if the pattern wasn't met
+///
 /// # Streaming Specific
 /// *Streaming version* will return a `Err::Incomplete(Needed::Size(1))` or if the pattern reaches the end of the input.
-/// And will return an `Err(Err::Error((_, ErrorKind::TakeWhile1)))` if the pattern wasn't met
 ///
 /// # Example
 /// ```rust


### PR DESCRIPTION
This pull request is a continuation of #928 which now adds documentation for both the streaming, and complete version of bytes (#915), with appropriate documentation when there's a difference. There's also been a few stylistic differences  from #928