### PR TITLE
Add `bitvec` and implement support for it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,16 @@ include = [
 ]
 
 [features]
-alloc = []
-std = ["alloc", "memchr/use_std"]
-default = ["std", "lexical"]
+alloc = ["bitvec/alloc"]
+std = ["alloc", "bitvec/std", "memchr/use_std"]
+default = ["std", "bitvec", "lexical"]
 regexp = ["regex"]
 lexical = ["lexical-core"]
+
+[dependencies.bitvec]
+version = "0.19"
+optional = true
+default-features = false
 
 [dependencies.regex]
 version = "^1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,6 +407,8 @@
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 #[macro_use]
 extern crate alloc;
+#[cfg(feature = "bitvec")]
+extern crate bitvec;
 #[cfg(doctest)]
 extern crate doc_comment;
 #[cfg(feature = "lexical")]

--- a/tests/bitstream.rs
+++ b/tests/bitstream.rs
@@ -1,0 +1,16 @@
+#![cfg(feature = "bitvec")]
+
+use bitvec::prelude::*;
+use nom::{bytes::complete::tag, IResult};
+
+#[test]
+fn parse_bitstream() {
+  let data = [0xA5u8, 0x69, 0xF0, 0xC3];
+  let bits = data.view_bits::<Msb0>();
+
+  fn parser(bits: &BitSlice<Msb0, u8>) -> IResult<&BitSlice<Msb0, u8>, &BitSlice<Msb0, u8>> {
+    tag(bits![1, 0, 1, 0])(bits)
+  }
+
+  assert_eq!(parser(bits), Ok((&bits[..4], &bits[4..])));
+}


### PR DESCRIPTION
The trait implementations permit `bitvec` types to be used directly
within the `bytes` parsers, as demonstrated by the `tests/bitstream`
module using `bytes::tag` to process a bitstream.

This unification allows the removal of the `bits` module in favor of
ordinary combinators written to be generic over a consumable input
type.

----

I don’t know if I've hit all of the trait implementations necessary to drop `BitSlice` in wherever `[T]` is currently usable, but as the test file shows, `tag` at least works.

The slice-like nature of `BitSlice` allows it to be used in the slice API equivalently to any other sequence type. This means that the `bits` module's special-cased behavior and index type can be removed completely.

I'm not familiar enough with `nom`’s codebase to be sure that I’ve fully integrated `bitvec` into the `nom` infrastructure. If you see anything more I need to do in the implementation, please let me know. I am also happy to produce documentation and an example for parsing bitstreams if and when we decide that the implementation is complete.

Note that `bitvec 0.19` is not yet on crates.io, nor are the support functions `nom` requires yet in the trunk branch. In order to compile this commit, you will need to apply this patch:

```diff
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@
 regexp = ["regex"]
 lexical = ["lexical-core"]

 [dependencies.bitvec]
-version = "0.19"
+git = "https://github.com/myrrlyn/bitvec"
+rev = "feature/21"
optional = true
default-features = false
```