### PR TITLE
Make `error::context()` available without `alloc` feature

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -114,13 +114,11 @@ impl<I> ParseError<I> for VerboseError<I> {
   }
 }
 
-#[cfg(feature = "alloc")]
 use crate::internal::{Err, IResult};
 
 /// create a new error from an input position, a static string and an existing error.
 /// This is used mainly in the [context] combinator, to add user friendly information
 /// to errors when backtracking through a parse tree
-#[cfg(feature = "alloc")]
 pub fn context<I: Clone, E: ParseError<I>, F, O>(context: &'static str, f: F) -> impl Fn(I) -> IResult<I, O, E>
 where
   F: Fn(I) -> IResult<I, O, E>,


### PR DESCRIPTION
Currently [`nom::error::context()`](https://docs.rs/nom/5.1.0/nom/error/fn.context.html) is available only when `alloc` feature is enabled.
However, [`Clone` trait is available in nostd build](https://doc.rust-lang.org/stable/core/clone/trait.Clone.html), and `nom::error::context()` would be still useful for no-`alloc` environment (especially when the input type `I` is `&str`).

This pull request makes `context()` available even when `alloc` feature is not enabled.