### PR TITLE
Fix undefined behavior in JSON test/bench (#1195)

### DIFF
--- a/benches/json.rs
+++ b/benches/json.rs
@@ -11,7 +11,7 @@ use nom::{
   branch::alt,
   bytes::complete::{tag, take},
   character::complete::{anychar, char, multispace0, none_of},
-  combinator::{map, map_res, value},
+  combinator::{map, map_opt, map_res, value},
   error::{ErrorKind, ParseError},
   multi::{fold_many0, separated_list0},
   number::complete::{double, recognize_float},
@@ -50,11 +50,11 @@ fn character(input: &str) -> IResult<&str, char> {
           _ => return Err(()),
         })
       }),
-      map(
+      map_opt(
         map_res(preceded(char('u'), take(4usize)), |s| {
           u16::from_str_radix(s, 16)
         }),
-        |c| unsafe { std::char::from_u32_unchecked(c as u32) },
+        |c| std::char::from_u32(c as u32),
       ),
     ))(input)
   } else {

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -5,7 +5,7 @@ use nom::{
   branch::alt,
   bytes::complete::{tag, take},
   character::complete::{anychar, char, multispace0, none_of},
-  combinator::{map, map_res, value},
+  combinator::{map, map_opt, map_res, value},
   error::ParseError,
   multi::{fold_many0, separated_list0},
   number::complete::double,
@@ -44,11 +44,11 @@ fn character(input: &str) -> IResult<&str, char> {
           _ => return Err(()),
         })
       }),
-      map(
+      map_opt(
         map_res(preceded(char('u'), take(4usize)), |s| {
           u16::from_str_radix(s, 16)
         }),
-        |c| unsafe { std::char::from_u32_unchecked(c as u32) },
+        |c| std::char::from_u32(c as u32),
       ),
     ))(input)
   } else {


### PR DESCRIPTION
This fixes the undefined behavior caused by unsafely turning a u32 into a char without checking the necessary preconditions.
It also implements decoding surrogates if a Unicode escape sequence decodes to a high surrogate and a corresponding low surrogate is found in a directly adjacent second Unicode escape.

Fixes #1195.