### PR TITLE
Relax bounds on fold_many* functions to accept FnMut for accum func

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -725,11 +725,11 @@ where
 /// assert_eq!(parser("123123"), Ok(("123123", vec![])));
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// ```
-pub fn fold_many0<I, O, E, F, G, R>(mut f: F, init: R, g: G) -> impl FnMut(I) -> IResult<I, R, E>
+pub fn fold_many0<I, O, E, F, G, R>(mut f: F, init: R, mut g: G) -> impl FnMut(I) -> IResult<I, R, E>
 where
   I: Clone + PartialEq,
   F: Parser<I, O, E>,
-  G: Fn(R, O) -> R,
+  G: FnMut(R, O) -> R,
   E: ParseError<I>,
   R: Clone,
 {
@@ -765,7 +765,7 @@ pub fn fold_many0c<I, O, E, F, G, R>(i: I, f: F, init: R, g: G) -> IResult<I, R,
 where
   I: Clone + PartialEq,
   F: Fn(I) -> IResult<I, O, E>,
-  G: Fn(R, O) -> R,
+  G: FnMut(R, O) -> R,
   E: ParseError<I>,
   R: Clone,
 {
@@ -803,11 +803,11 @@ where
 /// assert_eq!(parser("123123"), Err(Err::Error(Error::new("123123", ErrorKind::Many1))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Many1))));
 /// ```
-pub fn fold_many1<I, O, E, F, G, R>(mut f: F, init: R, g: G) -> impl FnMut(I) -> IResult<I, R, E>
+pub fn fold_many1<I, O, E, F, G, R>(mut f: F, init: R, mut g: G) -> impl FnMut(I) -> IResult<I, R, E>
 where
   I: Clone + PartialEq,
   F: Parser<I, O, E>,
-  G: Fn(R, O) -> R,
+  G: FnMut(R, O) -> R,
   E: ParseError<I>,
   R: Clone,
 {
@@ -850,7 +850,7 @@ pub fn fold_many1c<I, O, E, F, G, R>(i: I, f: F, init: R, g: G) -> IResult<I, R,
 where
   I: Clone + PartialEq,
   F: Fn(I) -> IResult<I, O, E>,
-  G: Fn(R, O) -> R,
+  G: FnMut(R, O) -> R,
   E: ParseError<I>,
   R: Clone,
 {


### PR DESCRIPTION
This PR relaxes the requirement on the accumulator function to the fold_many* family of functions in order to allow FnMuts to be passed. This seems in line with the stated goals of the version 6 bump, and is strictly additive. 
It would be nice to also remove the Clone bound from the init value, however that doesn't seem possible for now. 
If this seems pretty weird, it is because I'm trying to use fold_many to accumulate on a value that does not implement Clone. So I have developed the following pattern for an expression list, which I find to be quite pleasant:
```rust
pub fn expr_list<'a>(input: &'a str) -> IResult<&'a str, Vec<Expr<'a>>> { 
    expr(input).and_then(
        |(i, e)| {
            let mut exprs = vec![e];
            let res = fold_many0(
                preceded(tag(","), expr),
                (),
                |_, e| {
                    exprs.push(e);
                }
            )(i);
            res.map(|(i, _)| (i, exprs))
        }
    )
}
```
In this example, `Expr` does not implement Clone. 

Edit: fixed example so that it compiles.