### PR TITLE
Allow empty elements in separated_list

### DIFF
--- a/src/multi/macros.rs
+++ b/src/multi/macros.rs
@@ -583,6 +583,7 @@ mod tests {
   fn separated_list0() {
     named!(multi<&[u8],Vec<&[u8]> >, separated_list0!(tag!(","), tag!("abcd")));
     named!(multi_empty<&[u8],Vec<&[u8]> >, separated_list0!(tag!(","), tag!("")));
+    named!(empty_sep<&[u8],Vec<&[u8]> >, separated_list0!(tag!(""), tag!("abc")));
     named!(multi_longsep<&[u8],Vec<&[u8]> >, separated_list0!(tag!(".."), tag!("abcd")));
 
     let a = &b"abcdef"[..];
@@ -593,18 +594,20 @@ mod tests {
     let f = &b"abc"[..];
     let g = &b"abcd."[..];
     let h = &b"abcd,abc"[..];
+    let i = &b"abcabc"[..];
 
     let res1 = vec![&b"abcd"[..]];
     assert_eq!(multi(a), Ok((&b"ef"[..], res1)));
     let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
     assert_eq!(multi(b), Ok((&b"ef"[..], res2)));
     assert_eq!(multi(c), Ok((&b"azerty"[..], Vec::new())));
+    let res3 = vec![&b""[..], &b""[..], &b""[..]];
+    assert_eq!(multi_empty(d), Ok((&b"abc"[..], res3)));
+    let i_err_pos = &i[3..];
     assert_eq!(
-      multi_empty(d),
-      Err(Err::Error(error_position!(d, ErrorKind::SeparatedList)))
+      empty_sep(i),
+      Err(Err::Error(error_position!(i_err_pos, ErrorKind::SeparatedList)))
     );
-    //let res3 = vec![&b""[..], &b""[..], &b""[..]];
-    //assert_eq!(multi_empty(d),Ok((&b"abc"[..], res3)));
     let res4 = vec![&b"abcd"[..], &b"abcd"[..]];
     assert_eq!(multi(e), Ok((&b",ef"[..], res4)));
 

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -255,10 +255,6 @@ where
       Err(Err::Error(_)) => return Ok((i, res)),
       Err(e) => return Err(e),
       Ok((i1, o)) => {
-        if i1 == i {
-          return Err(Err::Error(E::from_error_kind(i1, ErrorKind::SeparatedList)));
-        }
-
         res.push(o);
         i = i1;
       }
@@ -277,10 +273,6 @@ where
             Err(Err::Error(_)) => return Ok((i, res)),
             Err(e) => return Err(e),
             Ok((i2, o)) => {
-              if i2 == i {
-                return Err(Err::Error(E::from_error_kind(i2, ErrorKind::SeparatedList)));
-              }
-
               res.push(o);
               i = i2;
             }
@@ -345,10 +337,6 @@ where
     match f.parse(i.clone()) {
       Err(e) => return Err(e),
       Ok((i1, o)) => {
-        if i1 == i {
-          return Err(Err::Error(E::from_error_kind(i1, ErrorKind::SeparatedList)));
-        }
-
         res.push(o);
         i = i1;
       }
@@ -367,10 +355,6 @@ where
             Err(Err::Error(_)) => return Ok((i, res)),
             Err(e) => return Err(e),
             Ok((i2, o)) => {
-              if i2 == i {
-                return Err(Err::Error(E::from_error_kind(i2, ErrorKind::SeparatedList)));
-              }
-
               res.push(o);
               i = i2;
             }


### PR DESCRIPTION
There's no particular reason why empty elements shouldn't be allowed in the separated_list[0|1] macros and functions. It's useful to be able to parse things like CSV `",,,foo"`.

An empty separator is still not allowed.

This change includes test coverage of both cases (where the previous tests were, in `macros.rs`; not sure if more is expected in `issues.rs`.

This is intended to address #1063. (There seem to be older reports as well, but that's the one that's still open.)

An example of code that wouldn't work before, and does after this change:
```rust
use nom::IResult;
use nom::bytes::complete::tag;
use nom::multi::separated_list0;
use nom::character::complete::alphanumeric0;

fn comma_separated_text(input: &str) -> IResult<&str, Vec<&str>> {
    separated_list0(tag(","), alphanumeric0)(input)
}

#[test]
fn test_comma_separated() {
    assert_eq!(comma_separated_text("a,b,c"), Ok(("", vec!["a", "b", "c"])));
    assert_eq!(comma_separated_text(",,c"), Ok(("", vec!["", "", "c"])));
}

```