### PR TITLE
Remove stabilized `alloc` feature gate.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.31.0
+  - 1.36.0
 
 env:
   matrix:
@@ -20,12 +20,18 @@ before_script:
 
 matrix:
   include:
+    - rust: stable
+      env: FEATURES=''
+    - rust: stable
+      env: FEATURES='--no-default-features'
+    - rust: stable
+      env: FEATURES='--no-default-features --features "alloc"'
+    - rust: nightly
+      env: FEATURES=''
     - rust: nightly
       env: FEATURES='--no-default-features'
     - rust: nightly
       env: FEATURES='--no-default-features --features "alloc"'
-    - rust: stable
-      env: FEATURES=''
     - rust: nightly
       env: DOC_FEATURES='--features "std lexical regexp regexp_macros" --no-default-features'
       before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Thanks
 
+### Changed
+
+- the minimal Rust version is now 1.36
+- stabilized the `alloc` feature
+
 ### Added
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.org/Geal/nom.svg?branch=master)](https://travis-ci.org/Geal/nom)
 [![Coverage Status](https://coveralls.io/repos/Geal/nom/badge.svg?branch=master)](https://coveralls.io/r/Geal/nom?branch=master)
 [![Crates.io Version](https://img.shields.io/crates/v/nom.svg)](https://crates.io/crates/nom)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.31.0+-lightgray.svg)](#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.36.0+-lightgray.svg)](#rust-version-requirements)
 
 nom is a parser combinators library written in Rust. Its goal is to provide tools
 to build safe parsers without compromising the speed or memory consumption. To
@@ -188,7 +188,7 @@ Some benchmarks are available on [Github](https://github.com/Geal/nom_benchmarks
 
 ## Rust version requirements
 
-The 5.0 series of nom requires **Rustc version 1.31 or greater**.
+The 5.0 series of nom requires **Rustc version 1.36 or greater**.
 
 Travis CI always has a build with a pinned version of Rustc matching the oldest supported Rust release.
 The current policy is that this will only be updated in the next major nom release.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,7 +399,6 @@
 //! assert_eq!(alpha0_complete("abcd"), Ok(("", "abcd")));
 //! ```
 //! **Going further:** read the [guides](https://github.com/Geal/nom/tree/master/doc)!
-#![cfg_attr(all(not(feature = "std"), feature = "alloc"), feature(alloc))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "cargo-clippy", allow(doc_markdown))]
 #![cfg_attr(nightly, feature(test))]


### PR DESCRIPTION
**Metadata**

related to: #1038 
required rustc version bump: from v1.31 to v1.36

**Content**

The `alloc` feature got stabilized in rustc v1.36 and it is therefore possible to remove the feature gate and compile the crate with `alloc` feature enabled with the stable toolchain.

... fixes #1038 


