### PR TITLE
Add simple take_one

### DIFF
--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -412,6 +412,27 @@ where
   }
 }
 
+/// Returns one byte from input
+///
+/// # Streaming Specific
+/// *Streaming version* will return `Err::Incomplete(Needed::new(1))` if the input is empty
+///
+/// # Example
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}};
+/// use nom::bytes::streaming::take_one;
+///
+///
+/// assert_eq!(take_one::<(_, ErrorKind)>(&[1, 2, 3]), Ok((&[2u8, 3][..], 1u8)));
+/// assert_eq!(take_one::<(_, ErrorKind)>(&[]), Err(Err::Error(Error::new(&[], ErrorKind::Eof))));
+/// ```
+pub fn take_one<'a, Error: ParseError<&'a [u8]>>(input: &'a [u8]) -> IResult<&'a [u8], u8, Error> {
+  match input.split_first() {
+    None => Err(Err::Error(Error::from_error_kind(input, ErrorKind::Eof))),
+    Some((&b, tail)) => Ok((tail, b)),
+  }
+}
+
 /// Returns the input slice up to the first occurrence of the pattern.
 ///
 /// It doesn't consume the pattern. It will return `Err(Err::Error((_, ErrorKind::TakeUntil)))`

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -432,6 +432,27 @@ where
   }
 }
 
+/// Returns one byte from input
+///
+/// # Streaming Specific
+/// *Streaming version* will return `Err::Incomplete(Needed::new(1))` if the input is empty
+///
+/// # Example
+/// ```rust
+/// # use nom::{Err, Needed, error::ErrorKind};
+/// use nom::bytes::streaming::take_one;
+///
+///
+/// assert_eq!(take_one::<(_, ErrorKind)>(&[1, 2, 3]), Ok((&[2u8, 3][..], 1u8)));
+/// assert_eq!(take_one::<(_, ErrorKind)>(&[]), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+pub fn take_one<'a, Error: ParseError<&'a [u8]>>(input: &'a [u8]) -> IResult<&'a [u8], u8, Error> {
+  match input.split_first() {
+    None => Err(Err::Incomplete(Needed::new(1))),
+    Some((&b, tail)) => Ok((tail, b)),
+  }
+}
+
 /// Returns the input slice up to the first occurrence of the pattern.
 ///
 /// It doesn't consume the pattern.


### PR DESCRIPTION
Simple equivalent of `anychar()` unfortunately I try to make it generic over input but it's related quite difficult:

- `InputIter` could have a `split_first` but array implementation prevent `fn split_first(&self) -> Option<(Self::Item, Self)>` cause this require to return Self but Self is reduce by one so the returned array is not Self anymore.
- `InputTake` doesn't have Sized to return `Self` and doesn't have `Item` I try to add `Self: InputIter` but I don't know if this would require GAT to compile I didn't succeed.

Anyway, this combinator only make sense for thing that contains u8, so I guess taking a `&[u8]` is ok.

PS: I wonder if the implementation for array of `InputTake` is really useful and not just a bit limiter to what we can do with nom trait.