### PR TITLE
lazy_many1 handles Incomplete error with a success if there is at least one match

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -109,7 +109,7 @@ where
       loop {
         let len = i.input_len();
         match f.parse(i.clone()) {
-          Err(Err::Error(_)) => return Ok((i, acc)),
+          Err(Err::Error(_)| Err::Incomplete(_)) => return Ok((i, acc)),
           Err(e) => return Err(e),
           Ok((i1, o)) => {
             // infinite loop check: the parser must always consume

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -13,7 +13,7 @@ use crate::{
   lib::std::vec::Vec,
   multi::{
     count, fold_many0, fold_many1, fold_many_m_n, length_count, many0, many1, many_m_n, many_till,
-    separated_list0, separated_list1,
+    lazy_many1, separated_list0, separated_list1,
   },
 };
 
@@ -160,6 +160,30 @@ fn many1_test() {
     Err(Err::Error(error_position!(c, ErrorKind::Tag)))
   );
   assert_eq!(multi(d), Err(Err::Incomplete(Needed::new(2))));
+}
+
+#[test]
+#[cfg(feature = "alloc")]
+fn lazy1_test() {
+  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    lazy_many1(tag("abcd"))(i)
+  }
+
+  let a = &b"abcdef"[..];
+  let b = &b"abcdabcdefgh"[..];
+  let c = &b"azerty"[..];
+  let d = &b"abcdab"[..];
+
+  let res1 = vec![&b"abcd"[..]];
+  assert_eq!(multi(a), Ok((&b"ef"[..], res1)));
+  let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
+  assert_eq!(multi(b), Ok((&b"efgh"[..], res2)));
+  assert_eq!(
+    multi(c),
+    Err(Err::Error(error_position!(c, ErrorKind::Tag)))
+  );
+  let res3 = vec![&b"abcd"[..]];
+  assert_eq!(multi(d), Ok((&b"ab"[..], res3)));
 }
 
 #[test]

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -63,8 +63,8 @@ fn overflow_incomplete_many1() {
 
   // Trigger an overflow in many1
   assert_eq!(
-    multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]),
-    Err(Err::Incomplete(Needed::new(18446744073709551599)))
+    multi(&b"\xaa\xff\xff\xff\xff\xff\xff\xff\xef\x00\x00\x00\x00\x00\x00\x00\x01"[..]),
+    Err(Err::Incomplete(Needed::new(12321848580485677046)))
   );
 }
 

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -63,6 +63,22 @@ fn overflow_incomplete_many1() {
 
   // Trigger an overflow in many1
   assert_eq!(
+    multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]),
+    Err(Err::Incomplete(Needed::new(18446744073709551599)))
+  );
+}
+
+#[test]
+#[cfg(feature = "alloc")]
+fn overflow_incomplete_lazy_many1() {
+  use nom::multi::lazy_many1;
+
+  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    lazy_many1(length_data(be_u64))(i)
+  }
+
+  // Trigger an overflow in lazy_many1
+  assert_eq!(
     multi(&b"\xaa\xff\xff\xff\xff\xff\xff\xff\xef\x00\x00\x00\x00\x00\x00\x00\x01"[..]),
     Err(Err::Incomplete(Needed::new(12321848580485677046)))
   );


### PR DESCRIPTION
This PR changes `many1` to return a success if there is at least one match in case of `Err::Incomplete`.

## Motivation

When working with a streaming parser, it is convenient to parse as many items as possible for a given buffer.

Unfortunately `many1` does not enable a user to process the items as there are found because it requires to have a buffer large enough to capture the entire sequence of items.

## Change

With this change, it is possible to process incrementally a streaming parser using `many1`.

If at least one match has been captured so far, `many1` returns it with the appropriate rest so the user can parse the entire dataset by repeating the following process:

1. init or extend buffer
2. `many1` returns matches found with rest
3. `many1` fails because zero matches are found
4. back to 1

## Notes

I understand that this is a breaking change so I would be happy to use another combinator to achieve the same result if necessary.

For the time being I am using a copy of the function in my [project](https://github.com/agourlay/hprof-slurp/blob/master/src/record_parser.rs#L108) and it is working just fine so there is no hurry.

Thank you for this awesome library ❤️ 