### PR TITLE
Fix typo in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 //! software like [lex](https://en.wikipedia.org/wiki/Lex_(software)) and
 //! [yacc](https://en.wikipedia.org/wiki/Yacc). Instead of writing the grammar
 //! in a separate syntax and generating the corresponding code, you use very small
-//! functions with a very specific purposes, like "take 5 bytes", or "recognize the
+//! functions with very specific purposes, like "take 5 bytes", or "recognize the
 //! word 'HTTP'", and assemble them in meaningful patterns like "recognize
 //! 'HTTP', then a space, then a version".
 //! The resulting code is small, and looks like the grammar you would have

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,8 @@
 //! software like [lex](https://en.wikipedia.org/wiki/Lex_(software)) and
 //! [yacc](https://en.wikipedia.org/wiki/Yacc). Instead of writing the grammar
 //! in a separate syntax and generating the corresponding code, you use very small
-//! functions with a very specific purpose, like "take 5 bytes", or "recognize the
-//! word 'HTTP'", and assemble then in meaningful patterns like "recognize
+//! functions with a very specific purposes, like "take 5 bytes", or "recognize the
+//! word 'HTTP'", and assemble them in meaningful patterns like "recognize
 //! 'HTTP', then a space, then a version".
 //! The resulting code is small, and looks like the grammar you would have
 //! written with other parser approaches.


### PR DESCRIPTION
This PR fixes a minor grammatical error and a minor typo in the docs in src/lib.rs the diff is tiny and should be easy to check for correctness.

* purpose -> purposes
* then -> them