### PR TITLE
Add delimited_list parser.

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -980,3 +980,77 @@ where
 {
   length_value(f, g)(i)
 }
+
+/// Alternates between two parsers delimited by two outer parsers to
+/// produce a list of elements.
+///
+/// Similar to `delimited(pre, separated_list(sep, item), term)`, but
+/// handles errors differently: Since this parser knows what is
+/// supposed to terminate the list, it can report errors from the item
+/// parser rather than assuming that the list has ended when item
+/// parsing fails.
+///
+/// The list is allowed to be empty, and a trailing separator (before
+/// the terminator) is allowed but not required.
+///
+/// # Arguments
+///
+/// * `pre` The opening parser.
+/// * `item` Parses the elements of the list.
+/// * `sep` Parses the separator between list elements.
+/// * `term` The list-terminating parser.
+///
+/// # Example
+///
+/// ```
+/// # use nom::multi::delimited_list;
+/// # use nom::bytes::complete::{is_a, tag};
+/// # use nom::{Err, error::ErrorKind};
+/// let parser = delimited_list(tag("("), is_a("abcde"), tag(","), tag(")"));
+///
+/// assert_eq!(parser("(a,b,c)"), Ok(("", vec!["a", "b", "c"])));
+/// assert_eq!(parser("(a,b,c,)"), Ok(("", vec!["a", "b", "c"])));
+/// assert_eq!(parser("()"), Ok(("", vec![])));
+///
+/// // This call returns the error from the terminator parser:
+/// assert_eq!(parser("(a!)"), Err(Err::Error(("!)", ErrorKind::Tag))));
+/// // This call returns the error from the item parser:
+/// assert_eq!(parser("(a,!)"), Err(Err::Error(("!)", ErrorKind::IsA))));
+/// ```
+#[cfg(feature = "alloc")]
+pub fn delimited_list<I, OP, OF, OS, OT, E: ParseError<I>, P, F, S, T>(
+    pre: P,
+    item: F,
+    sep: S,
+    term: T,
+) -> impl Fn(I) -> IResult<I, Vec<OF>, E> where
+    I: Clone + PartialEq,
+    P: Fn(I) -> IResult<I, OP, E>,
+    F: Fn(I) -> IResult<I, OF, E>,
+    S: Fn(I) -> IResult<I, OS, E>,
+    T: Fn(I) -> IResult<I, OT, E>
+{
+    move |input| {
+        let (mut input, _) = pre(input)?;
+        let mut list = Vec::new();
+        loop {
+            let (i, value) =
+                match item(input.clone()) {
+                    Ok((i, value)) => (i, value),
+                    Err(item_error) => {
+                        match term(input) {
+                            Ok((i, _)) => return Ok((i, list)),
+                            Err(_) => return Err(item_error)
+                        }
+                    }
+                };
+            list.push(value);
+            match sep(i.clone()) {
+                Ok((i, _)) => input = i,
+                Err(_) => { input = i; break; }
+            }
+        }
+        let (input, _) = term(input)?;
+        Ok((input, list))
+    }
+}


### PR DESCRIPTION
Alternates between two parsers delimited by two outer parsers to produce a list of elements.

The parser `delimited_list(pre, item, sem, term)` is similar to `delimited(pre, separated_list(sep, item), term)`, but handles errors differently: Since this parser knows what is supposed to terminate the list, it can report errors from the `item` parser rather than assuming that the list has ended when item parsing fails.

The `pre` parser is mainly added for symmetry, but the `term` parser is needed for differentiating between an error in `item` parsing and the end of the list.  If you prefer a `terminated_list` parser without the `pre`, I could rewrite the PR to do that instead.

## Prerequisites

Documentation and testing example provided.  (The [combinator list](https://github.com/Geal/nom/blob/master/doc/choosing_a_combinator.md) seems to be mainly about macro combinators, so nothing added there.)

Example code repeated here:

```rust
let parser = delimited_list(tag("("), is_a("abcde"), tag(","), tag(")"));

assert_eq!(parser("(a,b,c)"), Ok(("", vec!["a", "b", "c"])));
assert_eq!(parser("(a,b,c,)"), Ok(("", vec!["a", "b", "c"])));
assert_eq!(parser("()"), Ok(("", vec![])));

// This call returns the error from the terminator parser:
assert_eq!(parser("(a!)"), Err(Err::Error(("!)", ErrorKind::Tag))));
// This call returns the error from the item parser:
assert_eq!(parser("(a,!)"), Err(Err::Error(("!)", ErrorKind::IsA))));
```