### PR TITLE
Changes to convert_error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -541,12 +541,29 @@ macro_rules! flat_map(
 mod tests {
   use super::*;
   use crate::character::complete::char;
+  use crate::sequence::preceded;
 
+  // see https://github.com/Geal/nom/issues/967
   #[test]
-  fn convert_error_panic() {
+  fn convert_error_empty_panic() {
     let input = "";
 
-    let result: IResult<_, _, VerboseError<&str>> = char('x')(input);
+    let err: VerboseError<&str> = match char('x')(input).unwrap_err() {
+      crate::Err::Error(e) | crate::Err::Failure(e) => e,
+      _ => panic!("Parse should not be incomplete"),
+    };
+    let _ = convert_error(input, err);
+  }
+
+  #[test]
+  fn convert_error_early_eof_panic() {
+    let input = "x";
+
+    let err: VerboseError<&str> = match preceded(char('x'), char('x'))(input).unwrap_err() {
+      crate::Err::Error(e) | crate::Err::Failure(e) => e,
+      _ => panic!("Parse should not be incomplete"),
+    };
+    let _ = convert_error(input, err);
   }
 }
 


### PR DESCRIPTION
This fixes the case where the input is non-empty, but still requires a char at EOF.

This also does some cleanup to speed up `convert_error`
* counting lines directly, rather than collecting into strings
* formatting into the result string, rather than into temporary strings first

#### This introduces two changes in the output of `convert_error`

In case of empty input (or any early EOF), outputs:
```
a b 
    ^
expected 'c' , found EOF
```

Chars are formatted with debug. This does not change the literal line, just the expected line:
```
a b 
    ^
expected 'c' found '\u{0}'
```

## Related Issue
#967 
