### PR TITLE
Remove unnecessary requirements on success()

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -782,11 +782,8 @@ enum State<E> {
 /// assert_eq!(sign("10"), Ok(("10", 1)));
 /// # }
 /// ```
-pub fn success<I: Clone + Slice<RangeTo<usize>>, O: Clone, E: ParseError<I>>(val: O) -> impl Fn(I) -> IResult<I, O, E>
-{
-  move |input: I| {
-    Ok((input, val.clone()))
-  }
+pub fn success<I, O: Clone, E: ParseError<I>>(val: O) -> impl Fn(I) -> IResult<I, O, E> {
+  move |input: I| Ok((input, val.clone()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The `Clone + Slice<RangeTo<usize>>` requirement on `I` is unnecessary, since the `success()` combinator just moves `input`. I also removed the braces to keep the style in line with `value()`.