### PR TITLE
separated_list, separated_nonempty_list: Document arguments in order

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -204,8 +204,8 @@ where
 /// Alternates between two parsers to produce
 /// a list of elements.
 /// # Arguments
-/// * `f` Parses the elements of the list.
 /// * `sep` Parses the separator between list elements.
+/// * `f` Parses the elements of the list.
 ///
 /// ```rust
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};
@@ -291,8 +291,8 @@ where
 /// a list of elements. Fails if the element
 /// parser does not produce at least one element.
 /// # Arguments
-/// * `f` Parses the elements of the list.
 /// * `sep` Parses the separator between list elements.
+/// * `f` Parses the elements of the list.
 /// ```rust
 /// # #[macro_use] extern crate nom;
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};


### PR DESCRIPTION
These functions take `(sep, f)`, so document `sep` before `f`.