### PR TITLE
Add AsStr trait for convert_error

### DIFF
--- a/doc/custom_input_types.md
+++ b/doc/custom_input_types.md
@@ -36,6 +36,12 @@ Here are the traits we have to implement for `MyInput`:
 | [ParseTo](https://docs.rs/nom/latest/nom/trait.ParseTo.html) | used to integrate `&str`'s parse() method |
 | [Slice](https://docs.rs/nom/latest/nom/trait.Slice.html) | slicing operations using ranges |
 
+Here are the optional traits we may implement for `MyInput`:
+
+| trait | usage |
+|---|---|
+| [AsStr](https://docs.rs/nom/latest/nom/trait.AsStr.html) | casts the input type to a string slice |
+
 Here are the traits we have to implement for `MyItem`:
 
 | trait | usage |

--- a/src/error.rs
+++ b/src/error.rs
@@ -137,19 +137,16 @@ where
 }
 
 /// transforms a `VerboseError` into a trace with input position information
-#[cfg(feature="alloc")]
-pub fn convert_error(input: &str, e: VerboseError<&str>) -> crate::lib::std::string::String {
-  use crate::{
-    lib::std:: iter::repeat,
-    traits::Offset
-  };
+#[cfg(feature = "alloc")]
+pub fn convert_error<T: crate::traits::AsStr, U: crate::traits::AsStr>(input: T, e: VerboseError<U>) -> crate::lib::std::string::String {
+  use crate::{lib::std::iter::repeat, traits::Offset};
 
-  let lines: crate::lib::std::vec::Vec<_> = input.lines().map(crate::lib::std::string::String::from).collect();
+  let lines: crate::lib::std::vec::Vec<_> = input.as_str().lines().map(crate::lib::std::string::String::from).collect();
 
   let mut result = crate::lib::std::string::String::new();
 
   for (i, (substring, kind)) in e.errors.iter().enumerate() {
-    let mut offset = input.offset(substring);
+    let mut offset = input.as_str().offset(substring.as_str());
 
     if lines.is_empty() {
       match kind {
@@ -158,7 +155,7 @@ pub fn convert_error(input: &str, e: VerboseError<&str>) -> crate::lib::std::str
         }
         VerboseErrorKind::Context(s) => {
           result += &format!("{}: in {}, got empty input\n\n", i, s);
-        },
+        }
         VerboseErrorKind::Nom(e) => {
           result += &format!("{}: in {:?}, got empty input\n\n", i, e);
         }
@@ -187,7 +184,7 @@ pub fn convert_error(input: &str, e: VerboseError<&str>) -> crate::lib::std::str
             result += &repeat(' ').take(column).collect::<crate::lib::std::string::String>();
           }
           result += "^\n";
-          result += &format!("expected '{}', found {}\n\n", c, substring.chars().next().unwrap());
+          result += &format!("expected '{}', found {}\n\n", c, substring.as_str().chars().next().unwrap());
         }
         VerboseErrorKind::Context(s) => {
           result += &format!("{}: at line {}, in {}:\n", i, line, s);
@@ -197,7 +194,7 @@ pub fn convert_error(input: &str, e: VerboseError<&str>) -> crate::lib::std::str
             result += &repeat(' ').take(column).collect::<crate::lib::std::string::String>();
           }
           result += "^\n\n";
-        },
+        }
         VerboseErrorKind::Nom(e) => {
           result += &format!("{}: at line {}, in {:?}:\n", i, line, e);
           result += &lines[line];

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1101,6 +1101,26 @@ impl ExtendInto for char {
   }
 }
 
+/// Helper trait for types that can be viewed as a string slice
+pub trait AsStr {
+  /// casts the input type to a string slice
+  fn as_str(&self) -> &str;
+}
+
+impl<'a> AsStr for &'a str {
+  #[inline(always)]
+  fn as_str(&self) -> &str {
+    self
+  }
+}
+
+impl AsStr for str {
+  #[inline(always)]
+  fn as_str(&self) -> &str {
+    self
+  }
+}
+
 /// Helper trait to convert numbers to usize
 ///
 /// by default, usize implements `From<u8>` and `From<u16>` but not


### PR DESCRIPTION
`convert_error` function takes `&str` only. So if I use an input type except `&str` like `nom_locate::LocatedSpanEx<&str, ()>`, `convert_error` can't be used.

This PR add `AsStr` trait to provide `as_str()`.
Hereby any input type implementing `AsStr` can be used at `convert_error`.