### PR TITLE
Fix escaped not returning err on failure (issue #953)

### DIFF
--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -355,7 +355,7 @@ where
 }
 
 /// Returns an input slice containing the first N input elements (Input[..N])
-/// 
+///
 /// It will return `Err(Err::Error((_, ErrorKind::Eof)))` if the input is shorter than the argument
 ///
 /// # Example
@@ -483,6 +483,9 @@ where
             }
           } else {
             let index = input.offset(&i);
+            if index == 0 {
+              return Err(Err::Error(Error::from_error_kind(input, ErrorKind::Escaped)));
+            }
             return Ok(input.take_split(index));
           }
         }
@@ -597,6 +600,9 @@ where
               }
             }
           } else {
+            if index == 0 {
+              return Err(Err::Error(Error::from_error_kind(remainder, ErrorKind::EscapedTransform)));
+            }
             return Ok((remainder, res));
           }
         }

--- a/tests/escaped.rs
+++ b/tests/escaped.rs
@@ -1,0 +1,18 @@
+use nom::{Err, error::ErrorKind, IResult};
+use nom::character::complete::digit1;
+use nom::bytes::complete::{escaped, escaped_transform, tag};
+use nom::character::complete::one_of;
+
+fn esc(s: &str) -> IResult<&str, &str> {
+    escaped(digit1, '\\', one_of("\"n\\"))(s)
+}
+
+fn esc_trans(s: &str) -> IResult<&str, String> {
+    escaped_transform(digit1, '\\', |i: &str| tag("n")(i))(s)
+}
+
+#[test]
+fn test_escaped() {
+    assert_eq!(esc("abcd"), Err(Err::Error(("abcd", ErrorKind::Escaped))));
+    assert_eq!(esc_trans("abcd"), Err(Err::Error(("abcd", ErrorKind::EscapedTransform))));
+}


### PR DESCRIPTION
If none of the input parsers match, then `escaped` and `escaped_transform` should return an `Err` instead of `Ok("")`
