### PR TITLE
Add `success` combinator returning the given value without consuming

### DIFF
--- a/doc/choosing_a_combinator.md
+++ b/doc/choosing_a_combinator.md
@@ -133,6 +133,7 @@ Whitespace delimited formats parsing
 - `named_args!`: Makes a function from a parser combination with arguments.
 - `named_attr!`: Makes a function from a parser combination, with attributes
 - `try_parse!`: A bit like `std::try!`, this macro will return the remaining input and parsed value if the child parser returned `Ok`, and will do an early return for `Error` and `Incomplete`. This can provide more flexibility than `do_parse!` if needed.
+- `success`: Returns a value without consuming any input, always succeeds.
 
 ## Character test functions
 

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -760,6 +760,35 @@ enum State<E> {
   Incomplete(Needed),
 }
 
+/// a parser which always succeeds with given value without consuming any input.
+///
+/// It can be used for example as the last alternative in `alt` to
+/// specify the default case.
+///
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err,error::ErrorKind, IResult};
+/// use nom::branch::alt;
+/// use nom::combinator::{success, value};
+/// use nom::character::complete::char;
+/// # fn main() {
+///
+/// let mut parser = success::<_,_,(_,ErrorKind)>(10);
+/// assert_eq!(parser("xyz"), Ok(("xyz", 10)));
+///
+/// let mut sign = alt((value(-1, char('-')), value(1, char('+')), success::<_,_,(_,ErrorKind)>(1)));
+/// assert_eq!(sign("+10"), Ok(("10", 1)));
+/// assert_eq!(sign("-10"), Ok(("10", -1)));
+/// assert_eq!(sign("10"), Ok(("10", 1)));
+/// # }
+/// ```
+pub fn success<I: Clone + Slice<RangeTo<usize>>, O: Clone, E: ParseError<I>>(val: O) -> impl Fn(I) -> IResult<I, O, E>
+{
+  move |input: I| {
+    Ok((input, val.clone()))
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;


### PR DESCRIPTION
Hi Geoffroy,

This pull request adds a new `success` parser which is basically like `pure` parser in Haskell Parsec or other parser combinator libraries. It always succeeds, consumes nothing and returns a  given value. I know that it can be achieved with `value!` macro, but I thought since version 5 using macros are discouraged.

My use case for this macro is included as the doc test, it is a parser for optional sign which I wanted to express like this:

```
alt((value(1, char('+')), value(-1, char('-')), success(1))) 
```

Using `success` here allows to specify a default for `alt` which might be quite useful. It is of course possible to achieve it using just a closure `|i| Ok((i, 1))`, but I think having a special combinator is more idiomatic.