### PR TITLE
Add OTDR file parser to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Here is a (non exhaustive) list of known projects using nom:
 - Misc formats:
   * [Gameboy ROM](https://github.com/MarkMcCaskey/gameboy-rom-parser)
   * [ANT FIT](https://github.com/stadelmanma/fitparse-rs)
+  * [Telcordia/Bellcore SR-4731 SOR OTDR files](https://github.com/JamesHarrison/otdrs)
 
 Want to create a new parser using `nom`? A list of not yet implemented formats is available [here](https://github.com/Geal/nom/issues/14).
 


### PR DESCRIPTION
Nice and easy one (much like writing my first parser with nom - thanks for this!) - adding a OTDR SOR file parser to the README list of parsers.

