### PR TITLE
fix many_m_n for n=0

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -409,6 +409,10 @@ where
     let mut input = i.clone();
     let mut count: usize = 0;
 
+    if n == 0 {
+        return Ok((i, vec!()))
+    }
+
     loop {
       let _i = input.clone();
       match f(_i) {

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -290,3 +290,11 @@ fn issue_942() {
   }
   assert_eq!(parser::<()>("aaa"), Ok(("", 3)));
 }
+
+#[test]
+fn issue_many_m_n_with_zeros() {
+    use nom::multi::many_m_n;
+    use nom::character::complete::char;
+    let parser = many_m_n::<_, _, (), _>(0, 0, char('a'));
+    assert_eq!(parser("aaa"), Ok(("aaa", vec!())));
+}


### PR DESCRIPTION
I don't think other function in multi are susceptible to the same bug (fold_many_m_n uses a for loop).