### PR TITLE
Add SystemVerilog parser to parsers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Here is a (non exhaustive) list of known projects using nom:
   * [Lua](https://github.com/doomrobo/nom-lua53)
   * [SQL](https://github.com/ms705/nom-sql)
   * [Elm](https://github.com/cout970/Elm-interpreter)
+  * [SystemVerilog](https://github.com/dalance/sv-parser)
 - Interface definition formats:
   * [Thrift](https://github.com/thehydroimpulse/thrust)
 - Audio, video and image formats:


### PR DESCRIPTION
I wrote a SystemVerilog parser with nom.
So I want to add it to parsers list of README.
