### PR TITLE
Remove #[deprecated] attribute from trait impl block

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -38,7 +38,6 @@ impl<'a> InputLength for &'a str {
   }
 }
 
-#[deprecated(since = "6.0.0", note = "Use `BitSlice`")]
 impl<'a> InputLength for (&'a [u8], usize) {
   #[inline]
   fn input_len(&self) -> usize {


### PR DESCRIPTION
The PR fixes the [nightly builds](https://github.com/nickelc/nom/runs/1363679867?check_suite_focus=true#step:4:40)

Deprecation attributes have no effect on trait implementations. See rust-lang/rust#78626