### PR TITLE
Implement Alt<I, O, E> for the 1-tuple type

### DIFF
--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -183,6 +183,15 @@ macro_rules! alt_trait_inner(
 
 alt_trait!(A B C D E F G H I J K L M N O P Q R S T U);
 
+// Manually implement Alt for (A,), the 1-tuple type
+impl<Input, Output, Error: ParseError<Input>, A: Parser<Input, Output, Error>>
+  Alt<Input, Output, Error> for (A,)
+{
+  fn choice(&mut self, input: Input) -> IResult<Input, Output, Error> {
+    self.0.parse(input)
+  }
+}
+
 macro_rules! permutation_trait(
   (
     $name1:ident $ty1:ident $item1:ident


### PR DESCRIPTION
This PR enables the use of the `alt()` combinator on a 1-tuple of parsers. While this likely isn't useful in finalized code, it's an edge case that has come up a surprising number of times when prototyping nom parsers. For instance, I'm currently writing a parser for a toy programming language. Specifically, I'm working on unary operators. The relevant type for these is pretty minimal at the moment:

```rust
#[derive(Clone, Debug, Eq, PartialEq)]
pub enum UnaryOperator {
    Negate,
}
```

I'm also working on building up a parser function that will attempt to parse any unary operator. I tried to implement this as follows.

```rust
use nom::branch::alt;
use nom::character::complete::char;
use nom::combinator::value;
use nom::IResult;

fn negate(input: &str) -> IResult<&str, UnaryOperator> {
    value(UnaryOperator::Negate, char('-'))(input)
}

fn unary_operator(input: &str) -> IResult<&str, UnaryOperator> {
    alt((negate,))(input)
}
```

While the body of `unary_operator` might look a little strange, I wrote it that way for a couple of reasons:

1. To convey intent more clearly: to me, this reads "this is any of n possible operators," which makes the need for the `unary_operator` parser more apparent, even if n is currently one.
2. To make the diffs when I do implement other operators tidier, drawing attention to the new parsers rather than the introduction of a new combinator (`alt()`).

While these reasons may seem flimsy, I don't see much reason not to support this edge case, as people typing constructs of the form `f((value,))` are unlikely to have done so by accident.

The only interesting technical detail in this PR is that, because only a single parser will need to see the input, there is no `Clone` bound on the implementation for the 1-tuple, unlike with other tuple sizes. Both because of this difference in trait bounds and a desire for simplicity, I implemented this the old-fashioned way rather than modify existing macros.