### PR TITLE
Simplify branching parsers

### DIFF
--- a/src/branch/macros.rs
+++ b/src/branch/macros.rs
@@ -566,6 +566,7 @@ macro_rules! succ (
   (17, $submac:ident ! ($($rest:tt)*)) => ($submac!(18, $($rest)*));
   (18, $submac:ident ! ($($rest:tt)*)) => ($submac!(19, $($rest)*));
   (19, $submac:ident ! ($($rest:tt)*)) => ($submac!(20, $($rest)*));
+  (20, $submac:ident ! ($($rest:tt)*)) => ($submac!(21, $($rest)*));
 );
 
 #[doc(hidden)]


### PR DESCRIPTION
A few updates to `alt()` and `permutation()`:
- Return nested error from `permutation()` (resolves a `FIXME`)
- Document that `permutation()` does not backtrack
- Avoid unnecessary `unwrap()`s in `alt()` by pattern matching
- Simplify macro base cases