### PR TITLE
Feature: Parsing using Tendril

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ default = ["std", "lexical"]
 regexp = ["regex"]
 regexp_macros = ["regexp", "lazy_static"]
 lexical = ["lexical-core"]
-tendrils = ["tendril", "std"]
+tendrils = ["tendril", "std", "rental"]
 
 [dependencies.regex]
 version = "^1.0"
@@ -52,6 +52,10 @@ optional = true
 
 [dependencies.tendril]
 version = "^0.4.1"
+optional = true
+
+[dependencies.rental]
+version = "^0.5.4"
 optional = true
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ default = ["std", "lexical"]
 regexp = ["regex"]
 regexp_macros = ["regexp", "lazy_static"]
 lexical = ["lexical-core"]
+tendrils = ["tendril", "std"]
 
 [dependencies.regex]
 version = "^1.0"
@@ -49,6 +50,10 @@ default-features = false
 version = "^0.4.0"
 optional = true
 
+[dependencies.tendril]
+version = "^0.4.1"
+optional = true
+
 [dev-dependencies]
 criterion = "0.2"
 jemallocator = "^0.1"
@@ -58,7 +63,7 @@ doc-comment = "0.3"
 version_check = "^0.1"
 
 [package.metadata.docs.rs]
-features = [ "alloc", "std", "regexp", "regexp_macros", "lexical"]
+features = [ "alloc", "std", "regexp", "regexp_macros", "lexical", "tendrils"]
 all-features = true
 
 [profile.bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,6 +422,10 @@ pub extern crate regex;
 #[cfg(nightly)]
 extern crate test;
 
+#[cfg(feature = "tendrils")]
+#[macro_use]
+extern crate rental;
+
 //FIXME: reactivate doctest once https://github.com/rust-lang/rust/issues/62210 is done
 //#[cfg(doctest)]
 //doc_comment::doctest!("../README.md");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,15 +412,15 @@ extern crate alloc;
 #[cfg(feature = "regexp_macros")]
 #[macro_use]
 extern crate lazy_static;
+#[cfg(test)]
+extern crate doc_comment;
+#[cfg(feature = "lexical")]
+extern crate lexical_core;
 extern crate memchr;
 #[cfg(feature = "regexp")]
 pub extern crate regex;
-#[cfg(feature = "lexical")]
-extern crate lexical_core;
 #[cfg(nightly)]
 extern crate test;
-#[cfg(test)]
-extern crate doc_comment;
 
 //FIXME: reactivate doctest once https://github.com/rust-lang/rust/issues/62210 is done
 //#[cfg(doctest)]
@@ -438,7 +438,7 @@ pub mod lib {
     #[cfg_attr(feature = "alloc", macro_use)]
     pub use alloc::{boxed, string, vec};
 
-    pub use core::{cmp, convert, fmt, iter, mem, ops, option, result, slice, str, borrow};
+    pub use core::{borrow, cmp, convert, fmt, iter, mem, ops, option, result, slice, str};
 
     /// internal reproduction of std prelude
     pub mod prelude {
@@ -449,7 +449,7 @@ pub mod lib {
   #[cfg(feature = "std")]
   /// internal std exports for no_std compatibility
   pub mod std {
-    pub use std::{alloc, boxed, cmp, collections, convert, fmt, hash, iter, mem, ops, option, result, slice, str, string, vec, borrow};
+    pub use std::{alloc, borrow, boxed, cmp, collections, convert, fmt, hash, iter, mem, ops, option, result, slice, str, string, vec};
 
     /// internal reproduction of std prelude
     pub mod prelude {
@@ -461,11 +461,11 @@ pub mod lib {
   pub use regex;
 }
 
-pub use self::traits::*;
-pub use self::util::*;
+pub use self::bits::*;
 pub use self::internal::*;
 pub use self::methods::*;
-pub use self::bits::*;
+pub use self::traits::*;
+pub use self::util::*;
 pub use self::whitespace::*;
 
 #[cfg(feature = "regexp")]
@@ -511,3 +511,6 @@ mod str;
 
 #[macro_use]
 pub mod number;
+
+#[cfg(feature = "tendrils")]
+pub mod tendrils;

--- a/src/tendrils.rs
+++ b/src/tendrils.rs
@@ -482,6 +482,6 @@ mod tests {
       take_while(|c| c == 'a')(s)
     }
 
-    assert_eq!(parser(&Tendril::from("aaaabba")), Ok(("bba".into(), "aaaa".into())));
+    assert_eq!(parser(Tendril::from("aaaabba")), Ok(("bba".into(), "aaaa".into())));
   }
 }

--- a/src/tendrils.rs
+++ b/src/tendrils.rs
@@ -1,0 +1,487 @@
+//! Implements the required traits to enable parsing of [`Tendril`s](https://github.com/servo/tendril).
+//!
+
+use crate::lib::std::iter::Enumerate;
+use crate::lib::std::iter::Map;
+use crate::lib::std::ops::{Range, RangeFrom, RangeFull, RangeTo};
+use crate::lib::std::slice::Iter;
+use crate::lib::std::str::CharIndices;
+use crate::lib::std::str::Chars;
+use crate::traits::*;
+
+use tendril::{fmt, Atomicity, Tendril};
+
+impl<'a, F: fmt::Format, A: Atomicity> InputLength for Tendril<F, A> {
+  #[inline]
+  fn input_len(&self) -> usize {
+    self.len32() as usize
+  }
+}
+
+impl<'a, F: fmt::Format, A: Atomicity> InputLength for &'a Tendril<F, A> {
+  #[inline]
+  fn input_len(&self) -> usize {
+    self.len32() as usize
+  }
+}
+
+impl<'a, A: Atomicity> Offset for Tendril<fmt::UTF8, A> {
+  fn offset(&self, second: &Self) -> usize {
+    let fst: &str = &self;
+    let snd: &str = &second;
+    let fst_ptr = fst.as_ptr();
+    let snd_ptr = snd.as_ptr();
+
+    snd_ptr as usize - fst_ptr as usize
+  }
+}
+
+impl<'a, A: Atomicity> Offset for Tendril<fmt::Bytes, A> {
+  fn offset(&self, second: &Self) -> usize {
+    let fst: &[u8] = &self;
+    let snd: &[u8] = &second;
+    let fst_ptr = fst.as_ptr();
+    let snd_ptr = snd.as_ptr();
+
+    snd_ptr as usize - fst_ptr as usize
+  }
+}
+
+impl<'a, A: Atomicity> Offset for &'a Tendril<fmt::UTF8, A> {
+  fn offset(&self, second: &Self) -> usize {
+    let fst: &str = &self;
+    let snd: &str = &second;
+    let fst_ptr = fst.as_ptr();
+    let snd_ptr = snd.as_ptr();
+
+    snd_ptr as usize - fst_ptr as usize
+  }
+}
+
+impl<'a, A: Atomicity> Offset for &'a Tendril<fmt::Bytes, A> {
+  fn offset(&self, second: &Self) -> usize {
+    let fst: &[u8] = &self;
+    let snd: &[u8] = &second;
+    let fst_ptr = fst.as_ptr();
+    let snd_ptr = snd.as_ptr();
+
+    snd_ptr as usize - fst_ptr as usize
+  }
+}
+
+impl<'a, A: Atomicity> AsBytes for Tendril<fmt::Bytes, A> {
+  #[inline(always)]
+  fn as_bytes(&self) -> &[u8] {
+    &self
+  }
+}
+
+impl<'a, A: Atomicity> AsBytes for Tendril<fmt::UTF8, A> {
+  #[inline(always)]
+  fn as_bytes(&self) -> &[u8] {
+    &self.as_bytes()
+  }
+}
+
+impl<'a, A: Atomicity> AsBytes for &'a Tendril<fmt::Bytes, A> {
+  #[inline(always)]
+  fn as_bytes(&self) -> &[u8] {
+    <Tendril<fmt::Bytes, A> as AsBytes>::as_bytes(self)
+  }
+}
+
+impl<'a, A: Atomicity> AsBytes for &'a Tendril<fmt::UTF8, A> {
+  #[inline(always)]
+  fn as_bytes(&self) -> &[u8] {
+    <Tendril<fmt::UTF8, A> as AsBytes>::as_bytes(self)
+  }
+}
+
+impl<'a, A: Atomicity> InputIter for &'a Tendril<fmt::Bytes, A> {
+  type Item = u8;
+  type Iter = Enumerate<Self::IterElem>;
+  type IterElem = Map<Iter<'a, Self::Item>, fn(&u8) -> u8>;
+
+  #[inline]
+  fn iter_indices(&self) -> Self::Iter {
+    self.iter_elements().enumerate()
+  }
+  #[inline]
+  fn iter_elements(&self) -> Self::IterElem {
+    self.iter().map(star)
+  }
+  #[inline]
+  fn position<P>(&self, predicate: P) -> Option<usize>
+  where
+    P: Fn(Self::Item) -> bool,
+  {
+    self.iter().position(|b| predicate(*b))
+  }
+  #[inline]
+  fn slice_index(&self, count: usize) -> Option<usize> {
+    if self.len() >= count {
+      Some(count)
+    } else {
+      None
+    }
+  }
+}
+
+impl<'a, A: Atomicity> InputIter for &'a Tendril<fmt::UTF8, A> {
+  type Item = char;
+  type Iter = CharIndices<'a>;
+  type IterElem = Chars<'a>;
+
+  #[inline]
+  fn iter_indices(&self) -> Self::Iter {
+    self.char_indices()
+  }
+  #[inline]
+  fn iter_elements(&self) -> Self::IterElem {
+    self.chars()
+  }
+  fn position<P>(&self, predicate: P) -> Option<usize>
+  where
+    P: Fn(Self::Item) -> bool,
+  {
+    for (o, c) in self.char_indices() {
+      if predicate(c) {
+        return Some(o);
+      }
+    }
+    None
+  }
+  #[inline]
+  fn slice_index(&self, count: usize) -> Option<usize> {
+    let mut cnt = 0;
+    for (index, _) in self.char_indices() {
+      if cnt == count {
+        return Some(index);
+      }
+      cnt += 1;
+    }
+    if cnt == count {
+      return Some(self.len());
+    }
+    None
+  }
+}
+
+impl<F: fmt::Format, A: Atomicity> InputTake for Tendril<F, A> {
+  #[inline]
+  fn take(&self, count: usize) -> Self {
+    self.subtendril(0, count as u32).into()
+  }
+
+  // return byte index
+  #[inline]
+  fn take_split(&self, count: usize) -> (Self, Self) {
+    split_tendril_at(self, count as u32)
+  }
+}
+
+fn split_tendril_at<'a, F: fmt::Format, A: Atomicity>(t: &Tendril<F, A>, i: u32) -> (Tendril<F, A>, Tendril<F, A>) {
+  let len = t.len32();
+  assert!(i < len);
+
+  (t.subtendril(i, len - i).into(), t.subtendril(0, i).into())
+}
+
+impl<F: fmt::Format, A: Atomicity> UnspecializedInput for Tendril<F, A> {}
+
+impl<'a, F: fmt::Format, A: Atomicity> UnspecializedInput for &'a Tendril<F, A> {}
+
+impl<'a, 'b, A: Atomicity> Compare<&'b Tendril<fmt::UTF8, A>> for &'a Tendril<fmt::UTF8, A> {
+  #[inline(always)]
+  fn compare(&self, t: &'b Tendril<fmt::UTF8, A>) -> CompareResult {
+    let a: &str = &self;
+    let b: &str = &t;
+    a.compare(b)
+  }
+
+  #[inline(always)]
+  fn compare_no_case(&self, t: &'b Tendril<fmt::UTF8, A>) -> CompareResult {
+    let a: &str = &self;
+    let b: &str = &t;
+    a.compare_no_case(b)
+  }
+}
+
+impl<'a, A: Atomicity> Compare<&'a Tendril<fmt::UTF8, A>> for Tendril<fmt::UTF8, A> {
+  #[inline(always)]
+  fn compare(&self, t: &'a Tendril<fmt::UTF8, A>) -> CompareResult {
+    let a: &str = &self;
+    let b: &str = &t;
+    a.compare(b)
+  }
+
+  #[inline(always)]
+  fn compare_no_case(&self, t: &'a Tendril<fmt::UTF8, A>) -> CompareResult {
+    let a: &str = &self;
+    let b: &str = &t;
+    a.compare_no_case(b)
+  }
+}
+
+impl<'a, 'b, A: Atomicity> Compare<&'b Tendril<fmt::Bytes, A>> for &'a Tendril<fmt::Bytes, A> {
+  #[inline(always)]
+  fn compare(&self, t: &'b Tendril<fmt::Bytes, A>) -> CompareResult {
+    let a: &[u8] = &self;
+    let b: &[u8] = &t;
+    a.compare(b)
+  }
+
+  #[inline(always)]
+  fn compare_no_case(&self, t: &'b Tendril<fmt::Bytes, A>) -> CompareResult {
+    let a: &[u8] = &self;
+    let b: &[u8] = &t;
+    a.compare_no_case(b)
+  }
+}
+
+impl<'a, 'b, A: Atomicity> Compare<&'b Tendril<fmt::UTF8, A>> for &'a Tendril<fmt::Bytes, A> {
+  #[inline(always)]
+  fn compare(&self, t: &'b Tendril<fmt::UTF8, A>) -> CompareResult {
+    let a: &[u8] = &self;
+    let b: &str = &t;
+    a.compare(b)
+  }
+
+  #[inline(always)]
+  fn compare_no_case(&self, t: &'b Tendril<fmt::UTF8, A>) -> CompareResult {
+    let a: &[u8] = &self;
+    let b: &str = &t;
+    a.compare_no_case(b)
+  }
+}
+
+impl<'a, A: Atomicity> Compare<&'a str> for Tendril<fmt::UTF8, A> {
+  #[inline(always)]
+  fn compare(&self, t: &'a str) -> CompareResult {
+    let a: &str = &self;
+    a.compare(t)
+  }
+
+  #[inline(always)]
+  fn compare_no_case(&self, t: &'a str) -> CompareResult {
+    let a: &str = &self;
+    a.compare_no_case(t)
+  }
+}
+
+impl<'a, A: Atomicity> Compare<&'a Tendril<fmt::UTF8, A>> for Tendril<fmt::Bytes, A> {
+  #[inline(always)]
+  fn compare(&self, t: &'a Tendril<fmt::UTF8, A>) -> CompareResult {
+    let a: &[u8] = &self;
+    let b: &str = &t;
+    a.compare(b)
+  }
+
+  #[inline(always)]
+  fn compare_no_case(&self, t: &'a Tendril<fmt::UTF8, A>) -> CompareResult {
+    let a: &[u8] = &self;
+    let b: &str = &t;
+    a.compare_no_case(b)
+  }
+}
+
+impl<'a, A: Atomicity> FindToken<char> for &'a Tendril<fmt::UTF8, A> {
+  fn find_token(&self, token: char) -> bool {
+    (&self[..]).find_token(token)
+  }
+}
+
+impl<'a, A: Atomicity> FindToken<u8> for &'a Tendril<fmt::UTF8, A> {
+  fn find_token(&self, token: u8) -> bool {
+    (&self[..]).find_token(token)
+  }
+}
+
+impl<'a, 'b, A: Atomicity> FindToken<&'a u8> for &'b Tendril<fmt::UTF8, A> {
+  fn find_token(&self, token: &'a u8) -> bool {
+    (&self[..]).find_token(token)
+  }
+}
+
+impl<'a, A: Atomicity> FindToken<char> for &'a Tendril<fmt::Bytes, A> {
+  fn find_token(&self, token: char) -> bool {
+    (&self[..]).find_token(token)
+  }
+}
+
+impl<'a, A: Atomicity> FindToken<u8> for &'a Tendril<fmt::Bytes, A> {
+  fn find_token(&self, token: u8) -> bool {
+    (&self[..]).find_token(token)
+  }
+}
+
+impl<'a, 'b, A: Atomicity> FindToken<&'a u8> for &'b Tendril<fmt::Bytes, A> {
+  fn find_token(&self, token: &'a u8) -> bool {
+    (&self[..]).find_token(token)
+  }
+}
+
+// Substring -- Tendril<fmt::Bytes>
+
+impl<'a, 'b, A: Atomicity> FindSubstring<&'b str> for &'a Tendril<fmt::Bytes, A> {
+  fn find_substring(&self, substr: &'b str) -> Option<usize> {
+    let a: &[u8] = &self;
+    let b: &[u8] = AsBytes::as_bytes(substr);
+    a.find_substring(b)
+  }
+}
+
+impl<'a, 'b, A: Atomicity> FindSubstring<&'b [u8]> for &'a Tendril<fmt::Bytes, A> {
+  fn find_substring(&self, substr: &'b [u8]) -> Option<usize> {
+    let a: &[u8] = &self;
+    a.find_substring(substr)
+  }
+}
+
+impl<'a, 'b, A: Atomicity> FindSubstring<&'b Tendril<fmt::Bytes, A>> for &'a Tendril<fmt::Bytes, A> {
+  fn find_substring(&self, substr: &'b Tendril<fmt::Bytes, A>) -> Option<usize> {
+    let a: &[u8] = &self;
+    let b: &[u8] = &substr;
+    a.find_substring(b)
+  }
+}
+
+impl<'a, 'b, A: Atomicity> FindSubstring<&'b Tendril<fmt::UTF8, A>> for &'a Tendril<fmt::Bytes, A> {
+  fn find_substring(&self, substr: &'b Tendril<fmt::UTF8, A>) -> Option<usize> {
+    let a: &[u8] = &self;
+    let b: &[u8] = AsBytes::as_bytes(substr);
+    a.find_substring(b)
+  }
+}
+
+// Substring -- Tendril<fmt::UTF8>
+
+impl<'a, 'b, A: Atomicity> FindSubstring<&'b str> for &'a Tendril<fmt::UTF8, A> {
+  fn find_substring(&self, substr: &'b str) -> Option<usize> {
+    let a: &[u8] = AsBytes::as_bytes(self);
+    let b: &[u8] = AsBytes::as_bytes(substr);
+    a.find_substring(b)
+  }
+}
+
+impl<'a, 'b, A: Atomicity> FindSubstring<&'b [u8]> for &'a Tendril<fmt::UTF8, A> {
+  fn find_substring(&self, substr: &'b [u8]) -> Option<usize> {
+    let a: &[u8] = AsBytes::as_bytes(self);
+    a.find_substring(substr)
+  }
+}
+
+impl<'a, 'b, A: Atomicity> FindSubstring<&'b Tendril<fmt::Bytes, A>> for &'a Tendril<fmt::UTF8, A> {
+  fn find_substring(&self, substr: &'b Tendril<fmt::Bytes, A>) -> Option<usize> {
+    let a: &[u8] = AsBytes::as_bytes(self);
+    let b: &[u8] = &substr;
+    a.find_substring(b)
+  }
+}
+
+impl<'a, 'b, A: Atomicity> FindSubstring<&'b Tendril<fmt::UTF8, A>> for &'a Tendril<fmt::UTF8, A> {
+  fn find_substring(&self, substr: &'b Tendril<fmt::UTF8, A>) -> Option<usize> {
+    let a: &[u8] = AsBytes::as_bytes(self);
+    let b: &[u8] = AsBytes::as_bytes(substr);
+    a.find_substring(b)
+  }
+}
+
+// Substring -- &[u8]
+
+impl<'a, 'b, A: Atomicity> FindSubstring<&'b Tendril<fmt::Bytes, A>> for &'a [u8] {
+  fn find_substring(&self, substr: &'b Tendril<fmt::Bytes, A>) -> Option<usize> {
+    let b: &[u8] = &substr;
+    self.find_substring(b)
+  }
+}
+
+impl<'a, 'b, A: Atomicity> FindSubstring<&'b Tendril<fmt::UTF8, A>> for &'a [u8] {
+  fn find_substring(&self, substr: &'b Tendril<fmt::UTF8, A>) -> Option<usize> {
+    let b: &[u8] = AsBytes::as_bytes(substr);
+    self.find_substring(b)
+  }
+}
+
+// Substring -- &str
+
+impl<'a, 'b, A: Atomicity> FindSubstring<&'b Tendril<fmt::Bytes, A>> for &'a str {
+  fn find_substring(&self, substr: &'b Tendril<fmt::Bytes, A>) -> Option<usize> {
+    let a: &[u8] = AsBytes::as_bytes(self);
+    let b: &[u8] = &substr;
+    a.find_substring(b)
+  }
+}
+
+impl<'a, 'b, A: Atomicity> FindSubstring<&'b Tendril<fmt::UTF8, A>> for &'a str {
+  fn find_substring(&self, substr: &'b Tendril<fmt::UTF8, A>) -> Option<usize> {
+    let a: &[u8] = AsBytes::as_bytes(self);
+    let b: &[u8] = AsBytes::as_bytes(substr);
+    a.find_substring(b)
+  }
+}
+
+impl<F: fmt::Format, A: Atomicity> Slice<Range<usize>> for Tendril<F, A> {
+  fn slice(&self, range: Range<usize>) -> Self {
+    let start = range.start as u32;
+    let end = range.end as u32;
+    let len = self.len32();
+    assert!(start <= len);
+    assert!(end <= len);
+
+    self.subtendril(start, end - start)
+  }
+}
+
+impl<F: fmt::Format, A: Atomicity> Slice<RangeTo<usize>> for Tendril<F, A> {
+  fn slice(&self, range: RangeTo<usize>) -> Self {
+    let end = range.end as u32;
+    let len = self.len32();
+    assert!(end <= len);
+
+    self.subtendril(0, end)
+  }
+}
+
+impl<F: fmt::Format, A: Atomicity> Slice<RangeFrom<usize>> for Tendril<F, A> {
+  fn slice(&self, range: RangeFrom<usize>) -> Self {
+    let start = range.start as u32;
+    let len = self.len32();
+    assert!(start <= len);
+
+    self.subtendril(start, len - start)
+  }
+}
+
+impl<F: fmt::Format, A: Atomicity> Slice<RangeFull> for Tendril<F, A> {
+  fn slice(&self, _range: RangeFull) -> Self {
+    self.clone()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::bytes::complete::{tag, take_while};
+  use crate::{error::ErrorKind, Err, IResult, Needed};
+
+  #[test]
+  fn test_tag() {
+    fn parser(s: Tendril<fmt::UTF8>) -> IResult<Tendril<fmt::UTF8>, Tendril<fmt::UTF8>> {
+      tag("Hello")(s)
+    }
+
+    assert_eq!(parser("Hello, World!".into()), Ok((", World!".into(), "Hello".into())));
+    assert_eq!(parser("Something".into()), Err(Err::Error(("Something".into(), ErrorKind::Tag))));
+    assert_eq!(parser("".into()), Err(Err::Error(("".into(), ErrorKind::Tag))));
+  }
+
+  #[test]
+  fn test_take_while() {
+    fn parser(s: Tendril<fmt::UTF8>) -> IResult<Tendril<fmt::UTF8>, Tendril<fmt::UTF8>> {
+      take_while(|c| c == 'a')(s)
+    }
+
+    assert_eq!(parser(&Tendril::from("aaaabba")), Ok(("bba".into(), "aaaa".into())));
+  }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -339,7 +339,7 @@ pub trait InputTake: Sized {
   fn take_split(&self, count: usize) -> (Self, Self);
 }
 
-fn star(r_u8: &u8) -> u8 {
+pub(crate) fn star(r_u8: &u8) -> u8 {
   *r_u8
 }
 


### PR DESCRIPTION
I would like to use [tendril](https://github.com/servo/tendril/) instead of `&str` and `&[u8]` for my parsers. This has some nice benefits of reducing allocations, especially when processing more complex things and wanting to support both streaming and complete input.

(Because of the orphan rule (I think that is the one) this needs to be implemented here, or in the tendril repo afaict. )

I have started to implement the necessary traits behind a feature flag, but ran into some issues around lifetimes and the various `Input*` traits. 

When you try to run the tests (`cargo test --features tendrils`) you can see the issue

```
the trait `traits::InputIter` is not implemented for `tendril::tendril::Tendril<tendril::fmt::UTF8>`
```

Which I am unable to fix, due to unconstrained lifetimes on that trait, as `Tendril` does not contain a lifetime, whereas `&str` and `&[u8]` the types for which this is implemented constrain the lifetime. 

I would appreciate input both on if this is something you could imagine merging and how to possibly fix this. I would be also happy to maintain this in a different place if there is a good solution we can find that the compiler accepts. 
