### PR TITLE
Impl std::error::Error for VerboseError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -222,6 +222,9 @@ impl<I: fmt::Display> fmt::Display for VerboseError<I> {
   }
 }
 
+#[cfg(feature = "std")]
+impl<I: fmt::Debug + fmt::Display> std::error::Error for VerboseError<I> {}
+
 use crate::internal::{Err, IResult};
 
 /// Create a new error from an input position, a static string and an existing error.


### PR DESCRIPTION
Users of rust libraries usually expect error types to implement the
`std::error::Error` trait, and many error utilities will naturally only
work with types implementing that trait. However, unless nom's custom
`Error` type, the `VerboseError` did not implement the std trait.

This change introduces an empty implementation, meaning that users will
only benefit from `Display` and `Debug` in the end.

<!--
Hello, and thank you for submitting a pull request to nom!

First, please note that, for family reasons, I have limited time to work on
nom, so following the advice here will make sure I will quickly understand
your work and be able to merge it early.
Second, if I don't get to work on your PR quickly, that does not mean I won't
include it later. Major version releases happen once a year, and a lot of
interesting work is merged for the occasion. So I will get back to you :)

## Prerequisites

Please provide the following information with this pull request:

- related issue number (I need some context to understand a PR with a lot of
code, except for documentation typos)
- a test case reproducing the issue. You can write it in [issues.rs](https://github.com/Geal/nom/blob/master/tests/issues.rs)
- if adding a new combinator, please add code documentation and some unit tests
in the same file. Also, please update the [combinator list](https://github.com/Geal/nom/blob/master/doc/choosing_a_combinator.md)

## Code style

This project follows a [code style](https://github.com/Geal/nom/blob/master/rustfmt.toml)
checked by [rustfmt][https://github.com/rust-lang-nursery/rustfmt].

Please avoid cosmetic fixes unrelated to the pull request. Keeping the changes
as small as possible increase your chances of getting this merged quickly.

## Rebasing

To make sure the changes will work properly once merged into the master branch
(which might have changed while you were working on your PR), please
[rebase your PR on master](https://git-scm.com/book/en/v2/Git-Branching-Rebasing).

## Squashing the commits

If the pull request include a lot of small commits used for testing, debugging,
or correcting previous work, it might be useful to
[squash the commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
to make the code easier to merge.
-->
