### PR TITLE
[Docs] Update/Fix example for bits::bits and add tests

### DIFF
--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -18,33 +18,42 @@ use crate::traits::{ErrorConvert, Slice};
 /// away.
 ///
 /// # Example
-/// ```ignore
-/// # #[macro_use] extern crate nom;
-/// # use nom::IResult;
-/// use nom::bits::bits;
-/// use nom::bits::complete::take;
+/// ```
+/// use nom::bits::{bits, streaming::take};
 /// use nom::error::Error;
+/// use nom::sequence::tuple;
+/// use nom::IResult;
 ///
-/// fn take_4_bits(input: &[u8]) -> IResult<&[u8], u64> {
-///   bits(take::<_, _, _, Error<_>>(4usize))(input)
+/// fn parse(input: &[u8]) -> IResult<&[u8], (u8, u8)> {
+///     bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((take(4usize), take(8usize))))(input)
 /// }
 ///
-/// let input = vec![0xAB, 0xCD, 0xEF, 0x12];
-/// let sl    = &input[..];
+/// let input = &[0x12, 0x34, 0xff, 0xff];
 ///
-/// assert_eq!(take_4_bits( sl ), Ok( (&sl[1..], 0xA) ));
+/// let output = parse(input).expect("We take 1.5 bytes and the input is longer than 2 bytes");
+///
+/// // The first byte is consumed, the second byte is partially consumed and dropped.
+/// let remaining = output.0;
+/// assert_eq!(remaining, [0xff, 0xff]);
+///
+/// let parsed = output.1;
+/// assert_eq!(parsed.0, 0x01);
+/// assert_eq!(parsed.1, 0x23);
 /// ```
-pub fn bits<I, O, E1: ParseError<(I, usize)> + ErrorConvert<E2>, E2: ParseError<I>, P>(
-  mut parser: P,
-) -> impl FnMut(I) -> IResult<I, O, E2>
+pub fn bits<I, O, E1, E2, P>(mut parser: P) -> impl FnMut(I) -> IResult<I, O, E2>
 where
+  E1: ParseError<(I, usize)> + ErrorConvert<E2>,
+  E2: ParseError<I>,
   I: Slice<RangeFrom<usize>>,
   P: FnMut((I, usize)) -> IResult<(I, usize), O, E1>,
 {
   move |input: I| match parser((input, 0)) {
-    Ok(((rest, offset), res)) => {
-      let byte_index = offset / 8 + if offset % 8 == 0 { 0 } else { 1 };
-      Ok((rest.slice(byte_index..), res))
+    Ok(((rest, offset), result)) => {
+      // If the next byte has been partially read, it will be sliced away as well.
+      // The parser functions might already slice away all fully read bytes.
+      // That's why `offset / 8` isn't necessarily needed at all times.
+      let remaining_bytes_index = offset / 8 + if offset % 8 == 0 { 0 } else { 1 };
+      Ok((rest.slice(remaining_bytes_index..), result))
     }
     Err(Err::Incomplete(n)) => Err(Err::Incomplete(n.map(|u| u.get() / 8 + 1))),
     Err(Err::Error(e)) => Err(Err::Error(e.convert())),
@@ -126,4 +135,72 @@ where
   P: FnMut(I) -> IResult<I, O, E1>,
 {
   bytes(parser)(input)
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use crate::bits::streaming::take;
+  use crate::error::Error;
+  use crate::sequence::tuple;
+
+  #[test]
+  /// Take the `bits` function and assert that remaining bytes are correctly returned, if the
+  /// previous bytes are fully consumed
+  fn test_complete_byte_consumption_bits() {
+    let input = &[0x12, 0x34, 0x56, 0x78];
+
+    // Take 3 bit slices with sizes [4, 8, 4].
+    let result: IResult<&[u8], (u8, u8, u8)> =
+      bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((take(4usize), take(8usize), take(4usize))))(
+        input,
+      );
+
+    let output = result.expect("We take 2 bytes and the input is longer than 2 bytes");
+
+    let remaining = output.0;
+    assert_eq!(remaining, [0x56, 0x78]);
+
+    let parsed = output.1;
+    assert_eq!(parsed.0, 0x01);
+    assert_eq!(parsed.1, 0x23);
+    assert_eq!(parsed.2, 0x04);
+  }
+
+  #[test]
+  /// Take the `bits` function and assert that remaining bytes are correctly returned, if the
+  /// previous bytes are NOT fully consumed. Partially consumed bytes are supposed to be dropped.
+  /// I.e. if we consume 1.5 bytes of 4 bytes, 2 bytes will be returned, bits 13-16 will be
+  /// dropped.
+  fn test_partial_byte_consumption_bits() {
+    let input = &[0x12, 0x34, 0x56, 0x78];
+
+    // Take bit slices with sizes [4, 8].
+    let result: IResult<&[u8], (u8, u8)> =
+      bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((take(4usize), take(8usize))))(input);
+
+    let output = result.expect("We take 1.5 bytes and the input is longer than 2 bytes");
+
+    let remaining = output.0;
+    assert_eq!(remaining, [0x56, 0x78]);
+
+    let parsed = output.1;
+    assert_eq!(parsed.0, 0x01);
+    assert_eq!(parsed.1, 0x23);
+  }
+
+  #[test]
+  #[cfg(feature = "std")]
+  /// Ensure that in Incomplete error is thrown, if too few bytes are passed for a given parser.
+  fn test_incomplete_bits() {
+    let input = &[0x12];
+
+    // Take bit slices with sizes [4, 8].
+    let result: IResult<&[u8], (u8, u8)> =
+      bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((take(4usize), take(8usize))))(input);
+
+    assert!(result.is_err());
+    let error = result.err().unwrap();
+    assert_eq!("Parsing requires 2 bytes/chars", error.to_string());
+  }
 }

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -79,29 +79,29 @@ where
 /// A partial byte remaining in the input will be ignored and the given parser will start parsing
 /// at the next full byte.
 ///
-/// ```ignore
-/// # #[macro_use] extern crate nom;
-/// # use nom::IResult;
-/// # use nom::combinator::rest;
-/// # use nom::sequence::tuple;
-/// use nom::bits::{bits, bytes, streaming::take_bits};
+/// ```
+/// use nom::bits::{bits, bytes, streaming::take};
+/// use nom::combinator::rest;
+/// use nom::error::Error;
+/// use nom::sequence::tuple;
+/// use nom::IResult;
 ///
 /// fn parse(input: &[u8]) -> IResult<&[u8], (u8, u8, &[u8])> {
-///   bits(tuple((
-///     take_bits(4usize),
-///     take_bits(8usize),
-///     bytes(rest)
+///   bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((
+///     take(4usize),
+///     take(8usize),
+///     bytes::<_, _, Error<&[u8]>, _, _>(rest)
 ///   )))(input)
 /// }
 ///
-/// let input = &[0xde, 0xad, 0xbe, 0xaf];
+/// let input = &[0x12, 0x34, 0xff, 0xff];
 ///
-/// assert_eq!(parse( input ), Ok(( &[][..], (0xd, 0xea, &[0xbe, 0xaf][..]) )));
+/// assert_eq!(parse( input ), Ok(( &[][..], (0x01, 0x23, &[0xff, 0xff][..]) )));
 /// ```
-pub fn bytes<I, O, E1: ParseError<I> + ErrorConvert<E2>, E2: ParseError<(I, usize)>, P>(
-  mut parser: P,
-) -> impl FnMut((I, usize)) -> IResult<(I, usize), O, E2>
+pub fn bytes<I, O, E1, E2, P>(mut parser: P) -> impl FnMut((I, usize)) -> IResult<(I, usize), O, E2>
 where
+  E1: ParseError<I> + ErrorConvert<E2>,
+  E2: ParseError<(I, usize)>,
   I: Slice<RangeFrom<usize>> + Clone,
   P: FnMut(I) -> IResult<I, O, E1>,
 {


### PR DESCRIPTION
First of all, thanks for providing and maintaining this library!

This PR is related to #976
Overwrites PR #992

Previously, the example code for `bits::bits` has been ignored and didn't work.

I updated/fixed the example and added some additional inline docs, since some things weren't clear to me.

Furthermore, I took the liberty to move the definition of the generic parameters `E1` and `E2` to the `where` block.
I felt that this makes understanding the relationships between the parameters a lot easier, since they're now closer together.
(I can revert this at any time, if it doesn't fit to your code-style)

Old docs page:

https://docs.rs/nom/6.1.2/nom/bits/fn.bits.html

New docs page:

![image](https://user-images.githubusercontent.com/3322822/113589089-40396800-9631-11eb-9218-174495ad7812.png)