### PR TITLE
Add D-Bus parser to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Here is a (non exhaustive) list of known projects using nom:
 [X.509](https://github.com/rusticata/x509-parser)
 - Network protocol formats:
 [Bencode](https://github.com/jbaum98/bencode.rs),
+[D-Bus](https://github.com/toshokan/misato),
 [DHCP](https://github.com/rusticata/dhcp-parser),
 [HTTP](https://github.com/sozu-proxy/sozu/tree/master/lib/src/protocol/http),
 [URI](https://github.com/santifa/rrp/blob/master/src/uri.rs),


### PR DESCRIPTION
I recently completed a parser for the D-Bus wire format using nom. 
I added it to the README in case it's a useful reference to someone.