### PR TITLE
Escaped parsers empty input fix

### DIFF
--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -452,6 +452,10 @@ where
   use crate::traits::AsChar;
 
   move |input: Input| {
+    if input.input_len() == 0 {
+      return Err(Err::Error(Error::from_error_kind(input, ErrorKind::Escaped)));
+    }
+
     let mut i = input.clone();
 
     while i.input_len() > 0 {
@@ -562,6 +566,10 @@ where
   use crate::traits::AsChar;
 
   move |input: Input| {
+    if input.input_len() == 0 {
+      return Err(Err::Error(Error::from_error_kind(input, ErrorKind::EscapedTransform)));
+    }
+
     let mut index = 0;
     let mut res = input.new_builder();
 

--- a/tests/escaped.rs
+++ b/tests/escaped.rs
@@ -23,3 +23,14 @@ fn test_escaped() {
 fn test_escaped_transform() {
     assert_eq!(esc_trans("abcd"), Err(Err::Error(("abcd", ErrorKind::EscapedTransform))));
 }
+
+#[test]
+fn test_escaped_empty() {
+    assert_eq!(esc(""), Err(Err::Error(("", ErrorKind::Escaped))));
+}
+
+#[test]
+#[cfg(feature="alloc")]
+fn test_escaped_transform_empty() {
+    assert_eq!(esc_trans(""), Err(Err::Error(("", ErrorKind::EscapedTransform))));
+}

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -298,3 +298,16 @@ fn issue_many_m_n_with_zeros() {
     let parser = many_m_n::<_, _, (), _>(0, 0, char('a'));
     assert_eq!(parser("aaa"), Ok(("aaa", vec!())));
 }
+
+#[test]
+fn issue_1082() {
+    use nom::bytes::complete::escaped_transform;
+    use nom::multi::many1;
+    use nom::IResult;
+    use nom::character::complete::{alpha1, char, one_of};
+
+    fn parser(i: &str) -> IResult<&str, Vec<String>> {
+        many1(escaped_transform(alpha1, '\\', one_of(r#"\\"#)))(i)
+    }
+    assert_eq!(parser("aaa\\\\"), Ok(("", vec!["aaa\\".to_owned()])));
+}


### PR DESCRIPTION
## Issue:
During the migration from nom 4 to nom 5 we found the following regression:
```
many!(escaped_transform(..)) 
```
Produced the `Many1` error, which is produced by indefinite cycle, which was related to `escaped_transform` behaviour, when empty input produces empty output.

## Test cases:
- integration regression test in `issues.rs`
- 2 unit tests in `escaped.rs`

## Solution:
Check the input length  before and return error in **complete** versions.

## Questions:
- Should **escaped** return error only if inner parser return error on empty output?
- Should **stream** versions be fixed in the similar way?

