### PR TITLE
[DISCUSSION] Reducing closure requirement from Fn to FnMut

### DIFF
--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -147,9 +147,9 @@ fn parse_constant<'a>(i: &'a str) -> IResult<&'a str, Expr, VerboseError<&'a str
 ///
 /// Unlike the previous functions, this function doesn't take or consume input, instead it
 /// takes a parsing function and returns a new parsing function.
-fn s_exp<'a, O1, F>(inner: F) -> impl Fn(&'a str) -> IResult<&'a str, O1, VerboseError<&'a str>>
+fn s_exp<'a, O1, F>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O1, VerboseError<&'a str>>
 where
-  F: Fn(&'a str) -> IResult<&'a str, O1, VerboseError<&'a str>>,
+  F: FnMut(&'a str) -> IResult<&'a str, O1, VerboseError<&'a str>>,
 {
   delimited(
     char('('),

--- a/src/bits/complete.rs
+++ b/src/bits/complete.rs
@@ -7,7 +7,7 @@ use crate::lib::std::ops::{AddAssign, RangeFrom, Shl, Shr, Div};
 use crate::traits::{InputIter, InputLength, Slice, ToUsize};
 
 /// generates a parser taking `count` bits
-pub fn take<I, O, C, E: ParseError<(I, usize)>>(count: C) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
+pub fn take<I, O, C, E: ParseError<(I, usize)>>(count: C) -> impl FnMut((I, usize)) -> IResult<(I, usize), O, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
   C: ToUsize,
@@ -54,7 +54,7 @@ where
 }
 
 /// generates a parser taking `count` bits and comparing them to `pattern`
-pub fn tag<I, O, C, E: ParseError<(I, usize)>>(pattern: O, count: C) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
+pub fn tag<I, O, C, E: ParseError<(I, usize)>>(pattern: O, count: C) -> impl FnMut((I, usize)) -> IResult<(I, usize), O, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + Clone,
   C: ToUsize,

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -34,10 +34,10 @@ use crate::traits::{Slice, ErrorConvert};
 ///
 /// assert_eq!(take_4_bits( sl ), Ok( (&sl[1..], 0xA) ));
 /// ```
-pub fn bits<I, O, E1: ParseError<(I, usize)>+ErrorConvert<E2>, E2: ParseError<I>, P>(parser: P) -> impl Fn(I) -> IResult<I, O, E2>
+pub fn bits<I, O, E1: ParseError<(I, usize)>+ErrorConvert<E2>, E2: ParseError<I>, P>(mut parser: P) -> impl FnMut(I) -> IResult<I, O, E2>
 where
   I: Slice<RangeFrom<usize>>,
-  P: Fn((I, usize)) -> IResult<(I, usize), O, E1>,
+  P: FnMut((I, usize)) -> IResult<(I, usize), O, E1>,
 {
   move |input: I| match parser((input, 0)) {
     Ok(((rest, offset), res)) => {
@@ -54,7 +54,7 @@ where
 pub fn bitsc<I, O, E1: ParseError<(I, usize)>+ErrorConvert<E2>, E2: ParseError<I>, P>(input: I, parser: P) -> IResult<I, O, E2>
 where
   I: Slice<RangeFrom<usize>>,
-  P: Fn((I, usize)) -> IResult<(I, usize), O, E1>,
+  P: FnMut((I, usize)) -> IResult<(I, usize), O, E1>,
 {
   bits(parser)(input)
 }
@@ -84,10 +84,10 @@ where
 ///
 /// assert_eq!(parse( input ), Ok(( &[][..], (0xd, 0xea, &[0xbe, 0xaf][..]) )));
 /// ```
-pub fn bytes<I, O, E1: ParseError<I>+ErrorConvert<E2>, E2: ParseError<(I, usize)>, P>(parser: P) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E2>
+pub fn bytes<I, O, E1: ParseError<I>+ErrorConvert<E2>, E2: ParseError<(I, usize)>, P>(mut parser: P) -> impl FnMut((I, usize)) -> IResult<(I, usize), O, E2>
 where
   I: Slice<RangeFrom<usize>> + Clone,
-  P: Fn(I) -> IResult<I, O, E1>,
+  P: FnMut(I) -> IResult<I, O, E1>,
 {
   move |(input, offset): (I, usize)| {
     let inner = if offset % 8 != 0 {
@@ -113,7 +113,7 @@ where
 pub fn bytesc<I, O, E1: ParseError<I>+ErrorConvert<E2>, E2: ParseError<(I, usize)>, P>(input: (I, usize), parser: P) -> IResult<(I, usize), O, E2>
 where
   I: Slice<RangeFrom<usize>> + Clone,
-  P: Fn(I) -> IResult<I, O, E1>,
+  P: FnMut(I) -> IResult<I, O, E1>,
 {
   bytes(parser)(input)
 }

--- a/src/bits/streaming.rs
+++ b/src/bits/streaming.rs
@@ -7,7 +7,7 @@ use crate::lib::std::ops::{AddAssign, RangeFrom, Shl, Shr, Div};
 use crate::traits::{InputIter, InputLength, Slice, ToUsize};
 
 /// generates a parser taking `count` bits
-pub fn take<I, O, C, E: ParseError<(I, usize)>>(count: C) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
+pub fn take<I, O, C, E: ParseError<(I, usize)>>(count: C) -> impl FnMut((I, usize)) -> IResult<(I, usize), O, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
   C: ToUsize,
@@ -54,7 +54,7 @@ where
 }
 
 /// generates a parser taking `count` bits and comparing them to `pattern`
-pub fn tag<I, O, C, E: ParseError<(I, usize)>>(pattern: O, count: C) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
+pub fn tag<I, O, C, E: ParseError<(I, usize)>>(pattern: O, count: C) -> impl FnMut((I, usize)) -> IResult<(I, usize), O, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + Clone,
   C: ToUsize,

--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -12,7 +12,7 @@ use crate::internal::{Err, IResult};
 /// this trait is implemented for tuples of up to 21 elements
 pub trait Alt<I, O, E> {
   /// tests each parser in the tuple and returns the result of the first one that succeeds
-  fn choice(&self, input: I) -> IResult<I, O, E>;
+  fn choice(&mut self, input: I) -> IResult<I, O, E>;
 }
 
 /// tests a list of parsers one by one until one succeeds
@@ -42,7 +42,7 @@ pub trait Alt<I, O, E> {
 ///
 /// with a custom error type, it is possible to have alt return the error of the parser
 /// that went the farthest in the input data
-pub fn alt<I: Clone, O, E: ParseError<I>, List: Alt<I, O, E>>(l: List) -> impl Fn(I) -> IResult<I, O, E> {
+pub fn alt<I: Clone, O, E: ParseError<I>, List: Alt<I, O, E>>(mut l: List) -> impl FnMut(I) -> IResult<I, O, E> {
   move |i: I| l.choice(i)
 }
 
@@ -51,7 +51,7 @@ pub fn alt<I: Clone, O, E: ParseError<I>, List: Alt<I, O, E>>(l: List) -> impl F
 /// this trait is implemented for tuples of up to 21 elements
 pub trait Permutation<I, O, E> {
   /// tries to apply all parsers in the tuple in various orders until all of them succeed
-  fn permutation(&self, input: I) -> IResult<I, O, E>;
+  fn permutation(&mut self, input: I) -> IResult<I, O, E>;
 }
 
 /// applies a list of parsers in any order
@@ -80,7 +80,7 @@ pub trait Permutation<I, O, E> {
 /// assert_eq!(parser("abc;"), Err(Err::Error(error_position!(";", ErrorKind::Permutation))));
 /// # }
 /// ```
-pub fn permutation<I: Clone, O, E: ParseError<I>, List: Permutation<I, O, E>>(l: List) -> impl Fn(I) -> IResult<I, O, E> {
+pub fn permutation<I: Clone, O, E: ParseError<I>, List: Permutation<I, O, E>>(mut l: List) -> impl FnMut(I) -> IResult<I, O, E> {
   move |i: I| l.permutation(i)
 }
 
@@ -103,10 +103,10 @@ macro_rules! alt_trait_impl(
   ($($id:ident)+) => (
     impl<
       Input: Clone, Output, Error: ParseError<Input>,
-      $($id: Fn(Input) -> IResult<Input, Output, Error>),+
+      $($id: FnMut(Input) -> IResult<Input, Output, Error>),+
     > Alt<Input, Output, Error> for ( $($id),+ ) {
 
-      fn choice(&self, input: Input) -> IResult<Input, Output, Error> {
+      fn choice(&mut self, input: Input) -> IResult<Input, Output, Error> {
         let mut err = None;
         alt_trait_inner!(0, self, input, err, $($id)+);
 
@@ -167,10 +167,10 @@ macro_rules! permutation_trait_impl(
   ($($name:ident $ty: ident),+) => (
     impl<
       Input: Clone, $($ty),+ , Error: ParseError<Input>,
-      $($name: Fn(Input) -> IResult<Input, $ty, Error>),+
+      $($name: FnMut(Input) -> IResult<Input, $ty, Error>),+
     > Permutation<Input, ( $($ty),+ ), Error> for ( $($name),+ ) {
 
-      fn permutation(&self, mut input: Input) -> IResult<Input, ( $($ty),+ ), Error> {
+      fn permutation(&mut self, mut input: Input) -> IResult<Input, ( $($ty),+ ), Error> {
         let mut res = permutation_init!((), $($name),+);
 
         loop {
@@ -262,4 +262,4 @@ macro_rules! permutation_trait_unwrap (
   });
 );
 
-permutation_trait!(FnA A, FnB B, FnC C, FnD D, FnE E, FnF F, FnG G, FnH H, FnI I, FnJ J, FnK K, FnL L, FnM M, FnN N, FnO O, FnP P, FnQ Q, FnR R, FnS S, FnT T, FnU U);
+permutation_trait!(FnMutA A, FnMutB B, FnMutC C, FnMutD D, FnMutE E, FnMutF F, FnMutG G, FnMutH H, FnMutI I, FnMutJ J, FnMutK K, FnMutL L, FnMutM M, FnMutN N, FnMutO O, FnMutP P, FnMutQ Q, FnMutR R, FnMutS S, FnMutT T, FnMutU U);

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -27,7 +27,7 @@ use crate::traits::{Compare, CompareResult, FindSubstring, FindToken, InputIter,
 /// assert_eq!(parser("Something"), Err(Err::Error(("Something", ErrorKind::Tag))));
 /// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
 /// ```
-pub fn tag<'a, T: 'a, Input: 'a, Error: ParseError<Input>>(tag: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn tag<'a, T: 'a, Input: 'a, Error: ParseError<Input>>(tag: T) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTake + Compare<T>,
   T: InputLength + Clone,
@@ -68,7 +68,7 @@ where
 /// assert_eq!(parser("Something"), Err(Err::Error(("Something", ErrorKind::Tag))));
 /// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
 /// ```
-pub fn tag_no_case<T, Input, Error: ParseError<Input>>(tag: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn tag_no_case<T, Input, Error: ParseError<Input>>(tag: T) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTake + Compare<T>,
   T: InputLength + Clone,
@@ -110,7 +110,7 @@ where
 /// assert_eq!(not_space("Nospace"), Ok(("", "Nospace")));
 /// assert_eq!(not_space(""), Err(Err::Error(("", ErrorKind::IsNot))));
 /// ```
-pub fn is_not<T, Input, Error: ParseError<Input>>(arr: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn is_not<T, Input, Error: ParseError<Input>>(arr: T) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
   T: InputLength + FindToken<<Input as InputTakeAtPosition>::Item>,
@@ -144,7 +144,7 @@ where
 /// assert_eq!(hex("D15EA5E"), Ok(("", "D15EA5E")));
 /// assert_eq!(hex(""), Err(Err::Error(("", ErrorKind::IsA))));
 /// ```
-pub fn is_a<T, Input, Error: ParseError<Input>>(arr: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn is_a<T, Input, Error: ParseError<Input>>(arr: T) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
   T: InputLength + FindToken<<Input as InputTakeAtPosition>::Item>,
@@ -176,10 +176,10 @@ where
 /// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
 /// assert_eq!(alpha(b""), Ok((&b""[..], &b""[..])));
 /// ```
-pub fn take_while<F, Input, Error: ParseError<Input>>(cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn take_while<F, Input, Error: ParseError<Input>>(mut cond: F) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  F: FnMut(<Input as InputTakeAtPosition>::Item) -> bool,
 {
   move |i: Input| i.split_at_position_complete(|c| !cond(c))
 }
@@ -206,10 +206,10 @@ where
 /// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
 /// assert_eq!(alpha(b"12345"), Err(Err::Error((&b"12345"[..], ErrorKind::TakeWhile1))));
 /// ```
-pub fn take_while1<F, Input, Error: ParseError<Input>>(cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn take_while1<F, Input, Error: ParseError<Input>>(mut cond: F) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  F: FnMut(<Input as InputTakeAtPosition>::Item) -> bool,
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::TakeWhile1;
@@ -242,10 +242,10 @@ where
 /// assert_eq!(short_alpha(b"ed"), Err(Err::Error((&b"ed"[..], ErrorKind::TakeWhileMN))));
 /// assert_eq!(short_alpha(b"12345"), Err(Err::Error((&b"12345"[..], ErrorKind::TakeWhileMN))));
 /// ```
-pub fn take_while_m_n<F, Input, Error: ParseError<Input>>(m: usize, n: usize, cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn take_while_m_n<F, Input, Error: ParseError<Input>>(m: usize, n: usize, mut cond: F) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTake + InputIter + InputLength + Slice<RangeFrom<usize>>,
-  F: Fn(<Input as InputIter>::Item) -> bool,
+  F: FnMut(<Input as InputIter>::Item) -> bool,
 {
   move |i: Input| {
     let input = i;
@@ -312,10 +312,10 @@ where
 /// assert_eq!(till_colon("12345"), Ok(("", "12345")));
 /// assert_eq!(till_colon(""), Ok(("", "")));
 /// ```
-pub fn take_till<F, Input, Error: ParseError<Input>>(cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn take_till<F, Input, Error: ParseError<Input>>(mut cond: F) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  F: FnMut(<Input as InputTakeAtPosition>::Item) -> bool,
 {
   move |i: Input| i.split_at_position_complete(|c| cond(c))
 }
@@ -343,10 +343,10 @@ where
 /// assert_eq!(till_colon("12345"), Ok(("", "12345")));
 /// assert_eq!(till_colon(""), Err(Err::Error(("", ErrorKind::TakeTill1))));
 /// ```
-pub fn take_till1<F, Input, Error: ParseError<Input>>(cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn take_till1<F, Input, Error: ParseError<Input>>(mut cond: F) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  F: FnMut(<Input as InputTakeAtPosition>::Item) -> bool,
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::TakeTill1;
@@ -373,7 +373,7 @@ where
 /// assert_eq!(take6("short"), Err(Err::Error(("short", ErrorKind::Eof))));
 /// assert_eq!(take6(""), Err(Err::Error(("", ErrorKind::Eof))));
 /// ```
-pub fn take<C, Input, Error: ParseError<Input>>(count: C) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn take<C, Input, Error: ParseError<Input>>(count: C) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputIter + InputTake,
   C: ToUsize,
@@ -404,7 +404,7 @@ where
 /// assert_eq!(until_eof("hello, world"), Err(Err::Error(("hello, world", ErrorKind::TakeUntil))));
 /// assert_eq!(until_eof(""), Err(Err::Error(("", ErrorKind::TakeUntil))));
 /// ```
-pub fn take_until<T, Input, Error: ParseError<Input>>(tag: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn take_until<T, Input, Error: ParseError<Input>>(tag: T) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTake + FindSubstring<T>,
   T: InputLength + Clone,
@@ -441,12 +441,12 @@ where
 /// assert_eq!(esc(r#"12\"34;"#), Ok((";", r#"12\"34"#)));
 /// ```
 ///
-pub fn escaped<Input, Error, F, G, O1, O2>(normal: F, control_char: char, escapable: G) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn escaped<Input, Error, F, G, O1, O2>(mut normal: F, control_char: char, mut escapable: G) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: Clone + crate::traits::Offset + InputLength + InputTake + InputTakeAtPosition + Slice<RangeFrom<usize>> + InputIter,
   <Input as InputIter>::Item: crate::traits::AsChar,
-  F: Fn(Input) -> IResult<Input, O1, Error>,
-  G: Fn(Input) -> IResult<Input, O2, Error>,
+  F: FnMut(Input) -> IResult<Input, O1, Error>,
+  G: FnMut(Input) -> IResult<Input, O2, Error>,
   Error: ParseError<Input>,
 {
   use crate::traits::AsChar;
@@ -504,8 +504,8 @@ pub fn escapedc<Input, Error, F, G, O1, O2>(i: Input, normal: F, control_char: c
 where
   Input: Clone + crate::traits::Offset + InputLength + InputTake + InputTakeAtPosition + Slice<RangeFrom<usize>> + InputIter,
   <Input as InputIter>::Item: crate::traits::AsChar,
-  F: Fn(Input) -> IResult<Input, O1, Error>,
-  G: Fn(Input) -> IResult<Input, O2, Error>,
+  F: FnMut(Input) -> IResult<Input, O1, Error>,
+  G: FnMut(Input) -> IResult<Input, O2, Error>,
   Error: ParseError<Input>,
 {
   escaped(normal, control_char, escapable)(i)
@@ -542,10 +542,10 @@ where
 /// ```
 #[cfg(feature = "alloc")]
 pub fn escaped_transform<Input, Error, F, G, O1, O2, ExtendItem, Output>(
-  normal: F,
+  mut normal: F,
   control_char: char,
-  transform: G,
-) -> impl Fn(Input) -> IResult<Input, Output, Error>
+  mut transform: G,
+) -> impl FnMut(Input) -> IResult<Input, Output, Error>
 where
   Input: Clone + crate::traits::Offset + InputLength + InputTake + InputTakeAtPosition + Slice<RangeFrom<usize>> + InputIter,
   Input: crate::traits::ExtendInto<Item = ExtendItem, Extender = Output>,
@@ -555,8 +555,8 @@ where
   Output: core::iter::Extend<<O1 as crate::traits::ExtendInto>::Item>,
   Output: core::iter::Extend<<O2 as crate::traits::ExtendInto>::Item>,
   <Input as InputIter>::Item: crate::traits::AsChar,
-  F: Fn(Input) -> IResult<Input, O1, Error>,
-  G: Fn(Input) -> IResult<Input, O2, Error>,
+  F: FnMut(Input) -> IResult<Input, O1, Error>,
+  G: FnMut(Input) -> IResult<Input, O2, Error>,
   Error: ParseError<Input>,
 {
   use crate::traits::AsChar;
@@ -630,7 +630,7 @@ where
   Output: core::iter::Extend<<O1 as crate::traits::ExtendInto>::Item>,
   Output: core::iter::Extend<<O2 as crate::traits::ExtendInto>::Item>,
   <Input as InputIter>::Item: crate::traits::AsChar,
-  F: Fn(Input) -> IResult<Input, O1, Error>,
+  F: FnMut(Input) -> IResult<Input, O1, Error>,
   G: Fn(Input) -> IResult<Input, O2, Error>,
   Error: ParseError<Input>,
 {

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -25,7 +25,7 @@ use crate::traits::{Compare, CompareResult, FindSubstring, FindToken, InputIter,
 /// assert_eq!(parser("Something"), Err(Err::Error(("Something", ErrorKind::Tag))));
 /// assert_eq!(parser(""), Err(Err::Incomplete(Needed::Size(5))));
 /// ```
-pub fn tag<'a, T: 'a, Input: 'a, Error: ParseError<Input>>(tag: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn tag<'a, T: 'a, Input: 'a, Error: ParseError<Input>>(tag: T) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTake + Compare<T>,
   T: InputLength + Clone,
@@ -66,7 +66,7 @@ where
 /// assert_eq!(parser("Something"), Err(Err::Error(("Something", ErrorKind::Tag))));
 /// assert_eq!(parser(""), Err(Err::Incomplete(Needed::Size(5))));
 /// ```
-pub fn tag_no_case<T, Input, Error: ParseError<Input>>(tag: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn tag_no_case<T, Input, Error: ParseError<Input>>(tag: T) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTake + Compare<T>,
   T: InputLength + Clone,
@@ -109,7 +109,7 @@ where
 /// assert_eq!(not_space("Nospace"), Err(Err::Incomplete(Needed::Size(1))));
 /// assert_eq!(not_space(""), Err(Err::Incomplete(Needed::Size(1))));
 /// ```
-pub fn is_not<T, Input, Error: ParseError<Input>>(arr: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn is_not<T, Input, Error: ParseError<Input>>(arr: T) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
   T: InputLength + FindToken<<Input as InputTakeAtPosition>::Item>,
@@ -144,7 +144,7 @@ where
 /// assert_eq!(hex("D15EA5E"), Err(Err::Incomplete(Needed::Size(1))));
 /// assert_eq!(hex(""), Err(Err::Incomplete(Needed::Size(1))));
 /// ```
-pub fn is_a<T, Input, Error: ParseError<Input>>(arr: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn is_a<T, Input, Error: ParseError<Input>>(arr: T) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
   T: InputLength + FindToken<<Input as InputTakeAtPosition>::Item>,
@@ -178,10 +178,10 @@ where
 /// assert_eq!(alpha(b"latin"), Err(Err::Incomplete(Needed::Size(1))));
 /// assert_eq!(alpha(b""), Err(Err::Incomplete(Needed::Size(1))));
 /// ```
-pub fn take_while<F, Input, Error: ParseError<Input>>(cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn take_while<F, Input, Error: ParseError<Input>>(mut cond: F) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  F: FnMut(<Input as InputTakeAtPosition>::Item) -> bool,
 {
   move |i: Input| i.split_at_position(|c| !cond(c))
 }
@@ -211,10 +211,10 @@ where
 /// assert_eq!(alpha(b"latin"), Err(Err::Incomplete(Needed::Size(1))));
 /// assert_eq!(alpha(b"12345"), Err(Err::Error((&b"12345"[..], ErrorKind::TakeWhile1))));
 /// ```
-pub fn take_while1<F, Input, Error: ParseError<Input>>(cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn take_while1<F, Input, Error: ParseError<Input>>(mut cond: F) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  F: FnMut(<Input as InputTakeAtPosition>::Item) -> bool,
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::TakeWhile1;
@@ -248,10 +248,10 @@ where
 /// assert_eq!(short_alpha(b"ed"), Err(Err::Incomplete(Needed::Size(1))));
 /// assert_eq!(short_alpha(b"12345"), Err(Err::Error((&b"12345"[..], ErrorKind::TakeWhileMN))));
 /// ```
-pub fn take_while_m_n<F, Input, Error: ParseError<Input>>(m: usize, n: usize, cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn take_while_m_n<F, Input, Error: ParseError<Input>>(m: usize, n: usize, mut cond: F) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTake + InputIter + InputLength + Slice<RangeFrom<usize>>,
-  F: Fn(<Input as InputIter>::Item) -> bool,
+  F: FnMut(<Input as InputIter>::Item) -> bool,
 {
   move |i: Input| {
     let input = i;
@@ -317,10 +317,10 @@ where
 /// assert_eq!(till_colon("12345"), Err(Err::Incomplete(Needed::Size(1))));
 /// assert_eq!(till_colon(""), Err(Err::Incomplete(Needed::Size(1))));
 /// ```
-pub fn take_till<F, Input, Error: ParseError<Input>>(cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn take_till<F, Input, Error: ParseError<Input>>(mut cond: F) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  F: FnMut(<Input as InputTakeAtPosition>::Item) -> bool,
 {
   move |i: Input| i.split_at_position(|c| cond(c))
 }
@@ -348,10 +348,10 @@ where
 /// assert_eq!(till_colon("12345"), Err(Err::Incomplete(Needed::Size(1))));
 /// assert_eq!(till_colon(""), Err(Err::Incomplete(Needed::Size(1))));
 /// ```
-pub fn take_till1<F, Input, Error: ParseError<Input>>(cond: F) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn take_till1<F, Input, Error: ParseError<Input>>(mut cond: F) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTakeAtPosition,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  F: FnMut(<Input as InputTakeAtPosition>::Item) -> bool,
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::TakeTill1;
@@ -379,7 +379,7 @@ where
 /// assert_eq!(take6("short"), Err(Err::Incomplete(Needed::Size(6)))); //N doesn't change
 /// assert_eq!(take6(""), Err(Err::Incomplete(Needed::Size(6))));
 /// ```
-pub fn take<C, Input, Error: ParseError<Input>>(count: C) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn take<C, Input, Error: ParseError<Input>>(count: C) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputIter + InputTake,
   C: ToUsize,
@@ -412,7 +412,7 @@ where
 /// assert_eq!(until_eof("hello, world"), Err(Err::Incomplete(Needed::Size(3))));
 /// assert_eq!(until_eof(""), Err(Err::Incomplete(Needed::Size(3))));
 /// ```
-pub fn take_until<T, Input, Error: ParseError<Input>>(tag: T) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn take_until<T, Input, Error: ParseError<Input>>(tag: T) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: InputTake + FindSubstring<T>,
   T: InputLength + Clone,
@@ -451,12 +451,12 @@ where
 /// assert_eq!(esc("12\\\"34;"), Ok((";", "12\\\"34")));
 /// ```
 ///
-pub fn escaped<Input, Error, F, G, O1, O2>(normal: F, control_char: char, escapable: G) -> impl Fn(Input) -> IResult<Input, Input, Error>
+pub fn escaped<Input, Error, F, G, O1, O2>(mut normal: F, control_char: char, mut escapable: G) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
   Input: Clone + crate::traits::Offset + InputLength + InputTake + InputTakeAtPosition + Slice<RangeFrom<usize>> + InputIter,
   <Input as InputIter>::Item: crate::traits::AsChar,
-  F: Fn(Input) -> IResult<Input, O1, Error>,
-  G: Fn(Input) -> IResult<Input, O2, Error>,
+  F: FnMut(Input) -> IResult<Input, O1, Error>,
+  G: FnMut(Input) -> IResult<Input, O2, Error>,
   Error: ParseError<Input>,
 {
   use crate::traits::AsChar;
@@ -511,8 +511,8 @@ pub fn escapedc<Input, Error, F, G, O1, O2>(i: Input, normal: F, control_char: c
 where
   Input: Clone + crate::traits::Offset + InputLength + InputTake + InputTakeAtPosition + Slice<RangeFrom<usize>> + InputIter,
   <Input as InputIter>::Item: crate::traits::AsChar,
-  F: Fn(Input) -> IResult<Input, O1, Error>,
-  G: Fn(Input) -> IResult<Input, O2, Error>,
+  F: FnMut(Input) -> IResult<Input, O1, Error>,
+  G: FnMut(Input) -> IResult<Input, O2, Error>,
   Error: ParseError<Input>,
 {
   escaped(normal, control_char, escapable)(i)
@@ -549,10 +549,10 @@ where
 /// ```
 #[cfg(feature = "alloc")]
 pub fn escaped_transform<Input, Error, F, G, O1, O2, ExtendItem, Output>(
-  normal: F,
+  mut normal: F,
   control_char: char,
-  transform: G,
-) -> impl Fn(Input) -> IResult<Input, Output, Error>
+  mut transform: G,
+) -> impl FnMut(Input) -> IResult<Input, Output, Error>
 where
   Input: Clone + crate::traits::Offset + InputLength + InputTake + InputTakeAtPosition + Slice<RangeFrom<usize>> + InputIter,
   Input: crate::traits::ExtendInto<Item = ExtendItem, Extender = Output>,
@@ -562,8 +562,8 @@ where
   Output: core::iter::Extend<<O1 as crate::traits::ExtendInto>::Item>,
   Output: core::iter::Extend<<O2 as crate::traits::ExtendInto>::Item>,
   <Input as InputIter>::Item: crate::traits::AsChar,
-  F: Fn(Input) -> IResult<Input, O1, Error>,
-  G: Fn(Input) -> IResult<Input, O2, Error>,
+  F: FnMut(Input) -> IResult<Input, O1, Error>,
+  G: FnMut(Input) -> IResult<Input, O2, Error>,
   Error: ParseError<Input>,
 {
   use crate::traits::AsChar;
@@ -634,8 +634,8 @@ where
   Output: core::iter::Extend<<O1 as crate::traits::ExtendInto>::Item>,
   Output: core::iter::Extend<<O2 as crate::traits::ExtendInto>::Item>,
   <Input as InputIter>::Item: crate::traits::AsChar,
-  F: Fn(Input) -> IResult<Input, O1, Error>,
-  G: Fn(Input) -> IResult<Input, O2, Error>,
+  F: FnMut(Input) -> IResult<Input, O1, Error>,
+  G: FnMut(Input) -> IResult<Input, O2, Error>,
   Error: ParseError<Input>,
 {
   escaped_transform(normal, control_char, transform)(i)

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -24,7 +24,7 @@ use crate::error::ErrorKind;
 /// assert_eq!(char::<_, (&str, ErrorKind)>('a')(""), Err(Err::Error(("", ErrorKind::Char))));
 /// # }
 /// ```
-pub fn char<I, Error: ParseError<I>>(c: char) -> impl Fn(I) -> IResult<I, char, Error>
+pub fn char<I, Error: ParseError<I>>(c: char) -> impl FnMut(I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,
   <I as InputIter>::Item: AsChar,
@@ -53,7 +53,7 @@ where
 /// assert_eq!(one_of::<_, _, (&str, ErrorKind)>("a")(""), Err(Err::Error(("", ErrorKind::OneOf))));
 /// # }
 /// ```
-pub fn one_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, char, Error>
+pub fn one_of<I, T, Error: ParseError<I>>(list: T) -> impl FnMut(I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,
   <I as InputIter>::Item: AsChar + Copy,
@@ -80,7 +80,7 @@ where
 /// assert_eq!(none_of::<_, _, (&str, ErrorKind)>("a")(""), Err(Err::Error(("", ErrorKind::NoneOf))));
 /// # }
 /// ```
-pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, char, Error>
+pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl FnMut(I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,
   <I as InputIter>::Item: AsChar + Copy,

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -25,7 +25,7 @@ use crate::error::ErrorKind;
 /// assert_eq!(char::<_, (_, ErrorKind)>('a')(&b""[..]), Err(Err::Incomplete(Needed::Size(1))));
 /// # }
 /// ```
-pub fn char<I, Error: ParseError<I>>(c: char) -> impl Fn(I) -> IResult<I, char, Error>
+pub fn char<I, Error: ParseError<I>>(c: char) -> impl FnMut(I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,
   <I as InputIter>::Item: AsChar,
@@ -57,7 +57,7 @@ where
 /// assert_eq!(one_of::<_, _, (_, ErrorKind)>("a")(""), Err(Err::Incomplete(Needed::Size(1))));
 /// # }
 /// ```
-pub fn one_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, char, Error>
+pub fn one_of<I, T, Error: ParseError<I>>(list: T) -> impl FnMut(I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,
   <I as InputIter>::Item: AsChar + Copy,
@@ -85,7 +85,7 @@ where
 /// assert_eq!(none_of::<_, _, (_, ErrorKind)>("a")(""), Err(Err::Incomplete(Needed::Size(1))));
 /// # }
 /// ```
-pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, char, Error>
+pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl FnMut(I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,
   <I as InputIter>::Item: AsChar + Copy,

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -63,7 +63,7 @@ where
 /// use nom::combinator::map;
 /// # fn main() {
 ///
-/// let parse = map(digit1, |s: &str| s.len());
+/// let mut parse = map(digit1, |s: &str| s.len());
 ///
 /// // the parser will count how many characters were returned by digit1
 /// assert_eq!(parse("123456"), Ok(("", 6)));
@@ -72,10 +72,10 @@ where
 /// assert_eq!(parse("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
 /// # }
 /// ```
-pub fn map<I, O1, O2, E: ParseError<I>, F, G>(first: F, second: G) -> impl Fn(I) -> IResult<I, O2, E>
+pub fn map<I, O1, O2, E: ParseError<I>, F, G>(mut first: F, mut second: G) -> impl FnMut(I) -> IResult<I, O2, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(O1) -> O2,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(O1) -> O2,
 {
   move |input: I| {
     let (input, o1) = first(input)?;
@@ -86,8 +86,8 @@ where
 #[doc(hidden)]
 pub fn mapc<I, O1, O2, E: ParseError<I>, F, G>(input: I, first: F, second: G) -> IResult<I, O2, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(O1) -> O2,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(O1) -> O2,
 {
   map(first, second)(input)
 }
@@ -101,7 +101,7 @@ where
 /// use nom::combinator::map_res;
 /// # fn main() {
 ///
-/// let parse = map_res(digit1, |s: &str| s.parse::<u8>());
+/// let mut parse = map_res(digit1, |s: &str| s.parse::<u8>());
 ///
 /// // the parser will convert the result of digit1 to a number
 /// assert_eq!(parse("123"), Ok(("", 123)));
@@ -113,10 +113,10 @@ where
 /// assert_eq!(parse("123456"), Err(Err::Error(("123456", ErrorKind::MapRes))));
 /// # }
 /// ```
-pub fn map_res<I: Clone, O1, O2, E: ParseError<I>, E2, F, G>(first: F, second: G) -> impl Fn(I) -> IResult<I, O2, E>
+pub fn map_res<I: Clone, O1, O2, E: ParseError<I>, E2, F, G>(mut first: F, mut second: G) -> impl FnMut(I) -> IResult<I, O2, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(O1) -> Result<O2, E2>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(O1) -> Result<O2, E2>,
 {
   move |input: I| {
     let i = input.clone();
@@ -131,8 +131,8 @@ where
 #[doc(hidden)]
 pub fn map_resc<I: Clone, O1, O2, E: ParseError<I>, E2, F, G>(input: I, first: F, second: G) -> IResult<I, O2, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(O1) -> Result<O2, E2>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(O1) -> Result<O2, E2>,
 {
   map_res(first, second)(input)
 }
@@ -146,7 +146,7 @@ where
 /// use nom::combinator::map_opt;
 /// # fn main() {
 ///
-/// let parse = map_opt(digit1, |s: &str| s.parse::<u8>().ok());
+/// let mut parse = map_opt(digit1, |s: &str| s.parse::<u8>().ok());
 ///
 /// // the parser will convert the result of digit1 to a number
 /// assert_eq!(parse("123"), Ok(("", 123)));
@@ -158,10 +158,10 @@ where
 /// assert_eq!(parse("123456"), Err(Err::Error(("123456", ErrorKind::MapOpt))));
 /// # }
 /// ```
-pub fn map_opt<I: Clone, O1, O2, E: ParseError<I>, F, G>(first: F, second: G) -> impl Fn(I) -> IResult<I, O2, E>
+pub fn map_opt<I: Clone, O1, O2, E: ParseError<I>, F, G>(mut first: F, mut second: G) -> impl FnMut(I) -> IResult<I, O2, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(O1) -> Option<O2>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(O1) -> Option<O2>,
 {
   move |input: I| {
     let i = input.clone();
@@ -176,8 +176,8 @@ where
 #[doc(hidden)]
 pub fn map_optc<I: Clone, O1, O2, E: ParseError<I>, F, G>(input: I, first: F, second: G) -> IResult<I, O2, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(O1) -> Option<O2>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(O1) -> Option<O2>,
 {
   map_opt(first, second)(input)
 }
@@ -192,17 +192,17 @@ where
 /// use nom::combinator::map_parser;
 /// # fn main() {
 ///
-/// let parse = map_parser(take(5u8), digit1);
+/// let mut parse = map_parser(take(5u8), digit1);
 ///
 /// assert_eq!(parse("12345"), Ok(("", "12345")));
 /// assert_eq!(parse("123ab"), Ok(("", "123")));
 /// assert_eq!(parse("123"), Err(Err::Error(("123", ErrorKind::Eof))));
 /// # }
 /// ```
-pub fn map_parser<I: Clone, O1, O2, E: ParseError<I>, F, G>(first: F, second: G) -> impl Fn(I) -> IResult<I, O2, E>
+pub fn map_parser<I: Clone, O1, O2, E: ParseError<I>, F, G>(mut first: F, mut second: G) -> impl FnMut(I) -> IResult<I, O2, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(O1) -> IResult<O1, O2, E>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(O1) -> IResult<O1, O2, E>,
   O1: InputLength,
 {
   move |input: I| {
@@ -215,8 +215,8 @@ where
 #[doc(hidden)]
 pub fn map_parserc<I: Clone, O1, O2, E: ParseError<I>, F, G>(input: I, first: F, second: G) -> IResult<I, O2, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(O1) -> IResult<O1, O2, E>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(O1) -> IResult<O1, O2, E>,
   O1: InputLength,
 {
   map_parser(first, second)(input)
@@ -232,17 +232,17 @@ where
 /// use nom::combinator::flat_map;
 /// # fn main() {
 ///
-/// let parse = flat_map(be_u8, take);
+/// let mut parse = flat_map(be_u8, take);
 ///
 /// assert_eq!(parse(&[2, 0, 1, 2][..]), Ok((&[2][..], &[0, 1][..])));
 /// assert_eq!(parse(&[4, 0, 1, 2][..]), Err(Err::Error((&[0, 1, 2][..], ErrorKind::Eof))));
 /// # }
 /// ```
-pub fn flat_map<I, O1, O2, E: ParseError<I>, F, G, H>(first: F, second: G) -> impl Fn(I) -> IResult<I, O2, E>
+pub fn flat_map<I, O1, O2, E: ParseError<I>, F, G, H>(mut first: F, mut second: G) -> impl FnMut(I) -> IResult<I, O2, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(O1) -> H,
-  H: Fn(I) -> IResult<I, O2, E>
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(O1) -> H,
+  H: FnMut(I) -> IResult<I, O2, E>
 {
   move |input: I| {
     let (input, o1) = first(input)?;
@@ -267,9 +267,9 @@ where
 /// assert_eq!(parser("123;"), Ok(("123;", None)));
 /// # }
 /// ```
-pub fn opt<I:Clone, O, E: ParseError<I>, F>(f: F) -> impl Fn(I) -> IResult<I, Option<O>, E>
+pub fn opt<I:Clone, O, E: ParseError<I>, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Option<O>, E>
 where
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
 {
   move |input: I| {
     let i = input.clone();
@@ -284,7 +284,7 @@ where
 #[doc(hidden)]
 pub fn optc<I:Clone, O, E: ParseError<I>, F>(input: I, f: F) -> IResult<I, Option<O>, E>
 where
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
 {
   opt(f)(input)
 }
@@ -308,9 +308,9 @@ where
 /// assert_eq!(parser(false, "123;"), Ok(("123;", None)));
 /// # }
 /// ```
-pub fn cond<I:Clone, O, E: ParseError<I>, F>(b: bool, f: F) -> impl Fn(I) -> IResult<I, Option<O>, E>
+pub fn cond<I:Clone, O, E: ParseError<I>, F>(b: bool, mut f: F) -> impl FnMut(I) -> IResult<I, Option<O>, E>
 where
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
 {
   move |input: I| {
     if b {
@@ -327,7 +327,7 @@ where
 #[doc(hidden)]
 pub fn condc<I:Clone, O, E: ParseError<I>, F>(input: I, b: bool, f: F) -> IResult<I, Option<O>, E>
 where
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
 {
   cond(b, f)(input)
 }
@@ -341,15 +341,15 @@ where
 /// use nom::character::complete::alpha1;
 /// # fn main() {
 ///
-/// let parser = peek(alpha1);
+/// let mut parser = peek(alpha1);
 ///
 /// assert_eq!(parser("abcd;"), Ok(("abcd;", "abcd")));
 /// assert_eq!(parser("123;"), Err(Err::Error(("123;", ErrorKind::Alpha))));
 /// # }
 /// ```
-pub fn peek<I:Clone, O, E: ParseError<I>, F>(f: F) -> impl Fn(I) -> IResult<I, O, E>
+pub fn peek<I:Clone, O, E: ParseError<I>, F>(mut f: F) -> impl FnMut(I) -> IResult<I, O, E>
 where
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
 {
   move |input: I| {
     let i = input.clone();
@@ -363,7 +363,7 @@ where
 #[doc(hidden)]
 pub fn peekc<I:Clone, O, E: ParseError<I>, F>(input: I, f: F) -> IResult<I, O, E>
 where
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
 {
   peek(f)(input)
 }
@@ -377,15 +377,15 @@ where
 /// use nom::combinator::complete;
 /// # fn main() {
 ///
-/// let parser = complete(take(5u8));
+/// let mut parser = complete(take(5u8));
 ///
 /// assert_eq!(parser("abcdefg"), Ok(("fg", "abcde")));
 /// assert_eq!(parser("abcd"), Err(Err::Error(("abcd", ErrorKind::Complete))));
 /// # }
 /// ```
-pub fn complete<I: Clone, O, E: ParseError<I>, F>(f: F) -> impl Fn(I) -> IResult<I, O, E>
+pub fn complete<I: Clone, O, E: ParseError<I>, F>(mut f: F) -> impl FnMut(I) -> IResult<I, O, E>
 where
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
 {
   move |input: I| {
     let i = input.clone();
@@ -401,7 +401,7 @@ where
 #[doc(hidden)]
 pub fn completec<I: Clone, O, E: ParseError<I>, F>(input: I, f: F) -> IResult<I, O, E>
 where
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
 {
     complete(f)(input)
 }
@@ -415,17 +415,17 @@ where
 /// use nom::character::complete::alpha1;
 /// # fn main() {
 ///
-/// let parser = all_consuming(alpha1);
+/// let mut parser = all_consuming(alpha1);
 ///
 /// assert_eq!(parser("abcd"), Ok(("", "abcd")));
 /// assert_eq!(parser("abcd;"),Err(Err::Error((";", ErrorKind::Eof))));
 /// assert_eq!(parser("123abcd;"),Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
 /// # }
 /// ```
-pub fn all_consuming<I, O, E: ParseError<I>, F>(f: F) -> impl Fn(I) -> IResult<I, O, E>
+pub fn all_consuming<I, O, E: ParseError<I>, F>(mut f: F) -> impl FnMut(I) -> IResult<I, O, E>
 where
   I: InputLength,
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
 {
   move |input: I| {
     let (input, res) = f(input)?;
@@ -449,17 +449,17 @@ where
 /// use nom::character::complete::alpha1;
 /// # fn main() {
 ///
-/// let parser = verify(alpha1, |s: &str| s.len() == 4);
+/// let mut parser = verify(alpha1, |s: &str| s.len() == 4);
 ///
 /// assert_eq!(parser("abcd"), Ok(("", "abcd")));
 /// assert_eq!(parser("abcde"), Err(Err::Error(("abcde", ErrorKind::Verify))));
 /// assert_eq!(parser("123abcd;"),Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
 /// # }
 /// ```
-pub fn verify<I: Clone, O1, O2, E: ParseError<I>, F, G>(first: F, second: G) -> impl Fn(I) -> IResult<I, O1, E>
+pub fn verify<I: Clone, O1, O2, E: ParseError<I>, F, G>(mut first: F, mut second: G) -> impl FnMut(I) -> IResult<I, O1, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(&O2) -> bool,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(&O2) -> bool,
   O1: Borrow<O2>,
   O2: ?Sized,
 {
@@ -478,8 +478,8 @@ where
 #[doc(hidden)]
 pub fn verifyc<I: Clone, O1, O2, E: ParseError<I>, F, G>(input: I, first: F, second: G) -> IResult<I, O1, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(&O2) -> bool,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(&O2) -> bool,
   O1: Borrow<O2>,
   O2: ?Sized,
 {
@@ -495,15 +495,15 @@ where
 /// use nom::character::complete::alpha1;
 /// # fn main() {
 ///
-/// let parser = value(1234, alpha1);
+/// let mut parser = value(1234, alpha1);
 ///
 /// assert_eq!(parser("abcd"), Ok(("", 1234)));
 /// assert_eq!(parser("123abcd;"), Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
 /// # }
 /// ```
-pub fn value<I, O1: Clone, O2, E: ParseError<I>, F>(val: O1, parser: F) -> impl Fn(I) -> IResult<I, O1, E>
+pub fn value<I, O1: Clone, O2, E: ParseError<I>, F>(val: O1, mut parser: F) -> impl FnMut(I) -> IResult<I, O1, E>
 where
-  F: Fn(I) -> IResult<I, O2, E>,
+  F: FnMut(I) -> IResult<I, O2, E>,
 {
   move |input: I| {
     parser(input).map(|(i, _)| (i, val.clone()))
@@ -513,7 +513,7 @@ where
 #[doc(hidden)]
 pub fn valuec<I, O1: Clone, O2, E: ParseError<I>, F>(input: I, val: O1, parser: F) -> IResult<I, O1, E>
 where
-  F: Fn(I) -> IResult<I, O2, E>,
+  F: FnMut(I) -> IResult<I, O2, E>,
 {
   value(val, parser)(input)
 }
@@ -527,15 +527,15 @@ where
 /// use nom::character::complete::alpha1;
 /// # fn main() {
 ///
-/// let parser = not(alpha1);
+/// let mut parser = not(alpha1);
 ///
 /// assert_eq!(parser("123"), Ok(("123", ())));
 /// assert_eq!(parser("abcd"), Err(Err::Error(("abcd", ErrorKind::Not))));
 /// # }
 /// ```
-pub fn not<I: Clone, O, E: ParseError<I>, F>(parser: F) -> impl Fn(I) -> IResult<I, (), E>
+pub fn not<I: Clone, O, E: ParseError<I>, F>(mut parser: F) -> impl FnMut(I) -> IResult<I, (), E>
 where
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
 {
   move |input: I| {
     let i = input.clone();
@@ -550,7 +550,7 @@ where
 #[doc(hidden)]
 pub fn notc<I: Clone, O, E: ParseError<I>, F>(input: I, parser: F) -> IResult<I, (), E>
 where
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
 {
   not(parser)(input)
 }
@@ -565,15 +565,15 @@ where
 /// use nom::sequence::separated_pair;
 /// # fn main() {
 ///
-/// let parser = recognize(separated_pair(alpha1, char(','), alpha1));
+/// let mut parser = recognize(separated_pair(alpha1, char(','), alpha1));
 ///
 /// assert_eq!(parser("abcd,efgh"), Ok(("", "abcd,efgh")));
 /// assert_eq!(parser("abcd;"),Err(Err::Error((";", ErrorKind::Char))));
 /// # }
 /// ```
-pub fn recognize<I: Clone + Offset + Slice<RangeTo<usize>>, O, E: ParseError<I>, F>(parser: F) -> impl Fn(I) -> IResult<I, I, E>
+pub fn recognize<I: Clone + Offset + Slice<RangeTo<usize>>, O, E: ParseError<I>, F>(mut parser: F) -> impl FnMut(I) -> IResult<I, I, E>
 where
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
 {
   move |input: I| {
     let i = input.clone();
@@ -590,7 +590,7 @@ where
 #[doc(hidden)]
 pub fn recognizec<I: Clone + Offset + Slice<RangeTo<usize>>, O, E: ParseError<I>, F>(input: I, parser: F) -> IResult<I, I, E>
 where
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
 {
   recognize(parser)(input)
 }
@@ -604,15 +604,15 @@ where
 /// use nom::character::complete::alpha1;
 /// # fn main() {
 ///
-/// let parser = cut(alpha1);
+/// let mut parser = cut(alpha1);
 ///
 /// assert_eq!(parser("abcd;"), Ok((";", "abcd")));
 /// assert_eq!(parser("123;"), Err(Err::Failure(("123;", ErrorKind::Alpha))));
 /// # }
 /// ```
-pub fn cut<I: Clone + Offset + Slice<RangeTo<usize>>, O, E: ParseError<I>, F>(parser: F) -> impl Fn(I) -> IResult<I, O, E>
+pub fn cut<I: Clone + Offset + Slice<RangeTo<usize>>, O, E: ParseError<I>, F>(mut parser: F) -> impl FnMut(I) -> IResult<I, O, E>
 where
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
 {
   move |input: I| {
     let i = input.clone();
@@ -626,7 +626,7 @@ where
 #[doc(hidden)]
 pub fn cutc<I: Clone + Offset + Slice<RangeTo<usize>>, O, E: ParseError<I>, F>(input: I, parser: F) -> IResult<I, O, E>
 where
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
 {
   cut(parser)(input)
 }
@@ -651,7 +651,7 @@ where
 /// ```
 pub fn iterator<Input, Output, Error, F>(input: Input, f: F) -> ParserIterator<Input, Error, F>
 where
-  F: Fn(Input) -> IResult<Input, Output, Error>,
+  F: FnMut(Input) -> IResult<Input, Output, Error>,
   Error: ParseError<Input> {
 
     ParserIterator {
@@ -681,7 +681,7 @@ impl<I: Clone, E: Clone, F> ParserIterator<I, E, F> {
 
 impl<'a, Input ,Output ,Error, F> core::iter::Iterator for &'a mut ParserIterator<Input, Error, F>
     where
-    F: Fn(Input) -> IResult<Input, Output, Error>,
+    F: FnMut(Input) -> IResult<Input, Output, Error>,
     Input: Clone
 {
   type Item = Output;
@@ -837,7 +837,7 @@ mod tests {
   fn test_verify_ref() {
     use crate::bytes::complete::take;
 
-    let parser1 = verify(take(3u8), |s: &[u8]| s == &b"abc"[..]);
+    let mut parser1 = verify(take(3u8), |s: &[u8]| s == &b"abc"[..]);
 
     assert_eq!(parser1(&b"abcd"[..]), Ok((&b"d"[..], &b"abc"[..])));
     assert_eq!(parser1(&b"defg"[..]), Err(Err::Error((&b"defg"[..], ErrorKind::Verify))));
@@ -851,7 +851,7 @@ mod tests {
   #[cfg(feature = "alloc")]
   fn test_verify_alloc() {
     use crate::bytes::complete::take;
-    let parser1 = verify(map(take(3u8), |s: &[u8]| s.to_vec()), |s: &[u8]| s == &b"abc"[..]);
+    let mut parser1 = verify(map(take(3u8), |s: &[u8]| s.to_vec()), |s: &[u8]| s == &b"abc"[..]);
 
     assert_eq!(parser1(&b"abcd"[..]), Ok((&b"d"[..], (&b"abc").to_vec())));
     assert_eq!(parser1(&b"defg"[..]), Err(Err::Error((&b"defg"[..], ErrorKind::Verify))));

--- a/src/error.rs
+++ b/src/error.rs
@@ -122,9 +122,9 @@ use crate::internal::{Err, IResult};
 /// This is used mainly in the [context] combinator, to add user friendly information
 /// to errors when backtracking through a parse tree
 #[cfg(feature = "alloc")]
-pub fn context<I: Clone, E: ParseError<I>, F, O>(context: &'static str, f: F) -> impl Fn(I) -> IResult<I, O, E>
+pub fn context<I: Clone, E: ParseError<I>, F, O>(context: &'static str, mut f: F) -> impl FnMut(I) -> IResult<I, O, E>
 where
-  F: Fn(I) -> IResult<I, O, E> {
+  F: FnMut(I) -> IResult<I, O, E> {
 
     move |i: I| {
       match f(i.clone()) {
@@ -241,7 +241,7 @@ pub enum ErrorKind {
   AlphaNumeric,
   Space,
   MultiSpace,
-  LengthValueFn,
+  LengthValueFnMut,
   Eof,
   Switch,
   TagBits,
@@ -296,7 +296,7 @@ pub fn error_to_u32(e: &ErrorKind) -> u32 {
     ErrorKind::AlphaNumeric              => 19,
     ErrorKind::Space                     => 20,
     ErrorKind::MultiSpace                => 21,
-    ErrorKind::LengthValueFn             => 22,
+    ErrorKind::LengthValueFnMut             => 22,
     ErrorKind::Eof                       => 23,
     ErrorKind::Switch                    => 27,
     ErrorKind::TagBits                   => 28,
@@ -358,7 +358,7 @@ impl ErrorKind {
       ErrorKind::AlphaNumeric              => "AlphaNumeric",
       ErrorKind::Space                     => "Space",
       ErrorKind::MultiSpace                => "Multiple spaces",
-      ErrorKind::LengthValueFn             => "LengthValueFn",
+      ErrorKind::LengthValueFnMut             => "LengthValueFnMut",
       ErrorKind::Eof                       => "End of file",
       ErrorKind::Switch                    => "Switch",
       ErrorKind::TagBits                   => "Tag on bitstream",

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -29,7 +29,7 @@ impl Needed {
 
   /// Maps a `Needed` to `Needed` by applying a function to a contained `Size` value.
   #[inline]
-  pub fn map<F: Fn(usize) -> usize>(self, f: F) -> Needed {
+  pub fn map<F: FnMut(usize) -> usize>(self, mut f: F) -> Needed {
     match self {
       Unknown => Unknown,
       Size(n) => Size(f(n)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@
 //! ## Making new parsers with function combinators
 //!
 //! nom is based on functions that generate parsers, with a signature like
-//! this: `(arguments) -> impl Fn(Input) -> IResult<Input, Output, Error>`.
+//! this: `(arguments) -> impl FnMut(Input) -> IResult<Input, Output, Error>`.
 //! The arguments of a combinator can be direct values (like `take` which uses
 //! a number of bytes or character as argument) or even other parsers (like
 //! `delimited` which takes as argument 3 parsers, and returns the result of
@@ -230,7 +230,7 @@
 //! use nom::branch::alt;
 //! use nom::bytes::complete::tag;
 //!
-//! let alt_tags = alt((tag("abcd"), tag("efgh")));
+//! let mut alt_tags = alt((tag("abcd"), tag("efgh")));
 //!
 //! assert_eq!(alt_tags(&b"abcdxxx"[..]), Ok((&b"xxx"[..], &b"abcd"[..])));
 //! assert_eq!(alt_tags(&b"efghxxx"[..]), Ok((&b"xxx"[..], &b"efgh"[..])));
@@ -293,7 +293,7 @@
 //! bytes::streaming::{tag, take},
 //! sequence::tuple};
 //!
-//! let tpl = tuple((be_u16, take(3u8), tag("fg")));
+//! let mut tpl = tuple((be_u16, take(3u8), tag("fg")));
 //!
 //! assert_eq!(
 //!   tpl(&b"abcdefgh"[..]),

--- a/src/multi/macros.rs
+++ b/src/multi/macros.rs
@@ -421,7 +421,7 @@ macro_rules! length_value(
   );
 );
 
-/// `fold_many0!(I -> IResult<I,O>, R, Fn(R, O) -> R) => I -> IResult<I, R>`
+/// `fold_many0!(I -> IResult<I,O>, R, FnMut(R, O) -> R) => I -> IResult<I, R>`
 /// Applies the parser 0 or more times and folds the list of return values
 ///
 /// the embedded parser may return Incomplete
@@ -454,7 +454,7 @@ macro_rules! fold_many0(
   );
 );
 
-/// `fold_many1!(I -> IResult<I,O>, R, Fn(R, O) -> R) => I -> IResult<I, R>`
+/// `fold_many1!(I -> IResult<I,O>, R, FnMut(R, O) -> R) => I -> IResult<I, R>`
 /// Applies the parser 1 or more times and folds the list of return values
 ///
 /// the embedded parser may return Incomplete
@@ -491,7 +491,7 @@ macro_rules! fold_many1(
   );
 );
 
-/// `fold_many_m_n!(usize, usize, I -> IResult<I,O>, R, Fn(R, O) -> R) => I -> IResult<I, R>`
+/// `fold_many_m_n!(usize, usize, I -> IResult<I,O>, R, FnMut(R, O) -> R) => I -> IResult<I, R>`
 /// Applies the parser between m and n times (n included) and folds the list of return value
 ///
 /// the embedded parser may return Incomplete

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -29,10 +29,10 @@ use crate::error::ErrorKind;
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// ```
 #[cfg(feature = "alloc")]
-pub fn many0<I, O, E, F>(f: F) -> impl Fn(I) -> IResult<I, Vec<O>, E>
+pub fn many0<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
   E: ParseError<I>,
 {
   move |i: I| {
@@ -60,7 +60,7 @@ where
 pub fn many0c<I, O, E, F>(input: I, f: F) -> IResult<I, Vec<O>, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
   E: ParseError<I>,
 {
   many0(f)(input)
@@ -87,10 +87,10 @@ where
 /// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
 /// ```
 #[cfg(feature = "alloc")]
-pub fn many1<I, O, E, F>(f: F) -> impl Fn(I) -> IResult<I, Vec<O>, E>
+pub fn many1<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
   E: ParseError<I>,
 {
   move |i: I| {
@@ -128,7 +128,7 @@ where
 pub fn many1c<I, O, E, F>(input: I, f: F) -> IResult<I, Vec<O>, E>
 where
   I: Clone + Copy + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
   E: ParseError<I>,
 {
   many1(f)(input)
@@ -153,11 +153,11 @@ where
 /// assert_eq!(parser("abcendefg"), Ok(("efg", (vec!["abc"], "end"))));
 /// ```
 #[cfg(feature = "alloc")]
-pub fn many_till<I, O, P, E, F, G>(f: F, g: G) -> impl Fn(I) -> IResult<I, (Vec<O>, P), E>
+pub fn many_till<I, O, P, E, F, G>(mut f: F, mut g: G) -> impl FnMut(I) -> IResult<I, (Vec<O>, P), E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
-  G: Fn(I) -> IResult<I, P, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
+  G: FnMut(I) -> IResult<I, P, E>,
   E: ParseError<I>,
 {
   move |i: I| {
@@ -194,8 +194,8 @@ where
 pub fn many_tillc<I, O, P, E, F, G>(i: I, f: F, g: G) -> IResult<I, (Vec<O>, P), E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
-  G: Fn(I) -> IResult<I, P, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
+  G: FnMut(I) -> IResult<I, P, E>,
   E: ParseError<I>,
 {
   many_till(f, g)(i)
@@ -223,11 +223,11 @@ where
 /// assert_eq!(parser("def|abc"), Ok(("def|abc", vec![])));
 /// ```
 #[cfg(feature = "alloc")]
-pub fn separated_list<I, O, O2, E, F, G>(sep: G, f: F) -> impl Fn(I) -> IResult<I, Vec<O>, E>
+pub fn separated_list<I, O, O2, E, F, G>(mut sep: G, mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
-  G: Fn(I) -> IResult<I, O2, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
+  G: FnMut(I) -> IResult<I, O2, E>,
   E: ParseError<I>,
 {
   move |i: I| {
@@ -280,8 +280,8 @@ where
 pub fn separated_listc<I, O, O2, E, F, G>(i: I, sep: G, f: F) -> IResult<I, Vec<O>, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
-  G: Fn(I) -> IResult<I, O2, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
+  G: FnMut(I) -> IResult<I, O2, E>,
   E: ParseError<I>,
 {
   separated_list(sep, f)(i)
@@ -310,11 +310,11 @@ where
 /// assert_eq!(parser("def|abc"), Err(Err::Error(("def|abc", ErrorKind::Tag))));
 /// ```
 #[cfg(feature = "alloc")]
-pub fn separated_nonempty_list<I, O, O2, E, F, G>(sep: G, f: F) -> impl Fn(I) -> IResult<I, Vec<O>, E>
+pub fn separated_nonempty_list<I, O, O2, E, F, G>(mut sep: G, mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
-  G: Fn(I) -> IResult<I, O2, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
+  G: FnMut(I) -> IResult<I, O2, E>,
   E: ParseError<I>,
 {
   move |i: I| {
@@ -367,8 +367,8 @@ where
 pub fn separated_nonempty_listc<I, O, O2, E, F, G>(i: I, sep: G, f: F) -> IResult<I, Vec<O>, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
-  G: Fn(I) -> IResult<I, O2, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
+  G: FnMut(I) -> IResult<I, O2, E>,
   E: ParseError<I>,
 {
   separated_nonempty_list(sep, f)(i)
@@ -398,10 +398,10 @@ where
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
 #[cfg(feature = "alloc")]
-pub fn many_m_n<I, O, E, F>(m: usize, n: usize, f: F) -> impl Fn(I) -> IResult<I, Vec<O>, E>
+pub fn many_m_n<I, O, E, F>(m: usize, n: usize, mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
   E: ParseError<I>,
 {
   move |i: I| {
@@ -447,7 +447,7 @@ where
 pub fn many_m_nc<I, O, E, F>(i: I, m: usize, n: usize, f: F) -> IResult<I, Vec<O>, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
   E: ParseError<I>,
 {
   many_m_n(m, n, f)(i)
@@ -472,10 +472,10 @@ where
 /// assert_eq!(parser("123123"), Ok(("123123", 0)));
 /// assert_eq!(parser(""), Ok(("", 0)));
 /// ```
-pub fn many0_count<I, O, E, F>(f: F) -> impl Fn(I) -> IResult<I, usize, E>
+pub fn many0_count<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, usize, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
   E: ParseError<I>,
 {
   move |i: I| {
@@ -507,7 +507,7 @@ where
 pub fn many0_countc<I, O, E, F>(i: I, f: F) -> IResult<I, usize, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
   E: ParseError<I>,
 {
   many0_count(f)(i)
@@ -534,10 +534,10 @@ where
 /// assert_eq!(parser("123123"), Err(Err::Error(("123123", ErrorKind::Many1Count))));
 /// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Many1Count))));
 /// ```
-pub fn many1_count<I, O, E, F>(f: F) -> impl Fn(I) -> IResult<I, usize, E>
+pub fn many1_count<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, usize, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
   E: ParseError<I>,
 {
   move |i: I| {
@@ -573,7 +573,7 @@ where
 pub fn many1_countc<I, O, E, F>(i: I, f: F) -> IResult<I, usize, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
   E: ParseError<I>,
 {
   many1_count(f)(i)
@@ -601,10 +601,10 @@ where
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
 #[cfg(feature = "alloc")]
-pub fn count<I, O, E, F>(f: F, count: usize) -> impl Fn(I) -> IResult<I, Vec<O>, E>
+pub fn count<I, O, E, F>(mut f: F, count: usize) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, O, E>,
   E: ParseError<I>,
 {
   move |i: I | {
@@ -660,11 +660,11 @@ where
 /// assert_eq!(parser("123123"), Ok(("123123", vec![])));
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// ```
-pub fn fold_many0<I, O, E, F, G, R>(f: F, init: R, g: G) -> impl Fn(I) -> IResult<I, R, E>
+pub fn fold_many0<I, O, E, F, G, R>(mut f: F, init: R, mut g: G) -> impl FnMut(I) -> IResult<I, R, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
-  G: Fn(R, O) -> R,
+  F: FnMut(I) -> IResult<I, O, E>,
+  G: FnMut(R, O) -> R,
   E: ParseError<I>,
   R: Clone,
 {
@@ -699,8 +699,8 @@ where
 pub fn fold_many0c<I, O, E, F, G, R>(i: I, f: F, init: R, g: G) -> IResult<I, R, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
-  G: Fn(R, O) -> R,
+  F: FnMut(I) -> IResult<I, O, E>,
+  G: FnMut(R, O) -> R,
   E: ParseError<I>,
   R: Clone,
 {
@@ -738,11 +738,11 @@ where
 /// assert_eq!(parser("123123"), Err(Err::Error(("123123", ErrorKind::Many1))));
 /// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Many1))));
 /// ```
-pub fn fold_many1<I, O, E, F, G, R>(f: F, init: R, g: G) -> impl Fn(I) -> IResult<I, R, E>
+pub fn fold_many1<I, O, E, F, G, R>(mut f: F, init: R, mut g: G) -> impl FnMut(I) -> IResult<I, R, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
-  G: Fn(R, O) -> R,
+  F: FnMut(I) -> IResult<I, O, E>,
+  G: FnMut(R, O) -> R,
   E: ParseError<I>,
   R: Clone,
 {
@@ -784,8 +784,8 @@ where
 pub fn fold_many1c<I, O, E, F, G, R>(i: I, f: F, init: R, g: G) -> IResult<I, R, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
-  G: Fn(R, O) -> R,
+  F: FnMut(I) -> IResult<I, O, E>,
+  G: FnMut(R, O) -> R,
   E: ParseError<I>,
   R: Clone,
 {
@@ -828,11 +828,11 @@ where
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
-pub fn fold_many_m_n<I, O, E, F, G, R>(m: usize, n: usize, f: F, init: R, g: G) -> impl Fn(I) ->IResult<I, R, E>
+pub fn fold_many_m_n<I, O, E, F, G, R>(m: usize, n: usize, mut f: F, init: R, mut g: G) -> impl FnMut(I) ->IResult<I, R, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
-  G: Fn(R, O) -> R,
+  F: FnMut(I) -> IResult<I, O, E>,
+  G: FnMut(R, O) -> R,
   E: ParseError<I>,
   R: Clone,
 {
@@ -869,8 +869,8 @@ where
 pub fn fold_many_m_nc<I, O, E, F, G, R>(i: I, m: usize, n: usize, f: F, init: R, g: G) -> IResult<I, R, E>
 where
   I: Clone + PartialEq,
-  F: Fn(I) -> IResult<I, O, E>,
-  G: Fn(R, O) -> R,
+  F: FnMut(I) -> IResult<I, O, E>,
+  G: FnMut(R, O) -> R,
   E: ParseError<I>,
   R: Clone,
 {
@@ -899,11 +899,11 @@ where
 /// assert_eq!(parser(b"\x00\x03abcefg"), Ok((&b"efg"[..], &b"abc"[..])));
 /// assert_eq!(parser(b"\x00\x03"), Err(Err::Incomplete(Size(3))));
 /// ```
-pub fn length_data<I, N, E, F>(f: F) -> impl Fn(I) -> IResult<I, I, E>
+pub fn length_data<I, N, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, I, E>
 where
   I: Clone + InputLength + InputTake,
   N: Copy + ToUsize,
-  F: Fn(I) -> IResult<I, N, E>,
+  F: FnMut(I) -> IResult<I, N, E>,
   E: ParseError<I>,
 {
   move |i: I| {
@@ -942,12 +942,12 @@ where
 /// assert_eq!(parser(b"\x00\x03123123"), Err(Err::Error((&b"123"[..], ErrorKind::Tag))));
 /// assert_eq!(parser(b"\x00\x03"), Err(Err::Incomplete(Size(3))));
 /// ```
-pub fn length_value<I, O, N, E, F, G>(f: F, g: G) -> impl Fn(I) -> IResult<I, O, E>
+pub fn length_value<I, O, N, E, F, G>(mut f: F, mut g: G) -> impl FnMut(I) -> IResult<I, O, E>
 where
   I: Clone + InputLength + InputTake,
   N: Copy + ToUsize,
-  F: Fn(I) -> IResult<I, N, E>,
-  G: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, N, E>,
+  G: FnMut(I) -> IResult<I, O, E>,
   E: ParseError<I>,
 {
   move |i: I| {
@@ -974,8 +974,8 @@ pub fn length_valuec<I, O, N, E, F, G>(i: I, f: F, g: G) -> IResult<I, O, E>
 where
   I: Clone + InputLength + InputTake,
   N: Copy + ToUsize,
-  F: Fn(I) -> IResult<I, N, E>,
-  G: Fn(I) -> IResult<I, O, E>,
+  F: FnMut(I) -> IResult<I, N, E>,
+  G: FnMut(I) -> IResult<I, O, E>,
   E: ParseError<I>,
 {
   length_value(f, g)(i)

--- a/src/number/macros.rs
+++ b/src/number/macros.rs
@@ -253,7 +253,7 @@ mod tests {
   #[cfg(feature = "std")]
   fn manual_configurable_endianness_test() {
     let x = 1;
-    let int_parse: Box<Fn(&[u8]) -> IResult<&[u8], u16, (&[u8], ErrorKind)>> = if x == 2 {
+    let int_parse: Box<FnMut(&[u8]) -> IResult<&[u8], u16, (&[u8], ErrorKind)>> = if x == 2 {
       Box::new(be_u16)
     } else {
       Box::new(le_u16)

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -18,17 +18,17 @@ use crate::error::ParseError;
 /// use nom::sequence::pair;
 /// use nom::bytes::complete::tag;
 ///
-/// let parser = pair(tag("abc"), tag("efg"));
+/// let mut parser = pair(tag("abc"), tag("efg"));
 ///
 /// assert_eq!(parser("abcefg"), Ok(("", ("abc", "efg"))));
 /// assert_eq!(parser("abcefghij"), Ok(("hij", ("abc", "efg"))));
 /// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
 /// assert_eq!(parser("123"), Err(Err::Error(("123", ErrorKind::Tag))));
 /// ```
-pub fn pair<I, O1, O2, E: ParseError<I>, F, G>(first: F, second: G) -> impl Fn(I) -> IResult<I, (O1, O2), E>
+pub fn pair<I, O1, O2, E: ParseError<I>, F, G>(mut first: F, mut second: G) -> impl FnMut(I) -> IResult<I, (O1, O2), E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(I) -> IResult<I, O2, E>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(I) -> IResult<I, O2, E>,
 {
   move |input: I| {
     let (input, o1) = first(input)?;
@@ -40,8 +40,8 @@ where
 #[doc(hidden)]
 pub fn pairc<I, O1, O2, E: ParseError<I>, F, G>(input: I, first: F, second: G) -> IResult<I, (O1, O2), E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(I) -> IResult<I, O2, E>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(I) -> IResult<I, O2, E>,
 {
   pair(first, second)(input)
 }
@@ -58,17 +58,17 @@ where
 /// use nom::sequence::preceded;
 /// use nom::bytes::complete::tag;
 ///
-/// let parser = preceded(tag("abc"), tag("efg"));
+/// let mut parser = preceded(tag("abc"), tag("efg"));
 ///
 /// assert_eq!(parser("abcefg"), Ok(("", "efg")));
 /// assert_eq!(parser("abcefghij"), Ok(("hij", "efg")));
 /// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
 /// assert_eq!(parser("123"), Err(Err::Error(("123", ErrorKind::Tag))));
 /// ```
-pub fn preceded<I, O1, O2, E: ParseError<I>, F, G>(first: F, second: G) -> impl Fn(I) -> IResult<I, O2, E>
+pub fn preceded<I, O1, O2, E: ParseError<I>, F, G>(mut first: F, mut second: G) -> impl FnMut(I) -> IResult<I, O2, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(I) -> IResult<I, O2, E>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(I) -> IResult<I, O2, E>,
 {
   move |input: I| {
     let (input, _) = first(input)?;
@@ -80,8 +80,8 @@ where
 #[doc(hidden)]
 pub fn precededc<I, O1, O2, E: ParseError<I>, F, G>(input: I, first: F, second: G) -> IResult<I, O2, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(I) -> IResult<I, O2, E>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(I) -> IResult<I, O2, E>,
 {
   preceded(first, second)(input)
 }
@@ -98,17 +98,17 @@ where
 /// use nom::sequence::terminated;
 /// use nom::bytes::complete::tag;
 ///
-/// let parser = terminated(tag("abc"), tag("efg"));
+/// let mut parser = terminated(tag("abc"), tag("efg"));
 ///
 /// assert_eq!(parser("abcefg"), Ok(("", "abc")));
 /// assert_eq!(parser("abcefghij"), Ok(("hij", "abc")));
 /// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
 /// assert_eq!(parser("123"), Err(Err::Error(("123", ErrorKind::Tag))));
 /// ```
-pub fn terminated<I, O1, O2, E: ParseError<I>, F, G>(first: F, second: G) -> impl Fn(I) -> IResult<I, O1, E>
+pub fn terminated<I, O1, O2, E: ParseError<I>, F, G>(mut first: F, mut second: G) -> impl FnMut(I) -> IResult<I, O1, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(I) -> IResult<I, O2, E>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(I) -> IResult<I, O2, E>,
 {
   move |input: I| {
     let (input, o1) = first(input)?;
@@ -120,8 +120,8 @@ where
 #[doc(hidden)]
 pub fn terminatedc<I, O1, O2, E: ParseError<I>, F, G>(input: I, first: F, second: G) -> IResult<I, O1, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(I) -> IResult<I, O2, E>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(I) -> IResult<I, O2, E>,
 {
   terminated(first, second)(input)
 }
@@ -140,18 +140,18 @@ where
 /// use nom::sequence::separated_pair;
 /// use nom::bytes::complete::tag;
 ///
-/// let parser = separated_pair(tag("abc"), tag("|"), tag("efg"));
+/// let mut parser = separated_pair(tag("abc"), tag("|"), tag("efg"));
 ///
 /// assert_eq!(parser("abc|efg"), Ok(("", ("abc", "efg"))));
 /// assert_eq!(parser("abc|efghij"), Ok(("hij", ("abc", "efg"))));
 /// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
 /// assert_eq!(parser("123"), Err(Err::Error(("123", ErrorKind::Tag))));
 /// ```
-pub fn separated_pair<I, O1, O2, O3, E: ParseError<I>, F, G, H>(first: F, sep: G, second: H) -> impl Fn(I) -> IResult<I, (O1, O3), E>
+pub fn separated_pair<I, O1, O2, O3, E: ParseError<I>, F, G, H>(mut first: F, mut sep: G, mut second: H) -> impl FnMut(I) -> IResult<I, (O1, O3), E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(I) -> IResult<I, O2, E>,
-  H: Fn(I) -> IResult<I, O3, E>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(I) -> IResult<I, O2, E>,
+  H: FnMut(I) -> IResult<I, O3, E>,
 {
   move |input: I| {
     let (input, o1) = first(input)?;
@@ -164,9 +164,9 @@ where
 #[doc(hidden)]
 pub fn separated_pairc<I, O1, O2, O3, E: ParseError<I>, F, G, H>(input: I, first: F, sep: G, second: H) -> IResult<I, (O1, O3), E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(I) -> IResult<I, O2, E>,
-  H: Fn(I) -> IResult<I, O3, E>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(I) -> IResult<I, O2, E>,
+  H: FnMut(I) -> IResult<I, O3, E>,
 {
   separated_pair(first, sep, second)(input)
 }
@@ -185,18 +185,18 @@ where
 /// use nom::sequence::delimited;
 /// use nom::bytes::complete::tag;
 ///
-/// let parser = delimited(tag("abc"), tag("|"), tag("efg"));
+/// let mut parser = delimited(tag("abc"), tag("|"), tag("efg"));
 ///
 /// assert_eq!(parser("abc|efg"), Ok(("", "|")));
 /// assert_eq!(parser("abc|efghij"), Ok(("hij", "|")));
 /// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
 /// assert_eq!(parser("123"), Err(Err::Error(("123", ErrorKind::Tag))));
 /// ```
-pub fn delimited<I, O1, O2, O3, E: ParseError<I>, F, G, H>(first: F, sep: G, second: H) -> impl Fn(I) -> IResult<I, O2, E>
+pub fn delimited<I, O1, O2, O3, E: ParseError<I>, F, G, H>(mut first: F, mut sep: G, mut second: H) -> impl FnMut(I) -> IResult<I, O2, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(I) -> IResult<I, O2, E>,
-  H: Fn(I) -> IResult<I, O3, E>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(I) -> IResult<I, O2, E>,
+  H: FnMut(I) -> IResult<I, O3, E>,
 {
   move |input: I| {
     let (input, _) = first(input)?;
@@ -209,9 +209,9 @@ where
 #[doc(hidden)]
 pub fn delimitedc<I, O1, O2, O3, E: ParseError<I>, F, G, H>(input: I, first: F, sep: G, second: H) -> IResult<I, O2, E>
 where
-  F: Fn(I) -> IResult<I, O1, E>,
-  G: Fn(I) -> IResult<I, O2, E>,
-  H: Fn(I) -> IResult<I, O3, E>,
+  F: FnMut(I) -> IResult<I, O1, E>,
+  G: FnMut(I) -> IResult<I, O2, E>,
+  H: FnMut(I) -> IResult<I, O3, E>,
 {
   delimited(first, sep, second)(input)
 }
@@ -221,7 +221,7 @@ where
 /// this trait is implemented for tuples of parsers of up to 21 elements
 pub trait Tuple<I,O,E> {
   /// parses the input and returns a tuple of results of each parser
-  fn parse(&self, input: I) -> IResult<I,O,E>;
+  fn parse(&mut self, input: I) -> IResult<I,O,E>;
 }
 
 macro_rules! tuple_trait(
@@ -242,10 +242,10 @@ macro_rules! tuple_trait_impl(
   ($($name:ident $ty: ident),+) => (
     impl<
       Input: Clone, $($ty),+ , Error: ParseError<Input>,
-      $($name: Fn(Input) -> IResult<Input, $ty, Error>),+
+      $($name: FnMut(Input) -> IResult<Input, $ty, Error>),+
     > Tuple<Input, ( $($ty),+ ), Error> for ( $($name),+ ) {
 
-      fn parse(&self, input: Input) -> IResult<Input, ( $($ty),+ ), Error> {
+      fn parse(&mut self, input: Input) -> IResult<Input, ( $($ty),+ ), Error> {
         tuple_trait_inner!(0, self, input, (), $($name)+)
 
       }
@@ -271,8 +271,8 @@ macro_rules! tuple_trait_inner(
   });
 );
 
-tuple_trait!(FnA A, FnB B, FnC C, FnD D, FnE E, FnF F, FnG G, FnH H, FnI I, FnJ J, FnK K, FnL L,
-  FnM M, FnN N, FnO O, FnP P, FnQ Q, FnR R, FnS S, FnT T, FnU U);
+tuple_trait!(FnMutA A, FnMutB B, FnMutC C, FnMutD D, FnMutE E, FnMutF F, FnMutG G, FnMutH H, FnMutI I, FnMutJ J, FnMutK K, FnMutL L,
+  FnMutM M, FnMutN N, FnMutO O, FnMutP P, FnMutQ Q, FnMutR R, FnMutS S, FnMutT T, FnMutU U);
 
 /// applies a tuple of parsers one by one and returns their results as a tuple
 ///
@@ -280,12 +280,12 @@ tuple_trait!(FnA A, FnB B, FnC C, FnD D, FnE E, FnF F, FnG G, FnH H, FnI I, FnJ 
 /// # use nom::{Err, error::ErrorKind};
 /// use nom::sequence::tuple;
 /// use nom::character::complete::{alpha1, digit1};
-/// let parser = tuple((alpha1, digit1, alpha1));
+/// let mut parser = tuple((alpha1, digit1, alpha1));
 ///
 /// assert_eq!(parser("abc123def"), Ok(("", ("abc", "123", "def"))));
 /// assert_eq!(parser("123def"), Err(Err::Error(("123def", ErrorKind::Alpha))));
 /// ```
-pub fn tuple<I: Clone, O, E: ParseError<I>, List: Tuple<I,O,E>>(l: List)  -> impl Fn(I) -> IResult<I, O, E> {
+pub fn tuple<I: Clone, O, E: ParseError<I>, List: Tuple<I,O,E>>(mut l: List)  -> impl FnMut(I) -> IResult<I, O, E> {
   move |i: I| {
     l.parse(i)
   }

--- a/src/util.rs
+++ b/src/util.rs
@@ -158,8 +158,8 @@ macro_rules! dbg (
 /// f(a);
 /// ```
 #[cfg(feature = "std")]
-pub fn dbg_dmp<'a, F, O, E: Debug>(f: F, context: &'static str) -> impl Fn(&'a [u8]) -> IResult<&'a [u8], O, E>
-  where F: Fn(&'a [u8]) -> IResult<&'a [u8], O, E> {
+pub fn dbg_dmp<'a, F, O, E: Debug>(mut f: F, context: &'static str) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], O, E>
+  where F: FnMut(&'a [u8]) -> IResult<&'a [u8], O, E> {
   move |i: &'a [u8]| {
       match f(i) {
         Err(e) => {


### PR DESCRIPTION
I created this PR after having a situation where mutable state while parsing was a good fit for my usecase. I found two previous occurrences of this need in the issue tracker:

* https://github.com/Geal/nom/issues/949

Here you mentioned that switching to `FnMut` would not be possible. I'm wasn't sure if you meant that the current design would break which is how I started changing everything in the project to `FnMut` just to see where it will break. However I reached a point where everything is `FnMut` and all the tests pass. Did I miss something in the process?

Of course using a `Cell` is definitely possible, but it makes the code a messier.

* https://github.com/Geal/nom/issues/898

Here you mentioned that in `fold_many0` we'd have to make `init` `Clone`. But after replacing everything in the project with FnMut an issue didn't seem to come up. Again I'm unsure if I missed something.

Also, I was wondering the same question as @z2oh. Do restricted versions of the combinators have a place in the main project, either in this or a future major release? Or would you rather have this be a separate crate (e.g `nom-sideeffect`)?

As the title suggests, this PR is more to discuss the issue of mutability and let people run tests using the branch rather than changing everything in the project.
