### PR TITLE
Restrict the bitvec->funty dependency to `<=1.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,11 @@ version = "0.19.3"
 optional = true
 default-features = false
 
+[dependencies.funty]
+version = ">1.0, <=1.1"
+optional = true
+default-features = false
+
 [dependencies.regex]
 version = "^1.0"
 optional = true


### PR DESCRIPTION
Nom builds fail since the release of `funty` 1.2. 
see #1283 / [pull/1283/checks]

Alternative would be to bump the version of bitvec to 0.21 

[pull/1283/checks]: https://github.com/Geal/nom/pull/1283/checks?check_run_id=1895765110