### PR TITLE
Build docs with docsrs / fix broken intra link warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --verbose --features "std lexical"
+          args: --verbose --features "std lexical docsrs"
 
   fmt:
     name: Check formatting

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,7 +28,7 @@ pub trait ParseError<I>: Sized {
   }
 
   /// Combines two existing errors. This function is used to compare errors
-  /// generated in various branches of [alt]
+  /// generated in various branches of `alt`.
   fn or(self, other: Self) -> Self {
     other
   }
@@ -45,7 +45,7 @@ pub trait ContextError<I>: Sized {
   }
 }
 
-/// This trait is required by the [map_res] combinator to integrate
+/// This trait is required by the `map_res` combinator to integrate
 /// error types from external functions, like [std::str::FromStr]
 pub trait FromExternalError<I, E> {
   /// Creates a new error from an input position, an [ErrorKind] indicating the


### PR DESCRIPTION
The PR eliminates all warnings of the doc build job.