### PR TITLE
Fix docs: misleading argument order (streaming::escaped_transform)

### DIFF
--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -629,7 +629,7 @@ where
 ///     alt((
 ///       value("\\", tag("\\")),
 ///       value("\"", tag("\"")),
-///       value("n", tag("\n")),
+///       value("\n", tag("n")),
 ///     ))
 ///   )(input)
 /// }


### PR DESCRIPTION
The docs example for streaming::escaped_transform is very misleading, as
it would transform backslash+newline to just n, not backslash+n to
newline, as most people would expect.

This is already correct in the docs for complete::escaped_transform and
the tests, this seems to be an oversight.
