### PR TITLE
Update bits example

### DIFF
--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -23,10 +23,10 @@ use crate::traits::{Slice, ErrorConvert};
 /// # #[macro_use] extern crate nom;
 /// # use nom::IResult;
 /// use nom::bits::bits;
-/// use nom::bits::complete::take_bits;
+/// use nom::bits::complete::take;
 ///
 /// fn take_4_bits(input: &[u8]) -> IResult<&[u8], u64> {
-///   bits( take_bits(4usize) )(input)
+///   bits(take::<_, _, _, (_, _)>(4usize))(input)
 /// }
 ///
 /// let input = vec![0xAB, 0xCD, 0xEF, 0x12];
@@ -117,4 +117,3 @@ where
 {
   bytes(parser)(input)
 }
-


### PR DESCRIPTION
The bits example at https://docs.rs/nom/5.0.1/nom/bits/fn.bits.html appears to be outdated. The function name for `take` is wrong and it is missing a type annotation.

Compiling without `<_, _, _, (_, _)>` raises the following:

```
error[E0283]: type annotations required: cannot resolve `_: nom::error::ParseError<(&[u8], usize)>`
z
    bits::bits(bits::complete::take(4usize))(input)
    ^^^^^^^^^^

   pub fn bits<I, O, E1: ParseError<(I, usize)>+ErrorConvert<E2>, E2: ParseError<I>, P>(parser: P) -> impl Fn(I) -> IResult<I, O, E2>
                         ---------------------- required by this bound in `nom::bits::bits`
```