### PR TITLE
Add nom::character::is_newline function

### DIFF
--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -98,3 +98,19 @@ pub fn is_alphanumeric(chr: u8) -> bool {
 pub fn is_space(chr: u8) -> bool {
   chr == b' ' || chr == b'\t'
 }
+
+/// Tests if byte is ASCII newline: \n
+///
+/// # Example
+///
+/// ```
+/// # use nom::character::is_newline;
+/// assert_eq!(is_newline(b'\n'), true);
+/// assert_eq!(is_newline(b'\r'), false);
+/// assert_eq!(is_newline(b' '), false);
+/// assert_eq!(is_newline(b'\t'), false);
+/// ```
+#[inline]
+pub fn is_newline(chr: u8) -> bool {
+  chr == b'\n'
+}


### PR DESCRIPTION
The function is present in nom::character and tests if a byte is equal
to "\n".

This PR is related to https://github.com/Geal/nom/issues/1205

I also noticed that there are several char traits that use similar functions.
If this function is required to be included in such traits I'll be happy to add such changes.

If anything else is required I'm open to improve this PR
