### PR TITLE
Fix bits and bytes functions, expecting Fn instead of FnMut (Closes #1231)

### DIFF
--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -34,11 +34,11 @@ use crate::traits::{ErrorConvert, Slice};
 /// assert_eq!(take_4_bits( sl ), Ok( (&sl[1..], 0xA) ));
 /// ```
 pub fn bits<I, O, E1: ParseError<(I, usize)> + ErrorConvert<E2>, E2: ParseError<I>, P>(
-  parser: P,
-) -> impl Fn(I) -> IResult<I, O, E2>
+  mut parser: P,
+) -> impl FnMut(I) -> IResult<I, O, E2>
 where
   I: Slice<RangeFrom<usize>>,
-  P: Fn((I, usize)) -> IResult<(I, usize), O, E1>,
+  P: FnMut((I, usize)) -> IResult<(I, usize), O, E1>,
 {
   move |input: I| match parser((input, 0)) {
     Ok(((rest, offset), res)) => {
@@ -58,7 +58,7 @@ pub fn bitsc<I, O, E1: ParseError<(I, usize)> + ErrorConvert<E2>, E2: ParseError
 ) -> IResult<I, O, E2>
 where
   I: Slice<RangeFrom<usize>>,
-  P: Fn((I, usize)) -> IResult<(I, usize), O, E1>,
+  P: FnMut((I, usize)) -> IResult<(I, usize), O, E1>,
 {
   bits(parser)(input)
 }
@@ -89,11 +89,11 @@ where
 /// assert_eq!(parse( input ), Ok(( &[][..], (0xd, 0xea, &[0xbe, 0xaf][..]) )));
 /// ```
 pub fn bytes<I, O, E1: ParseError<I> + ErrorConvert<E2>, E2: ParseError<(I, usize)>, P>(
-  parser: P,
-) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E2>
+  mut parser: P,
+) -> impl FnMut((I, usize)) -> IResult<(I, usize), O, E2>
 where
   I: Slice<RangeFrom<usize>> + Clone,
-  P: Fn(I) -> IResult<I, O, E1>,
+  P: FnMut(I) -> IResult<I, O, E1>,
 {
   move |(input, offset): (I, usize)| {
     let inner = if offset % 8 != 0 {
@@ -122,7 +122,7 @@ pub fn bytesc<I, O, E1: ParseError<I> + ErrorConvert<E2>, E2: ParseError<(I, usi
 ) -> IResult<(I, usize), O, E2>
 where
   I: Slice<RangeFrom<usize>> + Clone,
-  P: Fn(I) -> IResult<I, O, E1>,
+  P: FnMut(I) -> IResult<I, O, E1>,
 {
   bytes(parser)(input)
 }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -347,3 +347,19 @@ named!(issue_962<&[u8], Vec<&[u8]>>,
         }
     )
 );
+
+#[test]
+fn issue_1231_bits_expect_fn_closure() {
+    use nom::bits::{bits, complete::take};
+    use nom::error::Error;
+    use nom::sequence::tuple;
+    pub fn example(input: &[u8]) -> IResult<&[u8], (u8, u8)> {
+        bits::<_, _, Error<_>, _, _>(tuple((
+                    take(1usize), take(1usize)
+        )))(input)
+    }
+    assert_eq!(
+        example(&[0xff]),
+        Ok((&b""[..], (1, 1)))
+    );
+}


### PR DESCRIPTION
Hi,

- related issue: #1231 

The `bits` and `bytes` combinators still expect a `Fn` instead of `FntMut`, preventing using other combinators (for ex. `bits(pair(...))`).
This PR changes the closure types to expect a `FnMut`, allowing using other combinators.