### PR TITLE
Doc - Use function links (fix #1290)

### DIFF
--- a/doc/choosing_a_combinator.md
+++ b/doc/choosing_a_combinator.md
@@ -1,8 +1,8 @@
-# List of macros parsers and combinators
+# List of parsers and combinators
 
-**Note**: this list is meant to provide a nicer way to find a nom macros than reading through the
-documentation on docs.rs, since rustdoc puts all the macros at the top level. Function combinators
-are organized in module so they are a bit easier to find.
+**Note**: this list is meant to provide a nicer way to find a nom parser than reading through the documentation on docs.rs. Function combinators are organized in module so they are a bit easier to find.
+
+Links present in this document will nearly always point to `complete` version of the parser. Most of the parsers also have a `streaming` version.
 
 ## Basic elements
 
@@ -10,153 +10,134 @@ Those are used to recognize the lowest level elements of your grammar, like, "he
 
 | combinator | usage | input | output | comment |
 |---|---|---|---|---|
-| [char](https://docs.rs/nom/latest/nom/macro.char.html) | `char!('a')` |  `"abc"` | `Ok(("bc", 'a'))` |Matches one character (works with non ASCII chars too) | 
-| [is_a](https://docs.rs/nom/latest/nom/macro.is_a.html) | ` is_a!("ab")` |  `"ababc"` | `Ok(("c", "abab"))` |Matches a sequence of any of the characters passed as arguments|
-| [is_not](https://docs.rs/nom/latest/nom/macro.is_not.html) | `is_not!("cd")` |  `"ababc"` | `Ok(("c", "abab"))` |Matches a sequence of none of the characters passed as arguments|
-| [one_of](https://docs.rs/nom/latest/nom/macro.one_of.html) | `one_of!("abc")` |  `"abc"` | `Ok(("bc", 'a'))` |Matches one of the provided characters (works with non ASCII characters too)|
-| [none_of](https://docs.rs/nom/latest/nom/macro.none_of.html) | `none_of!("abc")` |  `"xyab"` | `Ok(("yab", 'x'))` |Matches anything but the provided characters|
-| [tag](https://docs.rs/nom/latest/nom/macro.tag.html) | `tag!("hello")` |  `"hello world"` | `Ok((" world", "hello"))` |Recognizes a specific suite of characters or bytes|
-| [tag_no_case](https://docs.rs/nom/latest/nom/macro.tag_no_case.html) | `tag_no_case!("hello")` |  `"HeLLo World"` | `Ok((" World", "HeLLo"))` |Case insensitive comparison. Note that case insensitive comparison is not well defined for unicode, and that you might have bad surprises|
-| [take](https://docs.rs/nom/latest/nom/macro.take.html) | `take!(4)` |  `"hello"` | `Ok(("o", "hell"))` |Takes a specific number of bytes or characters|
-| [take_while](https://docs.rs/nom/latest/nom/macro.take_while.html) | `take_while!(is_alphabetic)` |  `"abc123"` | `Ok(("123", "abc"))` |Returns the longest list of bytes for which the provided function returns true. `take_while1` does the same, but must return at least one character|
-| [take_till](https://docs.rs/nom/latest/nom/macro.take_till.html) | `take_till!(is_alphabetic)` |  `"123abc"` | `Ok(("abc", "123"))` |Returns the longest list of bytes or characters until the provided function returns true. `take_till1` does the same, but must return at least one character. This is the reverse behaviour from `take_while`: `take_till!(f)` is equivalent to `take_while!(\|c\| !f(c))`|
-| [take_until](https://docs.rs/nom/latest/nom/macro.take_until.html) | `take_until!("world")` |  `"Hello world"` | `Ok(("world", "Hello "))` |Returns the longest list of bytes or characters until the provided tag is found. `take_until1` does the same, but must return at least one character|
+| [char](https://docs.rs/nom/latest/nom/character/complete/fn.char.html) | `char('a')` |  `"abc"` | `Ok(("bc", 'a'))` |Matches one character (works with non ASCII chars too) | 
+| [is_a](https://docs.rs/nom/latest/nom/bytes/complete/fn.is_a.html) | ` is_a("ab")` |  `"ababc"` | `Ok(("c", "abab"))` |Matches a sequence of any of the characters passed as arguments|
+| [is_not](https://docs.rs/nom/latest/nom/bytes/complete/fn.is_not.html) | `is_not("cd")` |  `"ababc"` | `Ok(("c", "abab"))` |Matches a sequence of none of the characters passed as arguments|
+| [one_of](https://docs.rs/nom/latest/nom/character/complete/fn.one_of.html) | `one_of("abc")` |  `"abc"` | `Ok(("bc", 'a'))` |Matches one of the provided characters (works with non ASCII characters too)|
+| [none_of](https://docs.rs/nom/latest/nom/character/complete/fn.none_of.html) | `none_of("abc")` |  `"xyab"` | `Ok(("yab", 'x'))` |Matches anything but the provided characters|
+| [tag](https://docs.rs/nom/latest/nom/bytes/complete/fn.tag.html) | `tag("hello")` |  `"hello world"` | `Ok((" world", "hello"))` |Recognizes a specific suite of characters or bytes|
+| [tag_no_case](https://docs.rs/nom/latest/nom/bytes/complete/fn.tag_no_case.html) | `tag_no_case("hello")` |  `"HeLLo World"` | `Ok((" World", "HeLLo"))` |Case insensitive comparison. Note that case insensitive comparison is not well defined for unicode, and that you might have bad surprises|
+| [take](https://docs.rs/nom/latest/nom/bytes/complete/fn.take.html) | `take(4)` |  `"hello"` | `Ok(("o", "hell"))` |Takes a specific number of bytes or characters|
+| [take_while](https://docs.rs/nom/latest/bytes/complete/fn.take_while.html) | `take_while(is_alphabetic)` |  `"abc123"` | `Ok(("123", "abc"))` |Returns the longest list of bytes for which the provided function returns true. `take_while1` does the same, but must return at least one character|
+| [take_till](https://docs.rs/nom/latest/nom/bytes/complete/fn.take_till.html) | `take_till(is_alphabetic)` |  `"123abc"` | `Ok(("abc", "123"))` |Returns the longest list of bytes or characters until the provided function returns true. `take_till1` does the same, but must return at least one character. This is the reverse behaviour from `take_while`: `take_till(f)` is equivalent to `take_while(\|c\| !f(c))`|
+| [take_until](https://docs.rs/nom/latest/nom/bytes/complete/fn.take_until.html) | `take_until("world")` |  `"Hello world"` | `Ok(("world", "Hello "))` |Returns the longest list of bytes or characters until the provided tag is found. `take_until1` does the same, but must return at least one character|
 
 ## Choice combinators
 
 | combinator | usage | input | output | comment |
 |---|---|---|---|---|
-| [alt](https://docs.rs/nom/latest/nom/macro.alt.html) | `alt!(tag!("ab") \| tag!("cd"))` |  `"cdef"` | `Ok(("ef", "cd"))` |Try a list of parsers and return the result of the first successful one|
-| [switch](https://docs.rs/nom/latest/nom/macro.switch.html) | `switch!(take!(2), "ab" => tag!("XYZ") \| "cd" => tag!("123"))` | `"cd1234"` | `Ok(("4", "123"))` |Choose the next parser depending on the result of the first one, if successful, and returns the result of the second parser|
-| [permutation](https://docs.rs/nom/latest/nom/macro.permutation.html) | `permutation!(tag!("ab"), tag!("cd"), tag!("12"))` | `"cd12abc"` | `Ok(("c", ("ab", "cd", "12"))` |Succeeds when all its child parser have succeeded, whatever the order|
+| [alt](https://docs.rs/nom/latest/nom/branch/fn.alt.html) | `alt(tag("ab") \| tag("cd"))` |  `"cdef"` | `Ok(("ef", "cd"))` |Try a list of parsers and return the result of the first successful one|
+| [permutation](https://docs.rs/nom/latest/nom/branch/fn.permutation.html) | `permutation(tag("ab"), tag("cd"), tag("12"))` | `"cd12abc"` | `Ok(("c", ("ab", "cd", "12"))` |Succeeds when all its child parser have succeeded, whatever the order|
 
 ## Sequence combinators
 
 | combinator | usage | input | output | comment |
 |---|---|---|---|---|
-| [delimited](https://docs.rs/nom/latest/nom/macro.delimited.html) | `delimited!(char!('('), take!(2), char!(')'))` | `"(ab)cd"` | `Ok(("cd", "ab"))` ||
-| [preceded](https://docs.rs/nom/latest/nom/macro.preceded.html) | `preceded!(tag!("ab"), tag!("XY"))` | `"abXYZ"` | `Ok(("Z", "XY"))` ||
-| [terminated](https://docs.rs/nom/latest/nom/macro.terminated.html) | `terminated!(tag!("ab"), tag!("XY"))` | `"abXYZ"` | `Ok(("Z", "ab"))` ||
-| [pair](https://docs.rs/nom/latest/nom/macro.pair.html) | `pair!(tag!("ab"), tag!("XY"))` | `"abXYZ"` | `Ok(("Z", ("ab", "XY")))` ||
-| [separated_pair](https://docs.rs/nom/latest/nom/macro.separated_pair.html) | `separated_pair!(tag!("hello"), char!(','), tag!("world"))` | `"hello,world!"` | `Ok(("!", ("hello", "world")))` ||
-| [tuple](https://docs.rs/nom/latest/nom/macro.tuple.html) | `tuple!(tag!("ab"), tag!("XY"), take!(1))` | `"abXYZ!"` | `Ok(("!", ("ab", "XY", "Z")))` |Chains parsers and assemble the sub results in a tuple. You can use as many child parsers as you can put elements in a tuple|
-| [do_parse](https://docs.rs/nom/latest/nom/macro.do_parse.html) | `do_parse!(tag: take!(2) >> length: be_u8 >> data: take!(length) >> (Buffer { tag: tag, data: data}) )` | `&[0, 0, 3, 1, 2, 3][..]` | `Buffer { tag: &[0, 0][..], data: &[1, 2, 3][..] }` |`do_parse` applies sub parsers in a sequence. It can store intermediary results and make them available for later parsers|
+| [delimited](https://docs.rs/nom/latest/nom/sequence/fn.delimited.html) | `delimited(char('('), take(2), char(')'))` | `"(ab)cd"` | `Ok(("cd", "ab"))` ||
+| [preceded](https://docs.rs/nom/latest/nom/sequence/fn.preceded.html) | `preceded(tag("ab"), tag("XY"))` | `"abXYZ"` | `Ok(("Z", "XY"))` ||
+| [terminated](https://docs.rs/nom/latest/nom/sequence/fn.terminated.html) | `terminated(tag("ab"), tag("XY"))` | `"abXYZ"` | `Ok(("Z", "ab"))` ||
+| [pair](https://docs.rs/nom/latest/nom/sequence/fn.pair.html) | `pair(tag("ab"), tag("XY"))` | `"abXYZ"` | `Ok(("Z", ("ab", "XY")))` ||
+| [separated_pair](https://docs.rs/nom/latest/nom/sequence/fn.separated_pair.html) | `separated_pair(tag("hello"), char(','), tag("world"))` | `"hello,world!"` | `Ok(("!", ("hello", "world")))` ||
+| [tuple](https://docs.rs/nom/latest/nom/sequence/fn.tuple.html) | `tuple(tag("ab"), tag("XY"), take(1))` | `"abXYZ!"` | `Ok(("!", ("ab", "XY", "Z")))` |Chains parsers and assemble the sub results in a tuple. You can use as many child parsers as you can put elements in a tuple|
 
 ## Applying a parser multiple times
 
 | combinator | usage | input | output | comment |
 |---|---|---|---|---|
-| [count](https://docs.rs/nom/latest/nom/macro.count.html) | `count!(take!(2), 3)` | `"abcdefgh"` | `Ok(("gh", vec!("ab", "cd", "ef")))` |Applies the child parser a specified number of times|
-| [many0](https://docs.rs/nom/latest/nom/macro.many0.html) | `many0!(tag!("ab"))` |  `"abababc"` | `Ok(("c", vec!("ab", "ab", "ab")))` |Applies the parser 0 or more times and returns the list of results in a Vec. `many1` does the same operation but must return at least one element|
-| [many_m_n](https://docs.rs/nom/latest/nom/macro.many_m_n.html) | `many_m_n!(1, 3, tag!("ab"))` | `"ababc"` | `Ok(("c", vec!("ab", "ab")))` |Applies the parser between m and n times (n included) and returns the list of results in a Vec|
-| [many_till](https://docs.rs/nom/latest/nom/macro.many_till.html) | `many_till!(tag!( "ab" ), tag!( "ef" ))` | `"ababefg"` | `Ok(("g", (vec!("ab", "ab"), "ef")))` |Applies the first parser until the second applies. Returns a tuple containing the list of results from the first in a Vec and the result of the second|
-| [separated_list](https://docs.rs/nom/latest/nom/macro.separated_list.html) | `separated_list!(tag!(","), tag!("ab"))` | `"ab,ab,ab."` | `Ok((".", vec!("ab", "ab", "ab")))` |`separated_nonempty_list` works like `separated_list` but must returns at least one element|
-| [fold_many0](https://docs.rs/nom/latest/nom/macro.fold_many0.html) | `fold_many0!(be_u8, 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `Ok(([], 6))` |Applies the parser 0 or more times and folds the list of return values. The `fold_many1` version must apply the child parser at least one time|
-| [fold_many_m_n](https://docs.rs/nom/latest/nom/macro.fold_many_m_n.html) | `fold_many_m_n!(1, 2, be_u8, 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `Ok(([3], 3))` |Applies the parser between m and n times (n included) and folds the list of return value|
-| [length_count](https://docs.rs/nom/latest/nom/macro.length_count.html) | `length_count!(number, tag!("ab"))` | `"2ababab"` | `Ok(("ab", vec!("ab", "ab")))` |Gets a number from the first parser, then applies the second parser that many times|
+| [count](https://docs.rs/nom/latest/nom/multi/fn.count.html) | `count(take(2), 3)` | `"abcdefgh"` | `Ok(("gh", vec!("ab", "cd", "ef")))` |Applies the child parser a specified number of times|
+| [many0](https://docs.rs/nom/latest/nom/multi/fn.many0.html) | `many0(tag("ab"))` |  `"abababc"` | `Ok(("c", vec!("ab", "ab", "ab")))` |Applies the parser 0 or more times and returns the list of results in a Vec. `many1` does the same operation but must return at least one element|
+| [many_m_n](https://docs.rs/nom/latest/nom/multi/fn.many_m_n.html) | `many_m_n(1, 3, tag("ab"))` | `"ababc"` | `Ok(("c", vec!("ab", "ab")))` |Applies the parser between m and n times (n included) and returns the list of results in a Vec|
+| [many_till](https://docs.rs/nom/latest/nom/multi/fn.many_till.html) | `many_till(tag( "ab" ), tag( "ef" ))` | `"ababefg"` | `Ok(("g", (vec!("ab", "ab"), "ef")))` |Applies the first parser until the second applies. Returns a tuple containing the list of results from the first in a Vec and the result of the second|
+| [separated_list0](https://docs.rs/nom/latest/nom/multi/fn.separated_list0.html) | `separated_list0(tag(","), tag("ab"))` | `"ab,ab,ab."` | `Ok((".", vec!("ab", "ab", "ab")))` |`separated_list1` works like `separated_list0` but must returns at least one element|
+| [fold_many0](https://docs.rs/nom/latest/nom/multi/fn.fold_many0.html) | `fold_many0(be_u8, 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `Ok(([], 6))` |Applies the parser 0 or more times and folds the list of return values. The `fold_many1` version must apply the child parser at least one time|
+| [fold_many_m_n](https://docs.rs/nom/latest/nom/multi/fn.fold_many_m_n.html) | `fold_many_m_n(1, 2, be_u8, 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `Ok(([3], 3))` |Applies the parser between m and n times (n included) and folds the list of return value|
+| [length_count](https://docs.rs/nom/latest/nom/multi/fn.length_count.html) | `length_count(number, tag("ab"))` | `"2ababab"` | `Ok(("ab", vec!("ab", "ab")))` |Gets a number from the first parser, then applies the second parser that many times|
 
 ## Integers
 
-Parsing integers from binary formats can be done in two ways: With parser functions, or combinators with configurable endianness:
+Parsing integers from binary formats can be done in two ways: With parser functions, or combinators with configurable endianness.
 
-- **configurable endianness:** `i16!`, `i32!`, `i64!`, `u16!`, `u32!`, `u64!` are combinators that take as argument a `nom::Endianness`, like this: `i16!(endianness)`. If the parameter is `nom::Endianness::Big`, parse a big endian `i16` integer, otherwise a little endian `i16` integer.
+The following parsers could be found on [docs.rs number section](https://docs.rs/nom/latest/nom/number/complete/index.html).
+
+- **configurable endianness:** [`i16`](https://docs.rs/nom/latest/nom/number/complete/fn.i16.html), [`i32`](https://docs.rs/nom/latest/nom/number/complete/fn.i32.html), [`i64`](https://docs.rs/nom/latest/nom/number/complete/fn.i64.html), [`u16`](https://docs.rs/nom/latest/nom/number/complete/fn.u16.html), [`u32`](https://docs.rs/nom/latest/nom/number/complete/fn.u32.html), [`u64`](https://docs.rs/nom/latest/nom/number/complete/fn.u64.html) are combinators that take as argument a [`nom::number::Endianness`](https://docs.rs/nom/latest/nom/number/enum.Endianness.html), like this: `i16(endianness)`. If the parameter is `nom::number::Endianness::Big`, parse a big endian `i16` integer, otherwise a little endian `i16` integer.
 - **fixed endianness**: The functions are prefixed by `be_` for big endian numbers, and by `le_` for little endian numbers, and the suffix is the type they parse to. As an example, `be_u32` parses a big endian unsigned integer stored in 32 bits.
-- `be_f32`, `be_f64`, `le_f32`, `le_f64`: Recognize floating point numbers
-- `be_i8`, `be_i16`, `be_i24`, `be_i32`, `be_i64`: Big endian signed integers
-- `be_u8`, `be_u16`, `be_u24`, `be_u32`, `be_u64`: Big endian unsigned integers
-- `le_i8`, `le_i16`, `le_i24`, `le_i32`, `le_i64`: Little endian signed integers
-- `le_u8`, `le_u16`, `le_u24`, `le_u32`, `le_u64`: Little endian unsigned integers
+  - [`be_f32`](https://docs.rs/nom/latest/nom/number/complete/fn.be_f32.html), [`be_f64`](https://docs.rs/nom/latest/nom/number/complete/fn.be_f64.html): Big endian floating point numbers
+  - [`le_f32`](https://docs.rs/nom/latest/nom/number/complete/fn.le_f32.html), [`le_f64`](https://docs.rs/nom/latest/nom/number/complete/fn.le_f64.html): Little endian floating point numbers
+  - [`be_i8`](https://docs.rs/nom/latest/nom/number/complete/fn.be_i8.html), [`be_i16`](https://docs.rs/nom/latest/nom/number/complete/fn.be_i16.html), [`be_i24`](https://docs.rs/nom/latest/nom/number/complete/fn.be_i24.html), [`be_i32`](https://docs.rs/nom/latest/nom/number/complete/fn.be_i32.html), [`be_i64`](https://docs.rs/nom/latest/nom/number/complete/fn.be_i64.html), [`be_i128`](https://docs.rs/nom/latest/nom/number/complete/fn.be_i128.html): Big endian signed integers
+  - [`be_u8`](https://docs.rs/nom/latest/nom/number/complete/fn.be_u8.html), [`be_u16`](https://docs.rs/nom/latest/nom/number/complete/fn.be_u16.html), [`be_u24`](https://docs.rs/nom/latest/nom/number/complete/fn.be_u24.html), [`be_u32`](https://docs.rs/nom/latest/nom/number/complete/fn.be_u32.html), [`be_u64`](https://docs.rs/nom/latest/nom/number/complete/fn.be_u64.html), [`be_u128`](https://docs.rs/nom/latest/nom/number/complete/fn.be_u128.html): Big endian unsigned integers
+  - [`le_i8`](https://docs.rs/nom/latest/nom/number/complete/fn.le_i8.html), [`le_i16`](https://docs.rs/nom/latest/nom/number/complete/fn.le_i16.html), [`le_i24`](https://docs.rs/nom/latest/nom/number/complete/fn.le_i24.html), [`le_i32`](https://docs.rs/nom/latest/nom/number/complete/fn.le_i32.html), [`le_i64`](https://docs.rs/nom/latest/nom/number/complete/fn.le_i64.html), [`le_i128`](https://docs.rs/nom/latest/nom/number/complete/fn.le_i128.html): Little endian signed integers
+  - [`le_u8`](https://docs.rs/nom/latest/nom/number/complete/fn.le_u8.html), [`le_u16`](https://docs.rs/nom/latest/nom/number/complete/fn.le_u16.html), [`le_u24`](https://docs.rs/nom/latest/nom/number/complete/fn.le_u24.html), [`le_u32`](https://docs.rs/nom/latest/nom/number/complete/fn.le_u32.html), [`le_u64`](https://docs.rs/nom/latest/nom/number/complete/fn.le_u64.html), [`le_u128`](https://docs.rs/nom/latest/nom/number/complete/fn.le_u128.html): Little endian unsigned integers
 
 ## Streaming related
 
-- `eof!`: Returns its input if it is at the end of input data
-- `complete!`: Replaces an `Incomplete` returned by the child parser with an `Error`
+- [`eof`](https://docs.rs/nom/latest/nom/combinator/fn.eof.html): Returns its input if it is at the end of input data
+- [`complete`](https://docs.rs/nom/latest/nom/combinator/fn.complete.html): Replaces an `Incomplete` returned by the child parser with an `Error`
 
 ## Modifiers
 
-- `cond!`: Conditional combinator. Wraps another parser and calls it if the condition is met
-- `flat_map!`: 
-- `map!`: Maps a function on the result of a parser
-- `map_opt!`: Maps a function returning an `Option` on the output of a parser
-- `map_res!`: Maps a function returning a `Result` on the output of a parser
-- `not!`: Returns a result only if the embedded parser returns `Error` or `Incomplete`. Does not consume the input
-- `opt!`: Make the underlying parser optional
-- `opt_res!`: Make the underlying parser optional
-- `parse_to!`: Uses the parse method from `std::str::FromStr` to convert the current input to the specified type
-- `peek!`: Returns a result without consuming the input
-- `recognize!`: If the child parser was successful, return the consumed input as the produced value
-- `consumed()`: If the child parser was successful, return a tuple of the consumed input and the produced output.
-- `return_error!`: Prevents backtracking if the child parser fails
-- `tap!`: Allows access to the parser's result without affecting it
-- `verify!`: Returns the result of the child parser if it satisfies a verification function
+- [`cond`](https://docs.rs/nom/latest/nom/combinator/fn.cond.html): Conditional combinator. Wraps another parser and calls it if the condition is met
+- [`flat_map`](https://docs.rs/nom/latest/nom/combinator/fn.flat_map.html): Creates a new parser from the output of the first parser, then apply that parser over the rest of the input
+- [`map`](https://docs.rs/nom/latest/nom/combinator/fn.map.html): Maps a function on the result of a parser
+- [`map_opt`](https://docs.rs/nom/latest/nom/combinator/fn.map_opt.html): Maps a function returning an `Option` on the output of a parser
+- [`map_res`](https://docs.rs/nom/latest/nom/combinator/fn.map_res.html): Maps a function returning a `Result` on the output of a parser
+- [`not`](https://docs.rs/nom/latest/nom/combinator/fn.not.html): Returns a result only if the embedded parser returns `Error` or `Incomplete`. Does not consume the input
+- [`opt`](https://docs.rs/nom/latest/nom/combinator/fn.opt.html): Make the underlying parser optional
+- [`peek`](https://docs.rs/nom/latest/nom/combinator/fn.peek.html): Returns a result without consuming the input
+- [`recognize`](https://docs.rs/nom/latest/nom/combinator/fn.recognize.html): If the child parser was successful, return the consumed input as the produced value
+- [`consumed`](https://docs.rs/nom/latest/nom/combinator/fn.consumed.html): If the child parser was successful, return a tuple of the consumed input and the produced output.
+- [`verify`](https://docs.rs/nom/latest/nom/combinator/fn.verify.html): Returns the result of the child parser if it satisfies a verification function
 
 ## Error management and debugging
 
-- `add_return_error!`: Add an error if the child parser fails
-- `dbg!`: Prints a message if the parser fails
-- `dbg_dmp!`: Prints a message and the input if the parser fails
-- `error_node_position!`: Creates a parse error from a `nom::ErrorKind`, the position in the input and the next error in the parsing tree. If the `verbose-errors` feature is not activated, it defaults to only the error code
-- `error_position!`: Creates a parse error from a `nom::ErrorKind` and the position in the input. If the `verbose-errors` feature is not activated, it defaults to only the error code
-- `fix_error!`: Translate parser result from `IResult` to `IResult` with a custom type
+- [`dbg_dmp`](https://docs.rs/nom/latest/nom/fn.dbg_dmp.html): Prints a message and the input if the parser fails
 
 ## Text parsing
 
-- `escaped!`: Matches a byte string with escaped characters
-- `escaped_transform!`: Matches a byte string with escaped characters, and returns a new string with the escaped characters replaced
+- [`escaped`](https://docs.rs/nom/latest/nom/bytes/complete/fn.escaped.html): Matches a byte string with escaped characters
+- [`escaped_transform`](https://docs.rs/nom/latest/nom/bytes/complete/fn.escaped_transform.html): Matches a byte string with escaped characters, and returns a new string with the escaped characters replaced
 
 ## Binary format parsing
 
-- `length_data!`: Gets a number from the first parser, then takes a subslice of the input of that size, and returns that subslice
-- `length_bytes!`: Alias for length_data
-- `length_value!`: Gets a number from the first parser, takes a subslice of the input of that size, then applies the second parser on that subslice. If the second parser returns `Incomplete`, `length_value!` will return an error
+- [`length_data`](https://docs.rs/nom/latest/nom/multi/fn.length_data.html): Gets a number from the first parser, then takes a subslice of the input of that size, and returns that subslice
+- [`length_value`](https://docs.rs/nom/latest/nom/multi/fn.length_value.html): Gets a number from the first parser, takes a subslice of the input of that size, then applies the second parser on that subslice. If the second parser returns `Incomplete`, `length_value` will return an error
 
 ## Bit stream parsing
 
-- `bits!`: Transforms the current input type (byte slice `&[u8]`) to a bit stream on which bit specific parsers and more general combinators can be applied
-- `bytes!`: Transforms its bits stream input back into a byte slice for the underlying parser
-- `tag_bits!`: Matches an integer pattern to a bitstream. The number of bits of the input to compare must be specified
-- `take_bits!`: Generates a parser consuming the specified number of bits
+- [`bits`](https://docs.rs/nom/latest/nom/bits/fn.bits.html): Transforms the current input type (byte slice `&[u8]`) to a bit stream on which bit specific parsers and more general combinators can be applied
+- [`bytes`](https://docs.rs/nom/latest/nom/bits/fn.bytes.html): Transforms its bits stream input back into a byte slice for the underlying parser
 
 ## Remaining combinators
 
-- `apply!`: Emulate function currying: `apply!(my_function, arg1, arg2, ...)` becomes `my_function(input, arg1, arg2, ...)`
-- `call!`: Used to wrap common expressions and function as macros
-- `method!`: Makes a method from a parser combination
-- `named!`: Makes a function from a parser combination
-- `named_args!`: Makes a function from a parser combination with arguments
-- `named_attr!`: Makes a function from a parser combination, with attributes
-- `try_parse!`: A bit like `std::try!`, this macro will return the remaining input and parsed value if the child parser returned `Ok`, and will do an early return for `Error` and `Incomplete`. This can provide more flexibility than `do_parse!` if needed
-- `success`: Returns a value without consuming any input, always succeeds
+- [`success`](https://docs.rs/nom/latest/nom/combinator/fn.success.html): Returns a value without consuming any input, always succeeds
 
 ## Character test functions
 
-Use these functions with a combinator like `take_while!`:
+Use these functions with a combinator like `take_while`:
 
-- `is_alphabetic`: Tests if byte is ASCII alphabetic: `[A-Za-z]`
-- `is_alphanumeric`: Tests if byte is ASCII alphanumeric: `[A-Za-z0-9]`
-- `is_digit`: Tests if byte is ASCII digit: `[0-9]`
-- `is_hex_digit`: Tests if byte is ASCII hex digit: `[0-9A-Fa-f]`
-- `is_oct_digit`: Tests if byte is ASCII octal digit: `[0-7]`
-- `is_space`: Tests if byte is ASCII space or tab: `[ \t]`
-- `alpha`: Recognizes one or more lowercase and uppercase alphabetic characters: `[a-zA-Z]`
-- `alphanumeric`: Recognizes one or more numerical and alphabetic characters: `[0-9a-zA-Z]`
-- `anychar`: 
-- `begin`: 
-- `crlf`: 
-- `digit`: Recognizes one or more numerical characters: `[0-9]`
-- `double`: Recognizes floating point number in a byte string and returns a `f64`
-- `eol`: 
-- `float`: Recognizes floating point number in a byte string and returns a `f32`
-- `hex_digit`: Recognizes one or more hexadecimal numerical characters: `[0-9A-Fa-f]`
-- `hex_u32`: Recognizes a hex-encoded integer
-- `line_ending`: Recognizes an end of line (both `\n` and `\r\n`)
-- `multispace`: Recognizes one or more spaces, tabs, carriage returns and line feeds
-- `newline`: Matches a newline character `\n`
-- `non_empty`: Recognizes non empty buffers
-- `not_line_ending`: 
-- `oct_digit`: Recognizes one or more octal characters: `[0-7]`
-- `rest`: Return the remaining input
-- `shift`: 
-- `sized_buffer`: 
-- `space`: Recognizes one or more spaces and tabs
-- `tab`: Matches a tab character `\t`
+- [`is_alphabetic`](https://docs.rs/nom/latest/nom/character/fn.is_alphabetic.html): Tests if byte is ASCII alphabetic: `[A-Za-z]`
+- [`is_alphanumeric`](https://docs.rs/nom/latest/nom/character/fn.is_alphanumeric.html): Tests if byte is ASCII alphanumeric: `[A-Za-z0-9]`
+- [`is_digit`](https://docs.rs/nom/latest/nom/character/fn.is_digit.html): Tests if byte is ASCII digit: `[0-9]`
+- [`is_hex_digit`](https://docs.rs/nom/latest/nom/character/fn.is_hex_digit.html): Tests if byte is ASCII hex digit: `[0-9A-Fa-f]`
+- [`is_oct_digit`](https://docs.rs/nom/latest/nom/character/fn.is_oct_digit.html): Tests if byte is ASCII octal digit: `[0-7]`
+- [`is_space`](https://docs.rs/nom/latest/nom/character/fn.is_space.html): Tests if byte is ASCII space or tab: `[ \t]`
+- [`is_newline`](https://docs.rs/nom/latest/nom/character/fn.is_newline.html): Tests if byte is ASCII newline: `[\n]`
+
+Alternatively there are ready to use function:
+
+- [`alpha0`](https://docs.rs/nom/latest/nom/character/complete/fn.alpha0.html): Recognizes zero or more lowercase and uppercase alphabetic characters: `[a-zA-Z]`. [`alpha1`](https://docs.rs/nom/latest/nom/character/complete/fn.alpha1.html) does the same but returns at least one character
+- [`alphanumeric0`](https://docs.rs/nom/latest/nom/character/complete/fn.alphanumeric0.html): Recognizes zero or more numerical and alphabetic characters: `[0-9a-zA-Z]`. [`alphanumeric1`](https://docs.rs/nom/latest/nom/character/complete/fn.alphanumeric1.html) does the same but returns at least one character
+- [`anychar`](https://docs.rs/nom/latest/nom/character/complete/fn.anychar.html): Matches one byte as a character
+- [`crlf`](https://docs.rs/nom/latest/nom/character/complete/fn.crlf.html): Recognizes the string `\r\n`
+- [`digit0`](https://docs.rs/nom/latest/nom/character/complete/fn.digit0.html): Recognizes zero or more numerical characters: `[0-9]`. [`digit1`](https://docs.rs/nom/latest/nom/character/complete/fn.digit1.html) does the same but returns at least one character
+- [`double`](https://docs.rs/nom/latest/nom/number/complete/fn.double.html): Recognizes floating point number in a byte string and returns a `f64`
+- [`float`](https://docs.rs/nom/latest/nom/number/complete/fn.float.html): Recognizes floating point number in a byte string and returns a `f32`
+- [`hex_digit0`](https://docs.rs/nom/latest/nom/character/complete/fn.hex_digit0.html): Recognizes zero or more hexadecimal numerical characters: `[0-9A-Fa-f]`. [`hex_digit1`](https://docs.rs/nom/latest/nom/character/complete/fn.hex_digit1.html) does the same but returns at least one character
+- [`hex_u32`](https://docs.rs/nom/latest/nom/number/complete/fn.hex_u32.html): Recognizes a hex-encoded integer
+- [`line_ending`](https://docs.rs/nom/latest/nom/character/complete/fn.line_ending.html): Recognizes an end of line (both `\n` and `\r\n`)
+- [`multispace0`](https://docs.rs/nom/latest/nom/character/complete/fn.multispace0.html): Recognizes zero or more spaces, tabs, carriage returns and line feeds. [`multispace1`](https://docs.rs/nom/latest/nom/character/complete/fn.multispace1.html) does the same but returns at least one character
+- [`newline`](https://docs.rs/nom/latest/nom/character/complete/fn.newline.html): Matches a newline character `\n`
+- [`not_line_ending`](https://docs.rs/nom/latest/nom/character/complete/fn.not_line_ending.html): Recognizes a string of any char except `\r` or `\n`
+- [`oct_digit0`](https://docs.rs/nom/latest/nom/character/complete/fn.oct_digit0.html): Recognizes zero or more octal characters: `[0-7]`. [`oct_digit1`](https://docs.rs/nom/latest/nom/character/complete/fn.oct_digit1.html) does the same but returns at least one character
+- [`rest`](https://docs.rs/nom/latest/nom/combinator/fn.rest.html): Return the remaining input
+- [`space0`](https://docs.rs/nom/latest/nom/character/complete/fn.space0.html): Recognizes zero or more spaces and tabs. [`space1`](https://docs.rs/nom/latest/nom/character/complete/fn.space1.html) does the same but returns at least one character
+- [`tab`](https://docs.rs/nom/latest/nom/character/complete/fn.tab.html): Matches a tab character `\t`


### PR DESCRIPTION
This should fix #1290

I updated the `doc/choosing_a_combinator.md` to use function links. I added links where they were missing and removed every macro from the list. Below you can find the list of removed elements:

- [`opt_res`](https://docs.rs/nom/6.1.2/nom/macro.opt_res.html)
- [`switch`](https://docs.rs/nom/6.1.2/nom/macro.switch.html)
- [`do_parse`](https://docs.rs/nom/6.1.2/nom/macro.do_parse.html)
- [`opt_res`](https://docs.rs/nom/6.1.2/nom/macro.opt_res.html)
- [`parse_to`](https://docs.rs/nom/6.1.2/nom/macro.parse_to.html)
- [`return_error`](https://docs.rs/nom/6.1.2/nom/macro.return_error.html)
- [`tap`](https://docs.rs/nom/6.1.2/nom/macro.tap.html)
- [`add_return_error`](https://docs.rs/nom/6.1.2/nom/macro.add_return_error.html)
- [`dbg` (now `dbg_basic`)](https://docs.rs/nom/6.1.2/nom/macro.dbg_basic.html)
- [`error_node_position`](https://docs.rs/nom/6.1.2/nom/macro.error_node_position.html)
- [`error_position`](https://docs.rs/nom/6.1.2/nom/macro.error_position.html)
- [`fix_error`](https://docs.rs/nom/6.1.2/nom/macro.fix_error.html)
- [`tag_bits`](https://docs.rs/nom/6.1.2/nom/macro.tag_bits.html)
- [`take_bits`](https://docs.rs/nom/6.1.2/nom/macro.take_bits.html)
- `apply!`: Do not exist anymore
- [`call`](https://docs.rs/nom/6.1.2/nom/macro.call.html)
- `method!`: Do not exist anymore
- [`named`](https://docs.rs/nom/6.1.2/nom/macro.named.html)
- [`named_args`](https://docs.rs/nom/6.1.2/nom/macro.named_args.html)
- [`named_attr`](https://docs.rs/nom/6.1.2/nom/macro.named_attr.html)
- [`try_parse`](https://docs.rs/nom/6.1.2/nom/macro.try_parse.html)
- `begin`: Do not exist anymore
- `eol`: Do not exist anymore
- `non_empty`: Do not exist anymore
- `shift`: Do not exist anymore
- `sized_buffer`: Do not exist anymore