### PR TITLE
Add missing `use` statement to "Code organization" parser example

### DIFF
--- a/doc/making_a_new_parser_from_scratch.md
+++ b/doc/making_a_new_parser_from_scratch.md
@@ -48,6 +48,7 @@ pub mod parser;
 And the `src/parser.rs` file:
 
 ```rust
+use nom::IResult;
 use nom::number::complete::be_u16;
 use nom::bytes::complete::take;
 


### PR DESCRIPTION
In the "Making a new parser from scratch" document, the sample code in the "Code organization" section does not compile as written. I've added the missing `use` statement required to make the code compile.

