### PR TITLE
Add custom errors example

### DIFF
--- a/doc/error_management.md
+++ b/doc/error_management.md
@@ -87,6 +87,9 @@ expected '}', found 1
   ^
 ```
 
+See [examples/custom_error.rs](https://github.com/Geal/nom/blob/master/examples/custom_error.rs)
+for an example of example of implementing your custom errors.
+
 ## Debugging parsers
 
 While you are writing your parsers, you will sometimes need to follow

--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -1,0 +1,42 @@
+extern crate nom;
+
+use nom::error::ErrorKind;
+use nom::error::ParseError;
+use nom::Err::Error;
+use nom::IResult;
+
+#[derive(Debug, PartialEq)]
+pub enum CustomError<I> {
+  MyError,
+  Nom(I, ErrorKind),
+}
+
+impl<I> ParseError<I> for CustomError<I> {
+  fn from_error_kind(input: I, kind: ErrorKind) -> Self {
+    CustomError::Nom(input, kind)
+  }
+
+  fn append(_: I, _: ErrorKind, other: Self) -> Self {
+    other
+  }
+}
+
+fn parse(input: &str) -> IResult<&str, &str, CustomError<&str>> {
+  Err(Error(CustomError::MyError))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::parse;
+  use super::CustomError;
+  use nom::Err::Error;
+
+  #[test]
+  fn it_works() {
+    let err = parse("").unwrap_err();
+    match err {
+      Error(e) => assert_eq!(e, CustomError::MyError),
+      _ => panic!("Unexpected error: {:?}", err),
+    }
+  }
+}


### PR DESCRIPTION
Hello,

First, thanks for this awesome crate that make parsing more accessible to non-specialists in my opinion.

I'm fairly new to rust and had a hard time figuring out how to have my own errors. It's the only things I had to battle with during man short nom usage. So now (I think) I've found how, I would like to add an example to avoid the same hassles for future users.

I wish you the best for your personal problems.