### PR TITLE
README.md: Remove Rust's syn parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ parsing, and construct an AST in place.
 Example projects:
 
 - [PHP VM](https://github.com/tagua-vm/parser)
-- [Rust parser](https://github.com/dtolnay/syn)
 - eve language prototype
 - [xshade shading language](https://github.com/xshade-lang/xshade/)
 


### PR DESCRIPTION
The syn parser [dropped nom](https://github.com/dtolnay/syn/commit/06faaca04096644cc9f83be0a51fd63c11dad7bf).