### PR TITLE
Fix take_while_m_n utf8 where all input chars are matching

### DIFF
--- a/src/bytes/macros.rs
+++ b/src/bytes/macros.rs
@@ -863,6 +863,12 @@ mod tests {
     assert_eq!(parser("😃!"), Ok(("!", "😃")));
   }
 
+  #[test]
+  fn take_while_m_n_utf8_full_match() {
+    named!(parser<&str, &str>, take_while_m_n!(1, 1, |c: char| c.is_alphabetic()));
+    assert_eq!(parser("øn"), Ok(("n", "ø")));
+  }
+
   #[cfg(nightly)]
   use test::Bencher;
 

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -282,8 +282,10 @@ where
       None => {
         let len = input.input_len();
         if len >= n {
-          let res: IResult<_, _, Error> = Ok(input.take_split(n));
-          res
+          match input.slice_index(n) {
+            Some(index) => Ok(input.take_split(index)),
+            None => Err(Err::Error(Error::from_error_kind(input, ErrorKind::TakeWhileMN)))
+          }
         } else {
           let needed = if m > len { m - len } else { 1 };
           Err(Err::Incomplete(Needed::Size(needed)))


### PR DESCRIPTION
## Prerequisites

Related issue: #913 (take_while_m_n fails on multi-byte characters)

`take_while_m_n` panics when all of the input characters match the predicate, and `n` is smaller than the input (string is split in the middle of a multibyte char).

On the other hand: `take_while_m_n` seems to be inefficient when it cannot find a predicate complement. It appears to scan the complete string in that case, even if a string length equal to `n` is found before the end of string. I have not fixed this, just the panic.