### PR TITLE
Re-export bitvec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,7 +412,7 @@
 #[macro_use]
 extern crate alloc;
 #[cfg(feature = "bitvec")]
-extern crate bitvec;
+pub extern crate bitvec;
 #[cfg(doctest)]
 extern crate doc_comment;
 #[cfg(feature = "lexical")]


### PR DESCRIPTION
Re-export bitvec crate so that types necessary to create bit parsers are exposed.

I had considered a couple different ways of doing this:

- Re-export bitvec from `nom::bits`
- Create a `nom::bits::prelude` module that re-exports `bitvec::prelude::*`

Ultimately, the way it's being done in this PR seems straightforward and is similar to what's currently being done with the regex crate.