### PR TITLE
Increment minimal-lexical version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ default = ["std"]
 docsrs = []
 
 [dependencies.minimal-lexical]
-version = "0.1.2"
+version = "0.2.0"
 default-features = false
 
 [dependencies.memchr]


### PR DESCRIPTION
This both removes `stackvec` as a transient dependency, since it is no longer necessary, and ensure builds in a `no_std` environment with a system allocator. Fixes #1389. Since the stack-based vector is sufficient, and relatively compact, I've used it as the default in all cases.