### PR TITLE
Add vimwiki parser and associated macro library to list of parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Here is a (non exhaustive) list of known projects using nom:
   * [PDB](https://github.com/TianyiShi2001/nom-pdb)
   * [proto files](https://github.com/tafia/protobuf-parser)
   * [Fountain screenplay markup](https://github.com/adamchalmers/fountain-rs)
+  * [vimwiki](https://github.com/chipsenkbeil/vimwiki-server/tree/master/vimwiki) & [vimwiki_macros](https://github.com/chipsenkbeil/vimwiki-server/tree/master/vimwiki_macros)
 - Programming languages:
   * [PHP](https://github.com/tagua-vm/parser)
   * [Basic Calculator](https://github.com/balajisivaraman/basic_calculator_rs)


### PR DESCRIPTION
Both the library and macro library are functional and part of an effort to standardize the vimwiki language (see https://github.com/vimwiki/vimwiki/issues/989) as well as provide the foundation for tooling on top.