### PR TITLE
Docs: fix typo in `ws` recipe

### DIFF
--- a/doc/nom_recipes.md
+++ b/doc/nom_recipes.md
@@ -35,7 +35,7 @@ fn ws<'a, F: 'a, O, E: ParseError<&'a str>>(inner: F) -> impl Fn(&'a str) -> IRe
     multispace0,
     inner,
     multispace0
-  )(i)
+  )
 }
 ```
 


### PR DESCRIPTION
There is no `i` defined in this function; it seems like a leftover from some of the other recipes on this page.
Copy-pasting the function as it currently is results in a compiler error, but works as expected when `(i)` is removed.
