### PR TITLE
multi/count: initial capacity on result Vec

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -633,7 +633,7 @@ where
 {
   move |i: I| {
     let mut input = i.clone();
-    let mut res = crate::lib::std::vec::Vec::new();
+    let mut res = crate::lib::std::vec::Vec::with_capacity(count);
 
     for _ in 0..count {
       let input_ = input.clone();


### PR DESCRIPTION
The resulting length of the output Vec is known on success because
`count` is provided as an argument. Set the initial capacity of this
Vec to avoid unnecessary allocations.

Bench results for success case on 2010 MBP (not committed but available [here](https://github.com/simdugas/nom/commit/94dabcd1addb645cddc2a30f24d0dbc6bdaffe04)):
```
Finished bench [optimized + debuginfo] target(s) in 1m 55s
Running /nom/target/release/deps/count-e13e3d0ce6130515
count                   time:   [10.143 us 10.211 us 10.305 us]
                        change: [-22.146% -20.367% -18.235%] (p = 0.00 < 0.05)
                        Performance has improved.
```