### PR TITLE
Fix a typo (length_value -> length_data)

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -893,11 +893,10 @@ where
   fold_many_m_n(m, n, f, init, g)(i)
 }
 
-/// Gets a number from the first parser,
-/// takes a subslice of the input of that size,
-/// then applies the second parser on that subslice.
-/// If the second parser returns Incomplete,
-/// length_value will return an error.
+/// Gets a number from the parser and returns a
+/// subslice of the input of that size.
+/// If the parser returns Incomplete,
+/// length_data will return an error.
 /// # Arguments
 /// * `f` The parser to apply.
 /// ```rust


### PR DESCRIPTION
It looks like the comment for length_data was copied/pasted from length_value. In the description of the failure case, I believe the comment should refer to length_data.

I don't have an issue open for this pull request since it's purely a change to the documentation. Let me know if you'd like me to open one. Thanks!