### PR TITLE
Fix typo: add "#" before "Arguments"

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1066,7 +1066,7 @@ where
 
 /// Gets a number from the first parser,
 /// then applies the second parser that many times.
-/// Arguments
+/// # Arguments
 /// * `f` The parser to apply to obtain the count.
 /// * `g` The parser to apply repeatedly.
 /// ```rust


### PR DESCRIPTION
Just a typo fix.  
Have a nice day :)  