### PR TITLE
Hide duplicated content of std in the docs caused by std re-export

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,15 +436,19 @@ pub mod lib {
   #[allow(missing_doc_code_examples)]
   /// internal std exports for no_std compatibility
   pub mod std {
+    #[doc(hidden)]
     #[cfg(not(feature = "alloc"))]
     pub use core::borrow;
 
     #[cfg(feature = "alloc")]
+    #[doc(hidden)]
     pub use alloc::{borrow, boxed, string, vec};
 
+    #[doc(hidden)]
     pub use core::{cmp, convert, fmt, iter, mem, ops, option, result, slice, str};
 
     /// internal reproduction of std prelude
+    #[doc(hidden)]
     pub mod prelude {
       pub use core::prelude as v1;
     }
@@ -454,12 +458,14 @@ pub mod lib {
   #[allow(missing_doc_code_examples)]
   /// internal std exports for no_std compatibility
   pub mod std {
+    #[doc(hidden)]
     pub use std::{
       alloc, borrow, boxed, cmp, collections, convert, fmt, hash, iter, mem, ops, option, result,
       slice, str, string, vec,
     };
 
     /// internal reproduction of std prelude
+    #[doc(hidden)]
     pub mod prelude {
       pub use std::prelude as v1;
     }


### PR DESCRIPTION
I'm having difficulty searching nom's documentation, because it re-exports a large chunk of `std`, so whatever I search for, I get dozens of `std` results unrelated to `nom`.

This hides internals of the `std` re-export, so that nom's documentation search has mainly nom-related results.

The top-level `std` symbol remains visible in the docs.