### PR TITLE
Relaxing bounds on flat_map's second input

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -242,7 +242,7 @@ pub fn flat_map<I, O1, O2, E: ParseError<I>, F, G, H>(first: F, second: G) -> im
 where
   F: Fn(I) -> IResult<I, O1, E>,
   G: Fn(O1) -> H,
-  H: Fn(I) -> IResult<I, O2, E>
+  H: FnOnce(I) -> IResult<I, O2, E>
 {
   move |input: I| {
     let (input, o1) = first(input)?;


### PR DESCRIPTION
Fixing #1000.

Relaxes bound on `H` from `Fn` to `FnOnce`