### PR TITLE
Add inline attribute to the to_usize functions

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1109,22 +1109,26 @@ impl ExtendInto for char {
 /// with 32 and 64 bits pointer platforms
 pub trait ToUsize {
   /// converts self to usize
+  #[inline]
   fn to_usize(&self) -> usize;
 }
 
 impl ToUsize for u8 {
+  #[inline]
   fn to_usize(&self) -> usize {
     *self as usize
   }
 }
 
 impl ToUsize for u16 {
+  #[inline]
   fn to_usize(&self) -> usize {
     *self as usize
   }
 }
 
 impl ToUsize for usize {
+  #[inline]
   fn to_usize(&self) -> usize {
     *self
   }
@@ -1132,6 +1136,7 @@ impl ToUsize for usize {
 
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUsize for u32 {
+  #[inline]
   fn to_usize(&self) -> usize {
     *self as usize
   }
@@ -1139,6 +1144,7 @@ impl ToUsize for u32 {
 
 #[cfg(target_pointer_width = "64")]
 impl ToUsize for u64 {
+  #[inline]
   fn to_usize(&self) -> usize {
     *self as usize
   }


### PR DESCRIPTION
The nom take parser automatically converts it's argument to usize
using to_usize.

However, if the argument is already usize, this should be a no-op and
the compiler should just skip the call. Surprisingly, during my tests,
I noticed that a large part of the cycles were wasted in
to_usize(usize).

Adding the [inline] attribute fixes it for me.

Example:

Before the change, the parser would take 29,606,796,156 cycles.
After the change, the parser only takes 9,245,008,172 cycles.
This translates in runtime decreasing from 7.6 seconds to 2.8 seconds.

Thanks for nom! It's an awesome library.

