### PR TITLE
Fix document formatting for character::complete::digit0

### DIFF
--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -365,11 +365,22 @@ where
 }
 
 /// Recognizes zero or more ASCII numerical characters: 0-9
+///
+/// *complete version*: Will return the whole input if no terminating token is found (a non digit
+/// character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::character::complete::digit0;
+/// # fn main() {
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     digit0(input)
 /// }
 ///
 /// assert_eq!(parser("21c"), Ok(("c", "21")));
+/// assert_eq!(parser("21"), Ok(("", "21")));
 /// assert_eq!(parser("a21c"), Ok(("a21c", "")));
 /// assert_eq!(parser(""), Ok(("", "")));
 /// # }


### PR DESCRIPTION
* adds one new line, an additional assert_eq test in the documentation example to show
  what happens for the complete case at EOF
* the previous commit (git: 24ef7f1ec) should have only affected line 373, but also 
  deleted lines 374-383.
* replaces lines 374-383 for fix the formatting for the code sample and to make the doc test
  pass.

See lines 374-383 from nom/character/complete.rs in this diff of the prior commit: 
https://github.com/Geal/nom/commit/24ef7f1ecf1c955021e1e5f5d286a12d31b71416#diff-fb690cc45adbb1b733633d0400062f0dL373

## Prerequisites

* this is a documentation fix
* rebased to current master.
* single commit