### PR TITLE
Add link to SWF parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Here is a (non exhaustive) list of known projects using nom:
   * [GIF](https://github.com/Geal/gif.rs)
   * [MagicaVoxel .vox](https://github.com/davidedmonds/dot_vox)
   * [midi](https://github.com/derekdreery/nom-midi-rs)
+  * [SWF](https://github.com/open-flash/swf-parser)
   * [WAVE](http://github.com/noise-Labs/wave)
 - Document formats:
   * [TAR](https://github.com/Keruspe/tar-parser.rs)


### PR DESCRIPTION
## Prerequisites

Please provide the following information with this pull request:

- related issue number: #14
- a test case reproducing the issue: N/A
- if adding a new combinator, please add code documentation and some unit tests
in the same file: N/A

## Description

This commit adds a link to Open Flash's SWF parser implemented using nom. The parser was recently updated to nom 5 add provides a good example for parsing a fairly complex binary format.