### PR TITLE
Implemented std::error::Error and std::fmt::Display traits for nom::Err

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -84,7 +84,6 @@ impl<E> Err<E> {
   }
 }
 
-/*
 #[cfg(feature = "std")]
 use std::fmt;
 
@@ -94,7 +93,12 @@ where
   E: fmt::Debug,
 {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(f, "{:?}", self)
+    match self {
+      Err::Incomplete(Needed::Size(u)) => write!(f, "Parsing requires {} bytes/chars", u),
+      Err::Incomplete(Needed::Unknown) => write!(f, "Parsing requires more data"),
+      Err::Failure(c) => write!(f, "Parsing Failure: {:?}", c),
+      Err::Error(c) => write!(f, "Parsing Error: {:?}", c),
+    }
   }
 }
 
@@ -104,21 +108,12 @@ use std::error::Error;
 #[cfg(feature = "std")]
 impl<E> Error for Err<E>
 where
-  I: fmt::Debug,
   E: fmt::Debug,
 {
-  fn description(&self) -> &str {
-    match self {
-      &Err::Incomplete(..) => "there was not enough data",
-      &Err::Error(Context::Code(_, ref error_kind)) | &Err::Failure(Context::Code(_, ref error_kind)) => error_kind.description(),
-    }
-  }
-
-  fn cause(&self) -> Option<&Error> {
-    None
+  fn source(&self) -> Option<&(dyn Error + 'static)> {
+    None // no underlying error
   }
 }
-*/
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Related issue: #591 

I came across this issue when I worked with nom. I thought having the `Error` and `Display` trait on `nom::Err` might be very helpful.
When I poked around the code I realized that there already was an old implementation that was commented out. Referring to the mentioned issue it might have been because of `Error::description`. But because this is now deprecated anyway I considered opening a PR.

If the removal of the old `Error` and `Display` implementations had other reasons, feel free to close this PR.

