### PR TITLE
Bump lexical-core dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ version = "^2.0"
 default-features = false
 
 [dependencies.lexical-core]
-version = ">= 0.6, < 0.8"
+version = "^0.7.5"
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes #1298.

As described in #1298, this cannot be reproduced by compiling `nom` itself (I don't know why...), so no changes to tests and CI.