### PR TITLE
Stop converting `Err::Error` to `Err::Failure` in `error::context()`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -98,9 +98,8 @@ where
       match f(i.clone()) {
         Ok(o) => Ok(o),
         Err(Err::Incomplete(i)) => Err(Err::Incomplete(i)),
-        Err(Err::Error(e)) | Err(Err::Failure(e)) => {
-          Err(Err::Failure(E::add_context(i, context, e)))
-        }
+        Err(Err::Error(e)) => Err(Err::Error(E::add_context(i, context, e))),
+        Err(Err::Failure(e)) => Err(Err::Failure(E::add_context(i, context, e))),
       }
     }
 

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -279,3 +279,13 @@ fn issue_848_overflow_incomplete_bits_to_bytes() {
   named!(parser<&[u8], &[u8]>, bits!(bytes!(take!(0x2000000000000000))));
   assert_eq!(parser(&b""[..]), Err(Err::Failure(error_position!(&b""[..], ErrorKind::TooLarge))));
 }
+
+#[test]
+fn issue_942() {
+  use nom::error::ParseError;
+  pub fn parser<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, usize, E> {
+    use nom::{character::complete::char, error::context, multi::many0_count};
+    many0_count(context("char_a", char('a')))(i)
+  }
+  assert_eq!(parser::<()>("aaa"), Ok(("", 3)));
+}


### PR DESCRIPTION
Closes #942.

## Prerequisites

- related issue number: #942
- a test case reproducing the issue: Added `issue_942()` in `issue.rs`.