### PR TITLE
Add auxiliary data support.

### DIFF
--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -316,3 +316,19 @@ fn issue_1027_convert_error_panic_nonempty() {
   let msg = convert_error(&input, err);
   assert_eq!(msg, "0: at line 1:\na\n ^\nexpected \'b\', got end of input\n\n");
 }
+
+#[test]
+#[should_panic]
+fn issue_1120_trigger_stack_overlow() {
+  fn cp(i: &str) -> nom::IResult<&str, &str> {
+    use nom::branch::alt;
+    use nom::bytes::complete::tag;
+    use nom::sequence::delimited;
+
+    delimited(tag("("), alt((tag("x"), cp)), tag(")"))(i)
+  }
+
+  let n = 10000;
+  let buffer: String = (0..n).map(|_| '(').chain(vec!['x'].into_iter()).chain((0..n).map(|_| ')')).collect();
+  println!("{:?}", cp(&buffer));
+}


### PR DESCRIPTION
This is a non-invasive extension to allow for a limited form of the feature described in #1120.

The solution itself is a new input type, that is initialized with some extra data in addition to the input itself. This extra data is then readable by the users during parsing.

This way the administration of recursion depth of the parsers is left to the library users, which adds flexibitlity with the customary built-in footgun.