### PR TITLE
Fix feature documentation for count

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -614,6 +614,7 @@ where
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
 #[cfg(feature = "alloc")]
+#[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
 pub fn count<I, O, E, F>(mut f: F, count: usize) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
   I: Clone + PartialEq,


### PR DESCRIPTION
Documentation for `multi::count` did not have the marker indicating its dependence on the `alloc` feature. This PR adds it.