### PR TITLE
fixed rustdoc and example for character::complete::digit0

### DIFF
--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -365,6 +365,16 @@ where
 }
 
 /// Recognizes zero or more ASCII numerical characters: 0-9
+///
+/// *complete version*: Will return an error if there's not enough input data,
+/// or the whole input if no terminating token is found (a non digit character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::character::complete::digit0;
+/// # fn main() {
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     digit0(input)
 /// }


### PR DESCRIPTION
Title largely explains it.

There was a malformed example for the `digit0` parser in the character::complete module. I've fixed it and put it in alignment with the other examples.

On a related note: I went back and checked to see how far this documentation error went, and it appears that it was [introduced in v5.0.0-beta3](https://docs.rs/nom/5.0.0-beta3/nom/character/complete/fn.digit0.html). Would correcting the versions of nom from 5.0.0-beta3 through 5.0.0 be desired as well?