### PR TITLE
Add my pseudocode interpreter to the list of projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Here is a (non exhaustive) list of known projects using nom:
 [SystemVerilog](https://github.com/dalance/sv-parser),
 [Turtle](https://github.com/vandenoever/rome/tree/master/src/io/turtle),
 [CSML](https://github.com/CSML-by-Clevy/csml-interpreter)
+[Pseudocode](https://github.com/Gungy2/pseudocode)
 - Interface definition formats: [Thrift](https://github.com/thehydroimpulse/thrust)
 - Audio, video and image formats:
 [GIF](https://github.com/Geal/gif.rs),


### PR DESCRIPTION
Hello! I made a small interpreter for a pseudocode-type language used in Romanian high schools, using nom. I included it in the list of projects, in the README file.