### PR TITLE
Remove whitespace parsers from choosing a combinator docs

### DIFF
--- a/doc/choosing_a_combinator.md
+++ b/doc/choosing_a_combinator.md
@@ -117,13 +117,6 @@ Parsing integers from binary formats can be done in two ways: With parser functi
 - `tag_bits!`: Matches an integer pattern to a bitstream. The number of bits of the input to compare must be specified
 - `take_bits!`: Generates a parser consuming the specified number of bits
 
-## Whitespace delimited formats parsing
-
-- `eat_separator!`: Helper macro to build a separator parser
-- `sep!`: Parser rewriting macro for whitespace separated formats
-- `wrap_sep!`: 
-- `ws!`: Consumes whitespace characters, i.e. the `\s` regex pattern
-
 ## Remaining combinators
 
 - `apply!`: Emulate function currying: `apply!(my_function, arg1, arg2, ...)` becomes `my_function(input, arg1, arg2, ...)`


### PR DESCRIPTION
These parsers were removed in 6.0.0 and should be removed from all documentation.

<!--
Hello, and thank you for submitting a pull request to nom!

First, please note that, for family reasons, I have limited time to work on
nom, so following the advice here will make sure I will quickly understand
your work and be able to merge it early.
Second, if I don't get to work on your PR quickly, that does not mean I won't
include it later. Major version releases happen once a year, and a lot of
interesting work is merged for the occasion. So I will get back to you :)

## Prerequisites

Please provide the following information with this pull request:

- related issue number (I need some context to understand a PR with a lot of
code, except for documentation typos)
- a test case reproducing the issue. You can write it in [issues.rs](https://github.com/Geal/nom/blob/master/tests/issues.rs)
- if adding a new combinator, please add code documentation and some unit tests
in the same file. Also, please update the [combinator list](https://github.com/Geal/nom/blob/master/doc/choosing_a_combinator.md)

## Code style

This project follows a [code style](https://github.com/Geal/nom/blob/master/rustfmt.toml)
checked by [rustfmt][https://github.com/rust-lang-nursery/rustfmt].

Please avoid cosmetic fixes unrelated to the pull request. Keeping the changes
as small as possible increase your chances of getting this merged quickly.

## Rebasing

To make sure the changes will work properly once merged into the master branch
(which might have changed while you were working on your PR), please
[rebase your PR on master](https://git-scm.com/book/en/v2/Git-Branching-Rebasing).

## Squashing the commits

If the pull request include a lot of small commits used for testing, debugging,
or correcting previous work, it might be useful to
[squash the commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
to make the code easier to merge.
-->
