### PR TITLE
Updating doc reference to util::dbg_dmp

### DIFF
--- a/doc/making_a_new_parser_from_scratch.md
+++ b/doc/making_a_new_parser_from_scratch.md
@@ -189,7 +189,7 @@ this function wraps a parser that accepts a `&[u8]` as input and
 prints its hexdump if the child parser encountered an error:
 
 ```rust
-use nom::{util::dbg_dmp, bytes::complete::tag};
+use nom::{dbg_dmp, bytes::complete::tag};
 
 fn f(i: &[u8]) -> IResult<&[u8], &[u8]> {
   dbg_dmp(tag("abcd"))(i)


### PR DESCRIPTION
util isn't exported, but dbg_dmp is `pub use`d, so it can be imported directly from nom.