### PR TITLE
Correctness & style fixes to `fold_many_m_n` and `many_m_n`.

### DIFF
--- a/src/multi/macros.rs
+++ b/src/multi/macros.rs
@@ -519,7 +519,7 @@ macro_rules! fold_many1(
 ///  let b = b"abcdabcdefgh";
 ///  let c = b"abcdabcdabcdabcdabcdefgh";
 ///
-///  assert_eq!(multi(&a[..]), Err(Err::Error(error_position!(&a[..], ErrorKind::ManyMN))));
+///  assert_eq!(multi(&a[..]), Err(Err::Error(error_position!(&b"efgh"[..], ErrorKind::Tag))));
 ///  let res = vec![&b"abcd"[..], &b"abcd"[..]];
 ///  assert_eq!(multi(&b[..]),Ok((&b"efgh"[..], res)));
 ///  let res2 = vec![&b"abcd"[..], &b"abcd"[..], &b"abcd"[..], &b"abcd"[..]];
@@ -1024,7 +1024,7 @@ mod tests {
 
     assert_eq!(
       multi(a),
-      Err(Err::Error(error_position!(a, ErrorKind::ManyMN)))
+      Err(Err::Error(error_position!(&b"ef"[..], ErrorKind::Tag)))
     );
     let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
     assert_eq!(multi(b), Ok((&b"efgh"[..], res1)));


### PR DESCRIPTION
<!--
Hello, and thank you for submitting a pull request to nom!

First, please note that, for family reasons, I have limited time to work on
nom, so following the advice here will make sure I will quickly understand
your work and be able to merge it early.
Second, if I don't get to work on your PR quickly, that does not mean I won't
include it later. Major version releases happen once a year, and a lot of
interesting work is merged for the occasion. So I will get back to you :)

## Prerequisites

Please provide the following information with this pull request:

- related issue number (I need some context to understand a PR with a lot of
code, except for documentation typos)
- a test case reproducing the issue. You can write it in [issues.rs](https://github.com/Geal/nom/blob/master/tests/issues.rs)
- if adding a new combinator, please add code documentation and some unit tests
in the same file. Also, please update the [combinator list](https://github.com/Geal/nom/blob/master/doc/choosing_a_combinator.md)

## Code style

This project follows a [code style](https://github.com/Geal/nom/blob/master/rustfmt.toml)
checked by [rustfmt][https://github.com/rust-lang-nursery/rustfmt].

Please avoid cosmetic fixes unrelated to the pull request. Keeping the changes
as small as possible increase your chances of getting this merged quickly.

## Rebasing

To make sure the changes will work properly once merged into the master branch
(which might have changed while you were working on your PR), please
[rebase your PR on master](https://git-scm.com/book/en/v2/Git-Branching-Rebasing).

## Squashing the commits

If the pull request include a lot of small commits used for testing, debugging,
or correcting previous work, it might be useful to
[squash the commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
to make the code easier to merge.
-->

This PR makes the following fixes & chanes:

- `fold_many_m_n` now correctly attaches the error from the subparser with `ParseError::append`.
- `fold_many_m_n` now correctly reports the location of a subparser error. Previously it would always report the location as the front of the *original* input, which inconsistent with all the other `multi::*` parsers.
- Updated tests for the above changes.
- Follows the clippy recommendation to use more descriptive names for the parameters and variables for `fold_many_m_n` and `many_m_n`. I followed clippy's advice here because these variable names are the likely cause of the incorrect error behavior in `fold_many_m_n` (which returned `E::from(input, ...)` instead of `E::from(i, ...)`).
- `many_m_n` now uses a for loop, simplifying its implementation and making it consistent for `fold_many_m_n`.
- Removed an unnecessary clone in `fold_many_m_n` and `many_m_n`.