### PR TITLE
Relax `Copy` bounds on eof and many1

### DIFF
--- a/src/combinator/macros.rs
+++ b/src/combinator/macros.rs
@@ -926,7 +926,8 @@ macro_rules! eof (
 
       use $crate::InputLength;
       if ($i).input_len() == 0 {
-        Ok(($i, $i))
+        let clone = $i.clone();
+        Ok(($i, clone))
       } else {
         Err(Err::Error(error_position!($i, ErrorKind::Eof)))
       }

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -411,9 +411,10 @@ where
 /// assert_eq!(parser(""), Ok(("", "")));
 /// # }
 /// ```
-pub fn eof<I: InputLength + Copy, E: ParseError<I>>(input: I) -> IResult<I, I, E> {
+pub fn eof<I: InputLength + Clone, E: ParseError<I>>(input: I) -> IResult<I, I, E> {
   if input.input_len() == 0 {
-    Ok((input, input))
+    let clone = input.clone();
+    Ok((input, clone))
   } else {
     Err(Err::Error(E::from_error_kind(input, ErrorKind::Eof)))
   }

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -140,7 +140,7 @@ where
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
 pub fn many1c<I, O, E, F>(input: I, f: F) -> IResult<I, Vec<O>, E>
 where
-  I: Clone + Copy + PartialEq,
+  I: Clone + PartialEq,
   F: Fn(I) -> IResult<I, O, E>,
   E: ParseError<I>,
 {


### PR DESCRIPTION
Relaxes the `Copy` requirement on the input types of `eof`, `eof!`, and `many1!` to `Clone`, to match other combinators.

The changelog notes that there was some work done to make all the combinators work with non-`Copy` types for 3.0.0; presumably this is still a desired property.

Related to #1251, but much less intrusive than the initial suggestion there.