### PR TITLE
docsrs: fix build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,7 +404,6 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::doc_markdown))]
 #![cfg_attr(nightly, feature(test))]
 #![cfg_attr(feature = "docsrs", feature(doc_cfg))]
-#![cfg_attr(feature = "docsrs", feature(external_doc))]
 #![deny(missing_docs)]
 #![warn(missing_doc_code_examples)]
 
@@ -521,5 +520,5 @@ mod str;
 pub mod number;
 
 #[cfg(feature = "docsrs")]
-#[cfg_attr(feature = "docsrs", doc(include = "../doc/nom_recipes.md"))]
+#[cfg_attr(feature = "docsrs", doc = include_str!("../doc/nom_recipes.md"))]
 pub mod recipes {}


### PR DESCRIPTION
This should fix the docsrs build issues for 6.2.0

The following command works thanks to this fix:
```sh
cargo +nightly doc --features docsrs,default
```

For reference the build logs can be found there https://docs.rs/crate/nom/6.2.0/builds/401812