### PR TITLE
Fix meta variable misuse

### DIFF
--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -212,7 +212,7 @@ macro_rules! permutation_trait_inner(
         }
       };
     }
-    succ!($it, permutation_trait_inner!($self, $input, $res, $all_done, $($id)*));
+    succ!($it, permutation_trait_inner!($self, $input, $res, $all_done, $($id)+));
   });
   ($it:tt, $self:expr, $input:ident, $res:expr, $all_done:expr, $head:ident) => ({
     if $res.$it.is_none() {

--- a/src/combinator/macros.rs
+++ b/src/combinator/macros.rs
@@ -657,7 +657,7 @@ macro_rules! verify (
     $crate::combinator::verify($f, $g)($i)
   );
   ($i:expr, $f:expr, $submac:ident!( $($args:tt)* )) => (
-    $crate::combinator::verify($f, |&o| $submac2!(o, $($args)*))($i)
+    $crate::combinator::verify($f, |&o| $submac!(o, $($args)*))($i)
   );
 );
 

--- a/src/sequence/macros.rs
+++ b/src/sequence/macros.rs
@@ -468,7 +468,7 @@ macro_rules! do_parse (
 #[doc(hidden)]
 #[macro_export]
 macro_rules! nom_compile_error (
-  (( $(args:tt)* )) => ( compile_error!($($args)*) );
+  (( $($args:tt)* )) => ( compile_error!($($args)*) );
 );
 
 #[cfg(test)]

--- a/src/whitespace.rs
+++ b/src/whitespace.rs
@@ -144,7 +144,7 @@ macro_rules! delimited_sep (
   ($i:expr, $separator:path, $submac1:ident!( $($args1:tt)* ), $($rest:tt)+) => ({
     use $crate::lib::std::result::Result::*;
 
-    match tuple_sep!($i, $separator, (), $submac1!($($args1)*), $($rest)*) {
+    match tuple_sep!($i, $separator, (), $submac1!($($args1)*), $($rest)+) {
       Err(e) => Err(e),
       Ok((remaining, (_,o,_))) => {
         Ok((remaining, o))
@@ -152,7 +152,7 @@ macro_rules! delimited_sep (
     }
   });
   ($i:expr, $separator:path, $f:expr, $($rest:tt)+) => (
-    delimited_sep!($i, $separator, call!($f), $($rest)*);
+    delimited_sep!($i, $separator, call!($f), $($rest)+);
   );
 );
 
@@ -162,7 +162,7 @@ macro_rules! separated_pair_sep (
   ($i:expr, $separator:path, $submac1:ident!( $($args1:tt)* ), $($rest:tt)+) => ({
     use $crate::lib::std::result::Result::*;
 
-    match tuple_sep!($i, $separator, (), $submac1!($($args1)*), $($rest)*) {
+    match tuple_sep!($i, $separator, (), $submac1!($($args1)*), $($rest)+) {
       Err(e) => Err(e),
       Ok((remaining, (o1,_,o2))) => {
         Ok((remaining, (o1,o2)))
@@ -170,7 +170,7 @@ macro_rules! separated_pair_sep (
     }
   });
   ($i:expr, $separator:path, $f:expr, $($rest:tt)+) => (
-    separated_pair_sep!($i, $separator, call!($f), $($rest)*);
+    separated_pair_sep!($i, $separator, call!($f), $($rest)+);
   );
 );
 
@@ -508,7 +508,7 @@ macro_rules! alt_sep (
       match sep!($i, $separator, $subrule!( $($args)* )) {
         Ok((i,o))               => Ok((i,$gen(o))),
         Err(Err::Error(_))      => {
-          alt_sep!(__impl $i, $separator, $($rest)*)
+          alt_sep!(__impl $i, $separator, $($rest)+)
         },
         Err(e)            => Err(e),
       }


### PR DESCRIPTION
Rust issue: https://github.com/rust-lang/rust/issues/61053
Rust PR: https://github.com/rust-lang/rust/pull/62008

Reproduce by compiling with a stage2 (or stage1) compiler at the PR given above (set the meta_variable_misuse lint to deny if it's not). The output would look like (only first errors are kept):
```
error: unknown macro variable `submac2`
   --> src/combinator/macros.rs:660:41
    |
660 |     $crate::combinator::verify($f, |&o| $submac2!(o, $($args)*))($i)
    |                                         ^^^^^^^^
    |
    = note: #[deny(meta_variable_misuse)] on by default

error: meta-variable repeats with different Kleene operator
   --> src/branch/mod.rs:215:75
    |
199 |   ($it:tt, $self:expr, $input:ident, $res:expr, $all_done:expr, $head:ident $($id:ident)+) => ({
    |                                                                                         - expected repetition
...
215 |     succ!($it, permutation_trait_inner!($self, $input, $res, $all_done, $($id)*));
    |                                                                           ^^^ - conflicting repetition

error: unknown macro variable `args`
   --> src/sequence/macros.rs:471:43
    |
471 |   (( $(args:tt)* )) => ( compile_error!($($args)*) );
    |                                           ^^^^^

error: meta-variable repeats with different Kleene operator
   --> src/whitespace.rs:147:67
    |
144 |   ($i:expr, $separator:path, $submac1:ident!( $($args1:tt)* ), $($rest:tt)+) => ({
    |                                                                           - expected repetition
...
147 |     match tuple_sep!($i, $separator, (), $submac1!($($args1)*), $($rest)*) {
    |                                                                   ^^^^^ - conflicting repetition
```
