### PR TITLE
Upgraded jemallocator dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ optional = true
 
 [dev-dependencies]
 criterion = "0.2"
-jemallocator = "^0.1"
+jemallocator = "^0.3"
 doc-comment = "0.3"
 
 [build-dependencies]


### PR DESCRIPTION
This PR just upgrades jemalloc and criterion to the latest supported versions. It does not require any code change, and tests seem to pass. It updates the two missing dependencies after #1101 and #1073 (or #950) get merged.

The API does not change, so this can be released as a minor version.
