### PR TITLE
docs: Remove wrong call from a whitespace combinator example

### DIFF
--- a/doc/nom_recipes.md
+++ b/doc/nom_recipes.md
@@ -27,7 +27,7 @@ These are short recipes for accomplishing common tasks with nom.
 ```rust
 /// A combinator that takes a parser `inner` and produces a parser that also consumes both leading and 
 /// trailing whitespace, returning the output of `inner`.
-fn ws<'a, F: 'a, O, E: ParseError<&'a str>>(inner: F) -> impl Fn(&'a str) -> IResult<&'a str, O, E>
+fn ws<'a, F: 'a, O, E: ParseError<&'a str>>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O, E>
   where
   F: Fn(&'a str) -> IResult<&'a str, O, E>,
 {

--- a/doc/nom_recipes.md
+++ b/doc/nom_recipes.md
@@ -35,7 +35,7 @@ fn ws<'a, F: 'a, O, E: ParseError<&'a str>>(inner: F) -> impl Fn(&'a str) -> IRe
     multispace0,
     inner,
     multispace0
-  )(i)
+  )
 }
 ```
 


### PR DESCRIPTION
It tries to apply the returned function to source immediately when it should just return the combinator.