### PR TITLE
Remove Clone trait bound from fold parsers

### DIFF
--- a/examples/string.rs
+++ b/examples/string.rs
@@ -148,7 +148,7 @@ where
     // Our parser function– parses a single string fragment
     parse_fragment,
     // Our init value, an empty string
-    String::new(),
+    String::new,
     // Our folding function. For each fragment, append the fragment to the
     // string.
     |mut string, fragment| {

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -422,10 +422,10 @@ fn fold_many0_test() {
     acc
   }
   fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-    fold_many0(tag("abcd"), Vec::new(), fold_into_vec)(i)
+    fold_many0(tag("abcd"), Vec::new, fold_into_vec)(i)
   }
   fn multi_empty(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-    fold_many0(tag(""), Vec::new(), fold_into_vec)(i)
+    fold_many0(tag(""), Vec::new, fold_into_vec)(i)
   }
 
   assert_eq!(multi(&b"abcdef"[..]), Ok((&b"ef"[..], vec![&b"abcd"[..]])));
@@ -454,7 +454,7 @@ fn fold_many1_test() {
     acc
   }
   fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-    fold_many1(tag("abcd"), Vec::new(), fold_into_vec)(i)
+    fold_many1(tag("abcd"), Vec::new, fold_into_vec)(i)
   }
 
   let a = &b"abcdef"[..];
@@ -481,7 +481,7 @@ fn fold_many_m_n_test() {
     acc
   }
   fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-    fold_many_m_n(2, 4, tag("Abcd"), Vec::new(), fold_into_vec)(i)
+    fold_many_m_n(2, 4, tag("Abcd"), Vec::new, fold_into_vec)(i)
   }
 
   let a = &b"Abcdef"[..];

--- a/tests/arithmetic.rs
+++ b/tests/arithmetic.rs
@@ -39,7 +39,7 @@ fn term(i: &str) -> IResult<&str, i64> {
 
   fold_many0(
     pair(alt((char('*'), char('/'))), factor),
-    init,
+    move || init,
     |acc, (op, val): (char, i64)| {
       if op == '*' {
         acc * val
@@ -55,7 +55,7 @@ fn expr(i: &str) -> IResult<&str, i64> {
 
   fold_many0(
     pair(alt((char('+'), char('-'))), term),
-    init,
+    move || init,
     |acc, (op, val): (char, i64)| {
       if op == '+' {
         acc + val

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -83,7 +83,7 @@ fn character(input: &str) -> IResult<&str, char> {
 fn string(input: &str) -> IResult<&str, String> {
   delimited(
     char('"'),
-    fold_many0(character, String::new(), |mut string, c| {
+    fold_many0(character, String::new, |mut string, c| {
       string.push(c);
       string
     }),

--- a/tests/reborrow_fold.rs
+++ b/tests/reborrow_fold.rs
@@ -23,7 +23,7 @@ fn atom<'a>(_tomb: &'a mut ()) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], Stri
 fn list<'a>(i: &'a [u8], tomb: &'a mut ()) -> IResult<&'a [u8], String> {
   delimited(
     char('('),
-    fold_many0(atom(tomb), String::new(), |acc: String, next: String| {
+    fold_many0(atom(tomb), String::new, |acc: String, next: String| {
       acc + next.as_str()
     }),
     char(')'),


### PR DESCRIPTION
<!--
Hello, and thank you for submitting a pull request to nom!

First, please note that, for family reasons, I have limited time to work on
nom, so following the advice here will make sure I will quickly understand
your work and be able to merge it early.
Second, if I don't get to work on your PR quickly, that does not mean I won't
include it later. Major version releases happen once a year, and a lot of
interesting work is merged for the occasion. So I will get back to you :)

## Prerequisites

Please provide the following information with this pull request:

- related issue number (I need some context to understand a PR with a lot of
code, except for documentation typos)
- a test case reproducing the issue. You can write it in [issues.rs](https://github.com/Geal/nom/blob/master/tests/issues.rs)
- if adding a new combinator, please add code documentation and some unit tests
in the same file. Also, please update the [combinator list](https://github.com/Geal/nom/blob/master/doc/choosing_a_combinator.md)

## Code style

This project follows a [code style](https://github.com/Geal/nom/blob/master/rustfmt.toml)
checked by [rustfmt][https://github.com/rust-lang-nursery/rustfmt].

Please avoid cosmetic fixes unrelated to the pull request. Keeping the changes
as small as possible increase your chances of getting this merged quickly.

## Rebasing

To make sure the changes will work properly once merged into the master branch
(which might have changed while you were working on your PR), please
[rebase your PR on master](https://git-scm.com/book/en/v2/Git-Branching-Rebasing).

## Squashing the commits

If the pull request include a lot of small commits used for testing, debugging,
or correcting previous work, it might be useful to
[squash the commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
to make the code easier to merge.
-->
This PR fixes #1008.

It removes the `R: Clone` bound for the initial acculumators of the `fold_*` family of nom parsers. This is accomplished by using a supplier function `FnMut() -> R` that returns a new accumulator instead of needing the parser to clone a new one.

This allows `fold_*` to be used even if the resulting type is not cloneable. Cloning the accumulator is still possible if desired but must be done by the supplier function.

This is a breaking change but migration is relatively easy as the intial accumulator can simply be wrapped in a closure/be replaced by a function reference.