### PR TITLE
Remove jemalloc in tests and examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,11 @@ default-features = false
 
 [dev-dependencies]
 criterion = "0.3"
-jemallocator = "^0.3"
 doc-comment = "0.3"
 proptest = "1.0.0"
+
+[target.'cfg(not(all(target_os = "windows", target_env = "msvc")))'.dev-dependencies]
+jemallocator = "^0.3"
 
 [build-dependencies]
 version_check = "0.9"

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,8 +1,5 @@
 #![cfg(feature = "alloc")]
 
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 use nom::{
   branch::alt,
   bytes::complete::{escaped, tag, take_while},

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -1,11 +1,5 @@
 #![cfg(feature = "alloc")]
 
-
-use jemallocator;
-
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 use nom::{
   branch::alt,
   bytes::complete::{escaped, tag, take_while},

--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -4,9 +4,6 @@
 
 #![cfg(feature = "alloc")]
 
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 use nom::{
   branch::alt,
   bytes::complete::tag,

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -11,9 +11,6 @@
 
 #![cfg(feature = "alloc")]
 
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 use nom::branch::alt;
 use nom::bytes::streaming::{is_not, take_while_m_n};
 use nom::character::streaming::{char, multispace1};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,16 +445,16 @@ pub use self::str::*;
 #[macro_use]
 pub mod error;
 
+pub mod combinator;
 mod internal;
 mod traits;
-pub mod combinator;
 #[macro_use]
 pub mod branch;
-pub mod sequence;
 pub mod multi;
+pub mod sequence;
 
-pub mod bytes;
 pub mod bits;
+pub mod bytes;
 
 pub mod character;
 


### PR DESCRIPTION
jemalloc doesn't compile on windows (only with windows gnu) it make run test a little annoying, related https://github.com/Geal/nom/issues/1270

- [x] Remove jemalloc from tests
- [x] Remove jemalloc from examples
- [x] make optional jemalloc use in bench (impossible)
- [x] only compile jemallocator for everything except windows-msvc