### PR TITLE
fix IResult’s declaration in top-level documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,9 +175,9 @@
 //! `IResult` is an alias for the `Result` type:
 //!
 //! ```rust
-//! use nom::{Needed, error::ErrorKind};
+//! use nom::{Needed, error::Error};
 //!
-//! type IResult<I, O, E = (I,ErrorKind)> = Result<(I, O), Err<E>>;
+//! type IResult<I, O, E = Error<I>> = Result<(I, O), Err<E>>;
 //!
 //! enum Err<E> {
 //!   Incomplete(Needed),


### PR DESCRIPTION
There’s a documentation code block that was left behind when `nom::error::Error` was introduced. This PR updates it to match `IResult` current definition.