### PR TITLE
Correct Incomplete errors from length_data/value

### DIFF
--- a/src/bytes/macros.rs
+++ b/src/bytes/macros.rs
@@ -940,13 +940,13 @@ mod tests {
     named!(x, length_data!(le_u8));
     assert_eq!(x(b"\x02..>>"), Ok((&b">>"[..], &b".."[..])));
     assert_eq!(x(b"\x02.."), Ok((&[][..], &b".."[..])));
-    assert_eq!(x(b"\x02."), Err(Err::Incomplete(Needed::new(2))));
+    assert_eq!(x(b"\x02."), Err(Err::Incomplete(Needed::new(1))));
     assert_eq!(x(b"\x02"), Err(Err::Incomplete(Needed::new(2))));
 
     named!(y, do_parse!(tag!("magic") >> b: length_data!(le_u8) >> (b)));
     assert_eq!(y(b"magic\x02..>>"), Ok((&b">>"[..], &b".."[..])));
     assert_eq!(y(b"magic\x02.."), Ok((&[][..], &b".."[..])));
-    assert_eq!(y(b"magic\x02."), Err(Err::Incomplete(Needed::new(2))));
+    assert_eq!(y(b"magic\x02."), Err(Err::Incomplete(Needed::new(1))));
     assert_eq!(y(b"magic\x02"), Err(Err::Incomplete(Needed::new(2))));
   }
 

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -26,7 +26,8 @@ use crate::traits::{
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
 /// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Incomplete(Needed::new(5))));
+/// assert_eq!(parser("S"), Err(Err::Error(Error::new("S", ErrorKind::Tag))));
+/// assert_eq!(parser("H"), Err(Err::Incomplete(Needed::new(4))));
 /// ```
 pub fn tag<T, Input, Error: ParseError<Input>>(
   tag: T,

--- a/src/multi/macros.rs
+++ b/src/multi/macros.rs
@@ -368,7 +368,7 @@ macro_rules! length_count(
 /// named!(parser, length_data!(be_u8));
 ///
 /// assert_eq!(parser(&b"\x06abcabcabc"[..]), Ok((&b"abc"[..], &b"abcabc"[..])));
-/// assert_eq!(parser(&b"\x06abc"[..]), Err(Err::Incomplete(Needed::new(6))));
+/// assert_eq!(parser(&b"\x06abc"[..]), Err(Err::Incomplete(Needed::new(3))));
 /// # }
 /// ```
 #[macro_export(local_inner_macros)]
@@ -399,7 +399,7 @@ macro_rules! length_data(
 /// named!(parser, length_value!(be_u8, alpha0));
 ///
 /// assert_eq!(parser(&b"\x06abcabcabc"[..]), Ok((&b"abc"[..], &b"abcabc"[..])));
-/// assert_eq!(parser(&b"\x06abc"[..]), Err(Err::Incomplete(Needed::new(6))));
+/// assert_eq!(parser(&b"\x06abc"[..]), Err(Err::Incomplete(Needed::new(3))));
 /// # }
 /// ```
 #[macro_export(local_inner_macros)]
@@ -896,7 +896,7 @@ mod tests {
       take(&b"6abcabcabcdef"[..]),
       Ok((&b"abcdef"[..], &b"abcabc"[..]))
     );
-    assert_eq!(take(&b"3ab"[..]), Err(Err::Incomplete(Needed::new(3))));
+    assert_eq!(take(&b"3ab"[..]), Err(Err::Incomplete(Needed::new(1))));
     assert_eq!(
       take(&b"xxx"[..]),
       Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Digit)))

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -991,7 +991,7 @@ where
 pub fn length_data<I, N, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, I, E>
 where
   I: InputLength + InputTake,
-  N: Copy + ToUsize,
+  N: ToUsize,
   F: Parser<I, N, E>,
   E: ParseError<I>,
 {
@@ -1033,7 +1033,7 @@ where
 pub fn length_value<I, O, N, E, F, G>(mut f: F, mut g: G) -> impl FnMut(I) -> IResult<I, O, E>
 where
   I: Clone + InputLength + InputTake,
-  N: Copy + ToUsize,
+  N: ToUsize,
   F: Parser<I, N, E>,
   G: Parser<I, O, E>,
   E: ParseError<I>,
@@ -1060,7 +1060,7 @@ where
 pub fn length_valuec<I, O, N, E, F, G>(i: I, f: F, g: G) -> IResult<I, O, E>
 where
   I: Clone + InputLength + InputTake,
-  N: Copy + ToUsize,
+  N: ToUsize,
   F: Fn(I) -> IResult<I, N, E>,
   G: Fn(I) -> IResult<I, O, E>,
   E: ParseError<I>,
@@ -1095,7 +1095,7 @@ where
 pub fn length_count<I, O, N, E, F, G>(mut f: F, mut g: G) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
   I: Clone + InputLength + InputTake,
-  N: Copy + ToUsize,
+  N: ToUsize,
   F: Parser<I, N, E>,
   G: Parser<I, O, E>,
   E: ParseError<I>,

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -51,7 +51,7 @@ fn overflow_incomplete_length_bytes() {
 
   // Trigger an overflow in length_data
   assert_eq!(
-    multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff\xaa"[..]),
+    multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff"[..]),
     Err(Err::Incomplete(Needed::new(18446744073709551615)))
   );
 }
@@ -63,7 +63,7 @@ fn overflow_incomplete_many0() {
 
   // Trigger an overflow in many0
   assert_eq!(
-    multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef\xaa"[..]),
+    multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]),
     Err(Err::Incomplete(Needed::new(18446744073709551599)))
   );
 }
@@ -75,7 +75,7 @@ fn overflow_incomplete_many1() {
 
   // Trigger an overflow in many1
   assert_eq!(
-    multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef\xaa"[..]),
+    multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]),
     Err(Err::Incomplete(Needed::new(18446744073709551599)))
   );
 }
@@ -87,7 +87,7 @@ fn overflow_incomplete_many_till() {
 
   // Trigger an overflow in many_till
   assert_eq!(
-    multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef\xaa"[..]),
+    multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]),
     Err(Err::Incomplete(Needed::new(18446744073709551599)))
   );
 }
@@ -99,7 +99,7 @@ fn overflow_incomplete_many_m_n() {
 
   // Trigger an overflow in many_m_n
   assert_eq!(
-    multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef\xaa"[..]),
+    multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]),
     Err(Err::Incomplete(Needed::new(18446744073709551599)))
   );
 }
@@ -110,7 +110,7 @@ fn overflow_incomplete_count() {
   named!(counter<&[u8], Vec<&[u8]> >, count!( length_data!(be_u64), 2 ) );
 
   assert_eq!(
-    counter(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef\xaa"[..]),
+    counter(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]),
     Err(Err::Incomplete(Needed::new(18446744073709551599)))
   );
 }
@@ -122,7 +122,7 @@ fn overflow_incomplete_length_count() {
   named!(multi<&[u8], Vec<&[u8]> >, length_count!( be_u8, length_data!(be_u64) ) );
 
   assert_eq!(
-    multi(&b"\x04\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xee\xaa"[..]),
+    multi(&b"\x04\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xee"[..]),
     Err(Err::Incomplete(Needed::new(18446744073709551598)))
   );
 }
@@ -133,7 +133,7 @@ fn overflow_incomplete_length_data() {
   named!(multi<&[u8], Vec<&[u8]> >, many0!( length_data!(be_u64) ) );
 
   assert_eq!(
-    multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff\xaa"[..]),
+    multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff"[..]),
     Err(Err::Incomplete(Needed::new(18446744073709551615)))
   );
 }


### PR DESCRIPTION
I believe the doc-tests were wrong for these macros/functions. Any example from this patch should illustrate the issue, such as:

```rust
named!(x, length_data!(le_u8));
assert_eq!(x(b"\x02."), Err(Err::Incomplete(Needed::new(2))));
```

That parser should see the `\x02` and try to read two bytes, but there is only one available after that. That means it needs one more, but it currently reports that it needs all two.

I also wrote a couple other miscellaneous patches for things I spotted while fixing this: one to remove some unnecessary `Copy` constraints, and another to add some doc-tests to the `tag` parser for behavior that wasn't obvious to me from the documentation.