### PR TITLE
coverage: fix issue with `skip` and `tarpaulin`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: cargo-tarpaulin
+          args: cargo-tarpaulin --version 0.18.0-alpha3 # @TODO restore to normal (https://github.com/xd009642/tarpaulin/issues/756#issuecomment-838769320)
 
       - name: Run cargo tarpaulin
         uses: actions-rs/cargo@v1
@@ -185,4 +185,4 @@ jobs:
           TOKEN: ${{ secrets.COVERALLS_TOKEN }}
         with:
           command: tarpaulin
-          args: --coveralls "$TOKEN"
+          args: --coveralls "$TOKEN" --avoid-cfg-tarpaulin # @TODO restore to normal (https://github.com/xd009642/tarpaulin/issues/756#issuecomment-838769320)


### PR DESCRIPTION
Looking at https://github.com/xd009642/tarpaulin/issues/756 we could fix coverage generation with the following changes

In local the following commands work, so it should on CI too:
```sh
$ cargo install cargo-tarpaulin --version 0.18.0-alpha3
$ cargo tarpaulin -o Html
```