### PR TITLE
Fix a small typo regarding the release date, in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 - `convert_error` optimization
 - `alt` optimization
 
-## 5.0.1 - 2020-08-22
+## 5.0.1 - 2019-08-22
 
 ### Thanks
 


### PR DESCRIPTION
5.0.1 was released on 22 Aug 2019 , *not* on 2020! 😀 

See: https://github.com/Geal/nom/commit/c326e077b83c62f81b717c80a281cb453cb914e7
