### PR TITLE
Allow lexical-core 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ version = "^2.0"
 default-features = false
 
 [dependencies.lexical-core]
-version = "^0.6.0"
+version = ">= 0.6, < 0.8"
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
[No APIs changed between 0.6 and 0.7](https://github.com/Alexhuszagh/rust-lexical/blob/master/lexical-core/CHANGELOG). The minimum Rust version was increased, but as this PR only *adds* a new allowed version, the previous version can still be used by downstream users of nom that need to maintain compatibility.