### PR TITLE
Use once_cell instead of lazy_static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,15 @@ alloc = []
 std = ["alloc", "memchr/use_std"]
 default = ["std", "lexical"]
 regexp = ["regex"]
-regexp_macros = ["regexp", "lazy_static"]
+regexp_macros = ["regexp", "once_cell"]
 lexical = ["lexical-core"]
 
 [dependencies.regex]
 version = "^1.0"
 optional = true
 
-[dependencies.lazy_static]
-version = "^1.0"
+[dependencies.once_cell]
+version = "^1.2"
 optional = true
 
 [dependencies.memchr]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,8 +410,7 @@
 #[macro_use]
 extern crate alloc;
 #[cfg(feature = "regexp_macros")]
-#[macro_use]
-extern crate lazy_static;
+extern crate once_cell;
 extern crate memchr;
 #[cfg(feature = "regexp")]
 pub extern crate regex;

--- a/src/regexp.rs
+++ b/src/regexp.rs
@@ -2,9 +2,9 @@
 #[macro_export]
 macro_rules! regex (
   ($re: ident, $s:expr) => (
-    lazy_static! {
-      static ref $re: $crate::lib::regex::Regex = $crate::lib::regex::Regex::new($s).unwrap();
-    }
+    static $re: once_cell::sync::Lazy<$crate::lib::regex::Regex> = once_cell::sync::Lazy::new(|| {
+      $crate::lib::regex::Regex::new($s).unwrap()
+    });
   );
 );
 
@@ -12,9 +12,9 @@ macro_rules! regex (
 #[macro_export]
 macro_rules! regex_bytes (
   ($re: ident, $s:expr) => (
-    lazy_static! {
-      static ref $re: $crate::lib::regex::bytes::Regex = $crate::lib::regex::bytes::Regex::new($s).unwrap();
-    }
+    static $re: once_cell::sync::Lazy<$crate::lib::regex::bytes::Regex> = once_cell::sync::Lazy::new(|| {
+      $crate::lib::regex::bytes::Regex::new($s).unwrap()
+    });
   );
 );
 


### PR DESCRIPTION
`once_cell` provides a neat way of initializing lazy singletons without macro.

# references

* RFC: https://github.com/matklad/rfcs/blob/std-lazy/text/0000-standard-lazy-types.md
* crate: https://crates.io/crates/once_cell
* async_std: https://github.com/async-rs/async-std/issues/406