### PR TITLE
Fix length_data docs

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -895,9 +895,7 @@ where
 
 /// Gets a number from the first parser,
 /// takes a subslice of the input of that size,
-/// then applies the second parser on that subslice.
-/// If the second parser returns Incomplete,
-/// length_value will return an error.
+/// and returns that subslice.
 /// # Arguments
 /// * `f` The parser to apply.
 /// ```rust


### PR DESCRIPTION
Looks like it was copy/pasted without changes from `length_value` at some point