### PR TITLE
[nom5] Add new combinator: take_up_to

### DIFF
--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -429,6 +429,48 @@ where
   }
 }
 
+/// Returns the longest input slice until it matches the pattern, pattern is consumed.
+///
+/// It does consume the pattern
+///
+/// # Streaming Specific
+/// *Streaming version* will return a `Err::Incomplete(Needed::Size(N))` if the input doesn't
+/// contain the pattern or if the input is smaller than the pattern
+/// # Example
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// use nom::bytes::streaming::take_up_to;
+///
+/// fn up_to_eof(s: &str) -> IResult<&str, &str> {
+///   take_up_to("eof")(s)
+/// }
+///
+/// assert_eq!(up_to_eof("hello, worldeof"), Ok(("", "hello, world")));
+/// assert_eq!(up_to_eof("eof"), Ok(("", "")));
+/// assert_eq!(up_to_eof("hello, world"), Err(Err::Incomplete(Needed::Size(3))));
+/// assert_eq!(up_to_eof(""), Err(Err::Incomplete(Needed::Size(3))));
+/// ```
+pub fn take_up_to<T, Input, Error: ParseError<Input>>(tag: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
+where
+  Input: InputTake + FindSubstring<T>,
+  T: InputLength + Clone,
+{
+  move |i: Input| {
+    let len = tag.input_len();
+    let t = tag.clone();
+
+    let res: IResult<_, _, Error> = match i.find_substring(t) {
+      None => Err(Err::Incomplete(Needed::Size(len))),
+      Some(index) => {
+        let (remain, consume) = i.take_split(index);
+        Ok((remain.take_split(len).0, consume))
+      }
+    };
+    res
+  }
+}
+
 /// Matches a byte string with escaped characters.
 ///
 /// * The first argument matches the normal characters (it must not accept the control character),

--- a/src/error.rs
+++ b/src/error.rs
@@ -271,6 +271,7 @@ pub enum ErrorKind {
   Many0Count,
   Many1Count,
   Float,
+  TakeUpTo,
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -330,6 +331,7 @@ pub fn error_to_u32(e: &ErrorKind) -> u32 {
     ErrorKind::Many0Count                => 72,
     ErrorKind::Many1Count                => 73,
     ErrorKind::Float                     => 74,
+    ErrorKind::TakeUpTo                  => 75,
   }
 }
 
@@ -391,6 +393,7 @@ impl ErrorKind {
       ErrorKind::Many0Count                => "Count occurrence of >=0 patterns",
       ErrorKind::Many1Count                => "Count occurrence of >=1 patterns",
       ErrorKind::Float                     => "Float",
+      ErrorKind::TakeUpTo                  => "Take up to",
     }
   }
 }


### PR DESCRIPTION
Works like `take_until`, except it consumes the pattern, and doesn't include the final pattern in the result.

Story behind this is, I was working on parsing something (duh ...), and found that I was writing this as a combination of other sub-parsers. Could be useful to others as well.

Couldn't think of a better name, so suggestions are welcome :)

Added docs for the new functions, as well as doc tests which are passing.