### PR TITLE
Fix panic on `convert_error` on EOF

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -187,7 +187,7 @@ pub fn convert_error(input: &str, e: VerboseError<&str>) -> crate::lib::std::str
             result += &repeat(' ').take(column).collect::<crate::lib::std::string::String>();
           }
           result += "^\n";
-          result += &format!("expected '{}', found {}\n\n", c, substring.chars().next().unwrap());
+          result += &format!("expected '{}', found {}\n\n", c, substring.chars().next().unwrap_or(' '));
         }
         VerboseErrorKind::Context(s) => {
           result += &format!("{}: at line {}, in {}:\n", i, line, s);


### PR DESCRIPTION
`convert_error` tries to print the next char when printing char errors, but if the error is at EOF, the next char does not exist.

Couldn't find an issue for this, and since the fix was trivial, I'm just submitting it directly.