### PR TITLE
Fix docs for IResult

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -7,7 +7,7 @@ use core::num::NonZeroUsize;
 /// Holds the result of parsing functions
 ///
 /// It depends on the input type `I`, the output type `O`, and the error type `E`
-/// (by default `(I, ErrorKind)`)
+/// (by default `(I, nom::ErrorKind)`)
 ///
 /// The `Ok` side is a pair containing the remainder of the input (the part of the data that
 /// was not parsed) and the produced value. The `Err` side contains an instance of `nom::Err`.

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -6,7 +6,8 @@ use core::num::NonZeroUsize;
 
 /// Holds the result of parsing functions
 ///
-/// It depends on I, the input type, O, the output type, and E, the error type (by default u32)
+/// It depends on the input type `I`, the output type `O`, and the error type `E`
+/// (by default `(I, ErrorKind)`)
 ///
 /// The `Ok` side is a pair containing the remainder of the input (the part of the data that
 /// was not parsed) and the produced value. The `Err` side contains an instance of `nom::Err`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@
 //! fn parser(input: I) -> IResult<I, O, E>;
 //! ```
 //!
-//! Or like this, if you don't want to specify a custom error type (it will be `u32` by default):
+//! Or like this, if you don't want to specify a custom error type (it will be `(I, ErrorKind)` by default):
 //!
 //! ```rust,ignore
 //! fn parser(input: I) -> IResult<I, O>;


### PR DESCRIPTION
First time looking at `nom`, and I noticed the default type for `E` is incorrectly documented. I also tried to increase readability by removing redundant commas.