### PR TITLE
Add to README.md's "Parsers written with nom"

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Here is a (non exhaustive) list of known projects using nom:
   * [libconfig-like configuration file format](https://github.com/filipegoncalves/rust-config)
   * [Web archive](https://github.com/sbeckeriv/warc_nom_parser)
   * [proto files](https://github.com/tafia/protobuf-parser)
+  * [Fountain screenplay markup](https://github.com/adamchalmers/fountain-rs)
 - Programming languages:
   * [PHP](https://github.com/tagua-vm/parser)
   * [Basic Calculator](https://github.com/balajisivaraman/basic_calculator_rs)


### PR DESCRIPTION
Adding my crate, [fountain](https://github.com/adamchalmers/fountain-rs) to the list of Parsers Written With Nom in the README.md
