### PR TITLE
Renaming !

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -34,7 +34,7 @@ let a = b"abcdabcd";
 
 fn main() {
   let res = vec![&b"abcd"[..], &b"abcd"[..]];
-  assert_eq!(multi(&a[..]),Ok((&b""[..], res))); // returns Err::Incomplete(Unknown))
+  assert_eq!(multi(&a[..]),Ok((&b""[..], res))); // returns Outcome::Incomplete(Unknown))
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ error prone plumbing.
 ```rust
 extern crate nom;
 use nom::{
-  IResult,
+  ParseResult,
   bytes::complete::{tag, take_while_m_n},
   combinator::map_res,
   sequence::tuple
@@ -45,14 +45,14 @@ fn is_hex_digit(c: char) -> bool {
   c.is_digit(16)
 }
 
-fn hex_primary(input: &str) -> IResult<&str, u8> {
+fn hex_primary(input: &str) -> ParseResult<&str, u8> {
   map_res(
     take_while_m_n(2, 2, is_hex_digit),
     from_hex
   )(input)
 }
 
-fn hex_color(input: &str) -> IResult<&str, Color> {
+fn hex_color(input: &str) -> ParseResult<&str, Color> {
   let (input, _) = tag("#")(input)?;
   let (input, (red, green, blue)) = tuple((hex_primary, hex_primary, hex_primary))(input)?;
 

--- a/benches/arithmetic.rs
+++ b/benches/arithmetic.rs
@@ -11,7 +11,7 @@ use nom::{
   combinator::map_res,
   multi::fold_many0,
   sequence::{delimited, pair},
-  IResult,
+  ParseResult,
 };
 
 // Parser definition
@@ -19,7 +19,7 @@ use nom::{
 // We transform an integer string into a i64, ignoring surrounding whitespaces
 // We look for a digit suite, and try to convert it.
 // If there are no digits, we look for a parenthesized expression.
-fn factor(input: &[u8]) -> IResult<&[u8], i64> {
+fn factor(input: &[u8]) -> ParseResult<&[u8], i64> {
   delimited(
     space0,
     alt((
@@ -35,7 +35,7 @@ fn factor(input: &[u8]) -> IResult<&[u8], i64> {
 // We read an initial factor and for each time we find
 // a * or / operator followed by another factor, we do
 // the math by folding everything
-fn term(input: &[u8]) -> IResult<&[u8], i64> {
+fn term(input: &[u8]) -> ParseResult<&[u8], i64> {
   let (input, init) = factor(input)?;
   fold_many0(
     pair(one_of("*/"), factor),
@@ -50,7 +50,7 @@ fn term(input: &[u8]) -> IResult<&[u8], i64> {
   )(input)
 }
 
-fn expr(input: &[u8]) -> IResult<&[u8], i64> {
+fn expr(input: &[u8]) -> ParseResult<&[u8], i64> {
   let (input, init) = term(input)?;
   fold_many0(
     pair(one_of("+-"), term),

--- a/benches/http.rs
+++ b/benches/http.rs
@@ -4,7 +4,7 @@
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use criterion::*;
-use nom::{IResult, bytes::complete::{tag, take_while1}, character::complete::{line_ending, char}, multi::many1};
+use nom::{ParseResult, bytes::complete::{tag, take_while1}, character::complete::{line_ending, char}, multi::many1};
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 #[derive(Debug)]
@@ -67,7 +67,7 @@ fn is_version(c: u8) -> bool {
   c >= b'0' && c <= b'9' || c == b'.'
 }
 
-fn request_line(input: &[u8]) -> IResult<&[u8], Request<'_>> {
+fn request_line(input: &[u8]) -> ParseResult<&[u8], Request<'_>> {
   let (input, method) = take_while1(is_token)(input)?;
   let (input, _) = take_while1(is_space)(input)?;
   let (input, uri) = take_while1(is_not_space)(input)?;
@@ -78,14 +78,14 @@ fn request_line(input: &[u8]) -> IResult<&[u8], Request<'_>> {
   Ok((input, Request {method, uri, version}))
 }
 
-fn http_version(input: &[u8]) -> IResult<&[u8], &[u8]> {
+fn http_version(input: &[u8]) -> ParseResult<&[u8], &[u8]> {
   let (input, _) = tag("HTTP/")(input)?;
   let (input, version) = take_while1(is_version)(input)?;
 
   Ok((input, version))
 }
 
-fn message_header_value(input: &[u8]) -> IResult<&[u8], &[u8]> {
+fn message_header_value(input: &[u8]) -> ParseResult<&[u8], &[u8]> {
   let (input, _) = take_while1(is_horizontal_space)(input)?;
   let (input, data) = take_while1(not_line_ending)(input)?;
   let (input, _) = line_ending(input)?;
@@ -93,7 +93,7 @@ fn message_header_value(input: &[u8]) -> IResult<&[u8], &[u8]> {
   Ok((input, data))
 }
 
-fn message_header(input: &[u8]) -> IResult<&[u8], Header<'_>> {
+fn message_header(input: &[u8]) -> ParseResult<&[u8], Header<'_>> {
   let (input, name) = take_while1(is_token)(input)?;
   let (input, _) = char(':')(input)?;
   let (input, value) = many1(message_header_value)(input)?;
@@ -101,7 +101,7 @@ fn message_header(input: &[u8]) -> IResult<&[u8], Header<'_>> {
   Ok((input, Header{ name, value }))
 }
 
-fn request(input: &[u8]) -> IResult<&[u8], (Request<'_>, Vec<Header<'_>>)> {
+fn request(input: &[u8]) -> ParseResult<&[u8], (Request<'_>, Vec<Header<'_>>)> {
   let (input, req) = request_line(input)?;
   let (input, h) = many1(message_header)(input)?;
   let (input, _) = line_ending(input)?;

--- a/benches/ini.rs
+++ b/benches/ini.rs
@@ -11,19 +11,19 @@ use nom::{
   combinator::{map, map_res, opt},
   multi::many0,
   sequence::{delimited, pair, separated_pair, terminated, tuple},
-  IResult,
+  ParseResult,
 };
 use std::collections::HashMap;
 use std::str;
 
-fn category(i: &[u8]) -> IResult<&[u8], &str> {
+fn category(i: &[u8]) -> ParseResult<&[u8], &str> {
   map_res(
     delimited(char('['), take_while(|c| c != b']'), char(']')),
     str::from_utf8,
   )(i)
 }
 
-fn key_value(i: &[u8]) -> IResult<&[u8], (&str, &str)> {
+fn key_value(i: &[u8]) -> ParseResult<&[u8], (&str, &str)> {
   let (i, key) = map_res(alphanumeric, str::from_utf8)(i)?;
   let (i, _) = tuple((opt(space), char('='), opt(space)))(i)?;
   let (i, val) = map_res(take_while(|c| c != b'\n' && c != b';'), str::from_utf8)(i)?;
@@ -31,7 +31,7 @@ fn key_value(i: &[u8]) -> IResult<&[u8], (&str, &str)> {
   Ok((i, (key, val)))
 }
 
-fn categories(i: &[u8]) -> IResult<&[u8], HashMap<&str, HashMap<&str, &str>>> {
+fn categories(i: &[u8]) -> ParseResult<&[u8], HashMap<&str, HashMap<&str, &str>>> {
   map(
     many0(separated_pair(
       category,
@@ -69,7 +69,7 @@ port=143
 file=payroll.dat
 \0";
 
-  fn acc(i: &[u8]) -> IResult<&[u8], Vec<(&str, &str)>> {
+  fn acc(i: &[u8]) -> ParseResult<&[u8], Vec<(&str, &str)>> {
     many0(key_value)(i)
   }
 

--- a/benches/ini_str.rs
+++ b/benches/ini_str.rs
@@ -9,7 +9,7 @@ use nom::{
   combinator::opt,
   multi::many0,
   sequence::{delimited, pair, terminated, tuple},
-  IResult,
+  ParseResult,
 };
 
 use std::collections::HashMap;
@@ -18,18 +18,18 @@ fn is_line_ending_or_comment(chr: char) -> bool {
   chr == ';' || chr == '\n'
 }
 
-fn space_or_line_ending(i: &str) -> IResult<&str, &str> {
+fn space_or_line_ending(i: &str) -> ParseResult<&str, &str> {
   is_a(" \r\n")(i)
 }
 
-fn category(i: &str) -> IResult<&str, &str> {
+fn category(i: &str) -> ParseResult<&str, &str> {
   terminated(
     delimited(char('['), take_while(|c| c != ']'), char(']')),
     opt(is_a(" \r\n")),
   )(i)
 }
 
-fn key_value(i: &str) -> IResult<&str, (&str, &str)> {
+fn key_value(i: &str) -> ParseResult<&str, (&str, &str)> {
   let (i, key) = alphanumeric(i)?;
   let (i, _) = tuple((opt(space), tag("="), opt(space)))(i)?;
   let (i, val) = take_till(is_line_ending_or_comment)(i)?;
@@ -39,26 +39,26 @@ fn key_value(i: &str) -> IResult<&str, (&str, &str)> {
   Ok((i, (key, val)))
 }
 
-fn keys_and_values_aggregator(i: &str) -> IResult<&str, Vec<(&str, &str)>> {
+fn keys_and_values_aggregator(i: &str) -> ParseResult<&str, Vec<(&str, &str)>> {
   many0(key_value)(i)
 }
 
-fn keys_and_values(input: &str) -> IResult<&str, HashMap<&str, &str>> {
+fn keys_and_values(input: &str) -> ParseResult<&str, HashMap<&str, &str>> {
   match keys_and_values_aggregator(input) {
     Ok((i, tuple_vec)) => Ok((i, tuple_vec.into_iter().collect())),
     Err(e) => Err(e),
   }
 }
 
-fn category_and_keys(i: &str) -> IResult<&str, (&str, HashMap<&str, &str>)> {
+fn category_and_keys(i: &str) -> ParseResult<&str, (&str, HashMap<&str, &str>)> {
   pair(category, keys_and_values)(i)
 }
 
-fn categories_aggregator(i: &str) -> IResult<&str, Vec<(&str, HashMap<&str, &str>)>> {
+fn categories_aggregator(i: &str) -> ParseResult<&str, Vec<(&str, HashMap<&str, &str>)>> {
   many0(category_and_keys)(i)
 }
 
-fn categories(input: &str) -> IResult<&str, HashMap<&str, HashMap<&str, &str>>> {
+fn categories(input: &str) -> ParseResult<&str, HashMap<&str, HashMap<&str, &str>>> {
   match categories_aggregator(input) {
     Ok((i, tuple_vec)) => Ok((i, tuple_vec.into_iter().collect())),
     Err(e) => Err(e),

--- a/benches/number.rs
+++ b/benches/number.rs
@@ -7,7 +7,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 use criterion::Criterion;
 use nom::number::complete;
 
-fn parser(i: &[u8]) -> nom::IResult<&[u8], u64> {
+fn parser(i: &[u8]) -> nom::ParseResult<&[u8], u64> {
   complete::be_u64(i)
 }
 

--- a/doc/custom_input_types.md
+++ b/doc/custom_input_types.md
@@ -11,10 +11,10 @@ that can carry line and column information, or to parse
 ## Implementing a custom type
 
 Let's assume we have an input type we'll call `MyInput`. `MyInput` is a sequence of `MyItem` type.
-The goal is to define nom parsers with this signature: `MyInput -> IResult<MyInput, Output>`.
+The goal is to define nom parsers with this signature: `MyInput -> ParseResult<MyInput, Output>`.
 
 ```rust
-fn parser(i: MyInput) -> IResult<MyInput, Output> {
+fn parser(i: MyInput) -> ParseResult<MyInput, Output> {
     tag("test")(i)
 }
 ```

--- a/doc/making_a_new_parser_from_scratch.md
+++ b/doc/making_a_new_parser_from_scratch.md
@@ -48,11 +48,11 @@ pub mod parser;
 And the `src/parser.rs` file:
 
 ```rust
-use nom::IResult;
+use nom::ParseResult;
 use nom::number::complete::be_u16;
 use nom::bytes::complete::take;
 
-pub fn length_value(input: &[u8]) -> IResult<&[u8],&[u8]> {
+pub fn length_value(input: &[u8]) -> ParseResult<&[u8],&[u8]> {
     let (input, length) = be_u16(input)?;
     take(length)(input)
 }
@@ -61,17 +61,17 @@ pub fn length_value(input: &[u8]) -> IResult<&[u8],&[u8]> {
 # Writing a first parser
 
 Let's parse a simple expression like `(12345)`. nom parsers are functions that
-use the `nom::IResult` type everywhere. As an example, a parser taking a byte
+use the `nom::ParseResult` type everywhere. As an example, a parser taking a byte
 slice `&[u8]` and returning a 32 bits unsigned integer `u32` would have this
-signature: `fn parse_u32(input: &[u8]) -> IResult<&[u8], u32>`.
+signature: `fn parse_u32(input: &[u8]) -> ParseResult<&[u8], u32>`.
 
-The `IResult` type depends on the input and output types, and an optional custom
+The `ParseResult` type depends on the input and output types, and an optional custom
 error type. This enum can either be `Ok((i,o))` containing the remaining input
 and the output value, or, on the `Err` side, an error or an indication that more
 data is needed.
 
 ```rust
-pub type IResult<I, O, E=(I,ErrorKind)> = Result<(I, O), Err<E>>;
+pub type ParseResult<I, O, E=(I,ParserKind)> = Result<(I, O), Err<E>>;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Needed {
@@ -114,7 +114,7 @@ let line_ending = tag("\r\n");
 let http_version = preceded(http, version);
 
 // combine all previous parsers in one function
-fn request_line(i: &[u8]) -> IResult<&[u8], Request> {
+fn request_line(i: &[u8]) -> ParseResult<&[u8], Request> {
 
   // tuple takes as argument a tuple of parsers and will return
   // a tuple of their results
@@ -191,7 +191,7 @@ prints its hexdump if the child parser encountered an error:
 ```rust
 use nom::{dbg_dmp, bytes::complete::tag};
 
-fn f(i: &[u8]) -> IResult<&[u8], &[u8]> {
+fn f(i: &[u8]) -> ParseResult<&[u8], &[u8]> {
   dbg_dmp(tag("abcd"))(i)
 }
 

--- a/doc/upgrading_to_nom_5.md
+++ b/doc/upgrading_to_nom_5.md
@@ -125,10 +125,10 @@ everywhere)
 they gain the performance benefit immediately
 
 In practice, nom parsers will have the following signature:
-`Input -> IResult<Input, Output, Error>`
+`Input -> IResult<Input, Output, Context>`
 
 A function combinator will then have this signature:
-`<args> -> impl Fn(Input) -> IResult<Input, Output, Error>`
+`<args> -> impl Fn(Input) -> IResult<Input, Output, Context>`
 
 Here is an example with a simplified `take` combinator:
 

--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -1,27 +1,27 @@
 extern crate nom;
 
-use nom::error::ErrorKind;
-use nom::error::ParseError;
-use nom::Err::Error;
-use nom::IResult;
+use nom::error::ParserKind;
+use nom::error::ParseContext;
+use nom::Outcome::Error;
+use nom::ParseResult;
 
 #[derive(Debug, PartialEq)]
 pub enum CustomError<I> {
   MyError,
-  Nom(I, ErrorKind),
+  Nom(I, ParserKind),
 }
 
-impl<I> ParseError<I> for CustomError<I> {
-  fn from_error_kind(input: I, kind: ErrorKind) -> Self {
+impl<I> ParseContext<I> for CustomError<I> {
+  fn from_parser_kind(input: I, kind: ParserKind) -> Self {
     CustomError::Nom(input, kind)
   }
 
-  fn append(_: I, _: ErrorKind, other: Self) -> Self {
+  fn append(_: I, _: ParserKind, other: Self) -> Self {
     other
   }
 }
 
-fn parse(input: &str) -> IResult<&str, &str, CustomError<&str>> {
+fn parse(input: &str) -> ParseResult<&str, &str, CustomError<&str>> {
   Err(Error(CustomError::MyError))
 }
 
@@ -29,7 +29,7 @@ fn parse(input: &str) -> IResult<&str, &str, CustomError<&str>> {
 mod tests {
   use super::parse;
   use super::CustomError;
-  use nom::Err::Error;
+  use nom::Outcome::Error;
 
   #[test]
   fn it_works() {

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -5,12 +5,12 @@ use nom::bytes::complete::tag;
 use nom::character::complete::alphanumeric1;
 use nom::combinator::iterator;
 use nom::sequence::{separated_pair, terminated};
-use nom::IResult;
+use nom::ParseResult;
 
 fn main() {
   let mut data = "abcabcabcabc";
 
-  fn parser(i: &str) -> IResult<&str, &str> {
+  fn parser(i: &str) -> ParseResult<&str, &str> {
     tag("abc")(i)
   }
 
@@ -74,7 +74,7 @@ fn main() {
     .map(|(k, v)| (k.to_uppercase(), v))
     .collect::<HashMap<_, _>>();
 
-  let parser_result: IResult<_, _> = nom_it.finish();
+  let parser_result: ParseResult<_, _> = nom_it.finish();
   let (remaining_input, ()) = parser_result.unwrap();
 
   // will print "iterator returned {"key1": "value1", "key3": "value3", "key2": "value2"}, remaining input is ';'"

--- a/src/branch/tests.rs
+++ b/src/branch/tests.rs
@@ -1,10 +1,10 @@
 use crate::branch::{alt, permutation};
 use crate::bytes::streaming::tag;
-use crate::error::ErrorKind;
-use crate::internal::{Err, IResult, Needed};
+use crate::error::ParserKind;
+use crate::internal::{Needed, Outcome, ParseResult};
 #[cfg(feature = "alloc")]
 use crate::{
-  error::ParseError,
+  error::ParseContext,
   lib::std::{
     fmt::Debug,
     string::{String, ToString},
@@ -30,12 +30,12 @@ impl<'a> From<&'a str> for ErrorStr {
 }
 
 #[cfg(feature = "alloc")]
-impl<I: Debug> ParseError<I> for ErrorStr {
-  fn from_error_kind(input: I, kind: ErrorKind) -> Self {
+impl<I: Debug> ParseContext<I> for ErrorStr {
+  fn from_parser_kind(input: I, kind: ParserKind) -> Self {
     ErrorStr(format!("custom error message: ({:?}, {:?})", input, kind))
   }
 
-  fn append(input: I, kind: ErrorKind, other: Self) -> Self {
+  fn append(input: I, kind: ParserKind, other: Self) -> Self {
     ErrorStr(format!(
       "custom error message: ({:?}, {:?}) - {:?}",
       input, kind, other
@@ -46,26 +46,26 @@ impl<I: Debug> ParseError<I> for ErrorStr {
 #[cfg(feature = "alloc")]
 #[test]
 fn alt_test() {
-  fn work(input: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
+  fn work(input: &[u8]) -> ParseResult<&[u8], &[u8], ErrorStr> {
     Ok((&b""[..], input))
   }
 
   #[allow(unused_variables)]
-  fn dont_work(input: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-    Err(Err::Error(ErrorStr("abcd".to_string())))
+  fn dont_work(input: &[u8]) -> ParseResult<&[u8], &[u8], ErrorStr> {
+    Err(Outcome::Failure(ErrorStr("abcd".to_string())))
   }
 
-  fn work2(input: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
+  fn work2(input: &[u8]) -> ParseResult<&[u8], &[u8], ErrorStr> {
     Ok((input, &b""[..]))
   }
 
-  fn alt1(i: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
+  fn alt1(i: &[u8]) -> ParseResult<&[u8], &[u8], ErrorStr> {
     alt((dont_work, dont_work))(i)
   }
-  fn alt2(i: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
+  fn alt2(i: &[u8]) -> ParseResult<&[u8], &[u8], ErrorStr> {
     alt((dont_work, work))(i)
   }
-  fn alt3(i: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
+  fn alt3(i: &[u8]) -> ParseResult<&[u8], &[u8], ErrorStr> {
     alt((dont_work, dont_work, work2, dont_work))(i)
   }
   //named!(alt1, alt!(dont_work | dont_work));
@@ -75,16 +75,16 @@ fn alt_test() {
   let a = &b"abcd"[..];
   assert_eq!(
     alt1(a),
-    Err(Err::Error(error_node_position!(
+    Err(Outcome::Failure(error_node_position!(
       a,
-      ErrorKind::Alt,
+      ParserKind::Alt,
       ErrorStr("abcd".to_string())
     )))
   );
   assert_eq!(alt2(a), Ok((&b""[..], a)));
   assert_eq!(alt3(a), Ok((a, &b""[..])));
 
-  fn alt4(i: &[u8]) -> IResult<&[u8], &[u8]> {
+  fn alt4(i: &[u8]) -> ParseResult<&[u8], &[u8]> {
     alt((tag("abcd"), tag("efgh")))(i)
   }
   let b = &b"efgh"[..];
@@ -94,27 +94,30 @@ fn alt_test() {
 
 #[test]
 fn alt_incomplete() {
-  fn alt1(i: &[u8]) -> IResult<&[u8], &[u8]> {
+  fn alt1(i: &[u8]) -> ParseResult<&[u8], &[u8]> {
     alt((tag("a"), tag("bc"), tag("def")))(i)
   }
 
   let a = &b""[..];
-  assert_eq!(alt1(a), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(alt1(a), Err(Outcome::Incomplete(Needed::new(1))));
   let a = &b"b"[..];
-  assert_eq!(alt1(a), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(alt1(a), Err(Outcome::Incomplete(Needed::new(1))));
   let a = &b"bcd"[..];
   assert_eq!(alt1(a), Ok((&b"d"[..], &b"bc"[..])));
   let a = &b"cde"[..];
-  assert_eq!(alt1(a), Err(Err::Error(error_position!(a, ErrorKind::Tag))));
+  assert_eq!(
+    alt1(a),
+    Err(Outcome::Failure(error_position!(a, ParserKind::Tag)))
+  );
   let a = &b"de"[..];
-  assert_eq!(alt1(a), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(alt1(a), Err(Outcome::Incomplete(Needed::new(1))));
   let a = &b"defg"[..];
   assert_eq!(alt1(a), Ok((&b"g"[..], &b"def"[..])));
 }
 
 #[test]
 fn permutation_test() {
-  fn perm(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8], &[u8])> {
+  fn perm(i: &[u8]) -> ParseResult<&[u8], (&[u8], &[u8], &[u8])> {
     permutation((tag("abcd"), tag("efg"), tag("hi")))(i)
   }
 
@@ -130,13 +133,13 @@ fn permutation_test() {
   let d = &b"efgxyzabcdefghi"[..];
   assert_eq!(
     perm(d),
-    Err(Err::Error(error_node_position!(
+    Err(Outcome::Failure(error_node_position!(
       &b"efgxyzabcdefghi"[..],
-      ErrorKind::Permutation,
-      error_position!(&b"xyzabcdefghi"[..], ErrorKind::Tag)
+      ParserKind::Permutation,
+      error_position!(&b"xyzabcdefghi"[..], ParserKind::Tag)
     )))
   );
 
   let e = &b"efgabc"[..];
-  assert_eq!(perm(e), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(perm(e), Err(Outcome::Incomplete(Needed::new(1))));
 }

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -1,8 +1,8 @@
 //! Parsers recognizing bytes streams, complete input version
 
-use crate::error::ErrorKind;
-use crate::error::ParseError;
-use crate::internal::{Err, IResult, Parser};
+use crate::error::ParseContext;
+use crate::error::ParserKind;
+use crate::internal::{Outcome, ParseResult, Parser};
 use crate::lib::std::ops::RangeFrom;
 use crate::lib::std::result::Result::*;
 use crate::traits::{
@@ -15,23 +15,23 @@ use crate::traits::{
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument
 ///
-/// It will return `Err(Err::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern
+/// It will return `Err(Outcome::Failure((_, ParserKind::Tag)))` if the input doesn't match the pattern
 /// # Example
 /// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::{Outcome, error::{Context, ParserKind}, Needed, ParseResult};
 /// use nom::bytes::complete::tag;
 ///
-/// fn parser(s: &str) -> IResult<&str, &str> {
+/// fn parser(s: &str) -> ParseResult<&str, &str> {
 ///   tag("Hello")(s)
 /// }
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
-/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("Something"), Err(Outcome::Failure(Context::new("Something", ParserKind::Tag))));
+/// assert_eq!(parser(""), Err(Outcome::Failure(Context::new("", ParserKind::Tag))));
 /// ```
-pub fn tag<T, Input, Error: ParseError<Input>>(
+pub fn tag<T, Input, Context: ParseContext<Input>>(
   tag: T,
-) -> impl Fn(Input) -> IResult<Input, Input, Error>
+) -> impl Fn(Input) -> ParseResult<Input, Input, Context>
 where
   Input: InputTake + Compare<T>,
   T: InputLength + Clone,
@@ -39,11 +39,11 @@ where
   move |i: Input| {
     let tag_len = tag.input_len();
     let t = tag.clone();
-    let res: IResult<_, _, Error> = match i.compare(t) {
+    let res: ParseResult<_, _, Context> = match i.compare(t) {
       CompareResult::Ok => Ok(i.take_split(tag_len)),
       _ => {
-        let e: ErrorKind = ErrorKind::Tag;
-        Err(Err::Error(Error::from_error_kind(i, e)))
+        let e: ParserKind = ParserKind::Tag;
+        Err(Outcome::Failure(Context::from_parser_kind(i, e)))
       }
     };
     res
@@ -55,25 +55,25 @@ where
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument with no regard to case.
 ///
-/// It will return `Err(Err::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern.
+/// It will return `Err(Outcome::Failure((_, ParserKind::Tag)))` if the input doesn't match the pattern.
 /// # Example
 /// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::{Outcome, error::{Context, ParserKind}, Needed, ParseResult};
 /// use nom::bytes::complete::tag_no_case;
 ///
-/// fn parser(s: &str) -> IResult<&str, &str> {
+/// fn parser(s: &str) -> ParseResult<&str, &str> {
 ///   tag_no_case("hello")(s)
 /// }
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
 /// assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
 /// assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
-/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("Something"), Err(Outcome::Failure(Context::new("Something", ParserKind::Tag))));
+/// assert_eq!(parser(""), Err(Outcome::Failure(Context::new("", ParserKind::Tag))));
 /// ```
-pub fn tag_no_case<T, Input, Error: ParseError<Input>>(
+pub fn tag_no_case<T, Input, Context: ParseContext<Input>>(
   tag: T,
-) -> impl Fn(Input) -> IResult<Input, Input, Error>
+) -> impl Fn(Input) -> ParseResult<Input, Input, Context>
 where
   Input: InputTake + Compare<T>,
   T: InputLength + Clone,
@@ -82,11 +82,11 @@ where
     let tag_len = tag.input_len();
     let t = tag.clone();
 
-    let res: IResult<_, _, Error> = match (i).compare_no_case(t) {
+    let res: ParseResult<_, _, Context> = match (i).compare_no_case(t) {
       CompareResult::Ok => Ok(i.take_split(tag_len)),
       _ => {
-        let e: ErrorKind = ErrorKind::Tag;
-        Err(Err::Error(Error::from_error_kind(i, e)))
+        let e: ParserKind = ParserKind::Tag;
+        Err(Outcome::Failure(Context::from_parser_kind(i, e)))
       }
     };
     res
@@ -99,30 +99,30 @@ where
 ///
 /// It doesn't consume the matched character.
 ///
-/// It will return a `Err::Error(("", ErrorKind::IsNot))` if the pattern wasn't met.
+/// It will return a `Outcome::Failure(("", ParserKind::IsNot))` if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::{Outcome, error::{Context, ParserKind}, Needed, ParseResult};
 /// use nom::bytes::complete::is_not;
 ///
-/// fn not_space(s: &str) -> IResult<&str, &str> {
+/// fn not_space(s: &str) -> ParseResult<&str, &str> {
 ///   is_not(" \t\r\n")(s)
 /// }
 ///
 /// assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
 /// assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
 /// assert_eq!(not_space("Nospace"), Ok(("", "Nospace")));
-/// assert_eq!(not_space(""), Err(Err::Error(Error::new("", ErrorKind::IsNot))));
+/// assert_eq!(not_space(""), Err(Outcome::Failure(Context::new("", ParserKind::IsNot))));
 /// ```
-pub fn is_not<T, Input, Error: ParseError<Input>>(
+pub fn is_not<T, Input, Context: ParseContext<Input>>(
   arr: T,
-) -> impl Fn(Input) -> IResult<Input, Input, Error>
+) -> impl Fn(Input) -> ParseResult<Input, Input, Context>
 where
   Input: InputTakeAtPosition,
   T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
   move |i: Input| {
-    let e: ErrorKind = ErrorKind::IsNot;
+    let e: ParserKind = ParserKind::IsNot;
     i.split_at_position1_complete(|c| arr.find_token(c), e)
   }
 }
@@ -132,13 +132,13 @@ where
 /// The parser will return the longest slice consisting of the characters in provided in the
 /// combinator's argument.
 ///
-/// It will return a `Err(Err::Error((_, ErrorKind::IsA)))` if the pattern wasn't met.
+/// It will return a `Err(Outcome::Failure((_, ParserKind::IsA)))` if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::{Outcome, error::{Context, ParserKind}, Needed, ParseResult};
 /// use nom::bytes::complete::is_a;
 ///
-/// fn hex(s: &str) -> IResult<&str, &str> {
+/// fn hex(s: &str) -> ParseResult<&str, &str> {
 ///   is_a("1234567890ABCDEF")(s)
 /// }
 ///
@@ -146,17 +146,17 @@ where
 /// assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
 /// assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
 /// assert_eq!(hex("D15EA5E"), Ok(("", "D15EA5E")));
-/// assert_eq!(hex(""), Err(Err::Error(Error::new("", ErrorKind::IsA))));
+/// assert_eq!(hex(""), Err(Outcome::Failure(Context::new("", ParserKind::IsA))));
 /// ```
-pub fn is_a<T, Input, Error: ParseError<Input>>(
+pub fn is_a<T, Input, Context: ParseContext<Input>>(
   arr: T,
-) -> impl Fn(Input) -> IResult<Input, Input, Error>
+) -> impl Fn(Input) -> ParseResult<Input, Input, Context>
 where
   Input: InputTakeAtPosition,
   T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
   move |i: Input| {
-    let e: ErrorKind = ErrorKind::IsA;
+    let e: ParserKind = ParserKind::IsA;
     i.split_at_position1_complete(|c| !arr.find_token(c), e)
   }
 }
@@ -167,11 +167,11 @@ where
 /// takes the input and returns a bool)*.
 /// # Example
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use nom::{Outcome, error::ParserKind, Needed, ParseResult};
 /// use nom::bytes::complete::take_while;
 /// use nom::character::is_alphabetic;
 ///
-/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+/// fn alpha(s: &[u8]) -> ParseResult<&[u8], &[u8]> {
 ///   take_while(is_alphabetic)(s)
 /// }
 ///
@@ -180,9 +180,9 @@ where
 /// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
 /// assert_eq!(alpha(b""), Ok((&b""[..], &b""[..])));
 /// ```
-pub fn take_while<F, Input, Error: ParseError<Input>>(
+pub fn take_while<F, Input, Context: ParseContext<Input>>(
   cond: F,
-) -> impl Fn(Input) -> IResult<Input, Input, Error>
+) -> impl Fn(Input) -> ParseResult<Input, Input, Context>
 where
   Input: InputTakeAtPosition,
   F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
@@ -195,30 +195,30 @@ where
 /// The parser will return the longest slice that matches the given predicate *(a function that
 /// takes the input and returns a bool)*.
 ///
-/// It will return an `Err(Err::Error((_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
+/// It will return an `Err(Outcome::Failure((_, ParserKind::TakeWhile1)))` if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::{Outcome, error::{Context, ParserKind}, Needed, ParseResult};
 /// use nom::bytes::complete::take_while1;
 /// use nom::character::is_alphabetic;
 ///
-/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+/// fn alpha(s: &[u8]) -> ParseResult<&[u8], &[u8]> {
 ///   take_while1(is_alphabetic)(s)
 /// }
 ///
 /// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
+/// assert_eq!(alpha(b"12345"), Err(Outcome::Failure(Context::new(&b"12345"[..], ParserKind::TakeWhile1))));
 /// ```
-pub fn take_while1<F, Input, Error: ParseError<Input>>(
+pub fn take_while1<F, Input, Context: ParseContext<Input>>(
   cond: F,
-) -> impl Fn(Input) -> IResult<Input, Input, Error>
+) -> impl Fn(Input) -> ParseResult<Input, Input, Context>
 where
   Input: InputTakeAtPosition,
   F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
 {
   move |i: Input| {
-    let e: ErrorKind = ErrorKind::TakeWhile1;
+    let e: ParserKind = ParserKind::TakeWhile1;
     i.split_at_position1_complete(|c| !cond(c), e)
   }
 }
@@ -228,29 +228,29 @@ where
 /// The parser will return the longest slice that matches the given predicate *(a function that
 /// takes the input and returns a bool)*.
 ///
-/// It will return an `Err::Error((_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
+/// It will return an `Outcome::Failure((_, ParserKind::TakeWhileMN))` if the pattern wasn't met or is out
 /// of range (m <= len <= n).
 /// # Example
 /// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::{Outcome, error::{Context, ParserKind}, Needed, ParseResult};
 /// use nom::bytes::complete::take_while_m_n;
 /// use nom::character::is_alphabetic;
 ///
-/// fn short_alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+/// fn short_alpha(s: &[u8]) -> ParseResult<&[u8], &[u8]> {
 ///   take_while_m_n(3, 6, is_alphabetic)(s)
 /// }
 ///
 /// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
 /// assert_eq!(short_alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(short_alpha(b"ed"), Err(Err::Error(Error::new(&b"ed"[..], ErrorKind::TakeWhileMN))));
-/// assert_eq!(short_alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(b"ed"), Err(Outcome::Failure(Context::new(&b"ed"[..], ParserKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(b"12345"), Err(Outcome::Failure(Context::new(&b"12345"[..], ParserKind::TakeWhileMN))));
 /// ```
-pub fn take_while_m_n<F, Input, Error: ParseError<Input>>(
+pub fn take_while_m_n<F, Input, Context: ParseContext<Input>>(
   m: usize,
   n: usize,
   cond: F,
-) -> impl Fn(Input) -> IResult<Input, Input, Error>
+) -> impl Fn(Input) -> ParseResult<Input, Input, Context>
 where
   Input: InputTake + InputIter + InputLength + Slice<RangeFrom<usize>>,
   F: Fn(<Input as InputIter>::Item) -> bool,
@@ -262,29 +262,29 @@ where
       Some(idx) => {
         if idx >= m {
           if idx <= n {
-            let res: IResult<_, _, Error> = if let Ok(index) = input.slice_index(idx) {
+            let res: ParseResult<_, _, Context> = if let Ok(index) = input.slice_index(idx) {
               Ok(input.take_split(index))
             } else {
-              Err(Err::Error(Error::from_error_kind(
+              Err(Outcome::Failure(Context::from_parser_kind(
                 input,
-                ErrorKind::TakeWhileMN,
+                ParserKind::TakeWhileMN,
               )))
             };
             res
           } else {
-            let res: IResult<_, _, Error> = if let Ok(index) = input.slice_index(n) {
+            let res: ParseResult<_, _, Context> = if let Ok(index) = input.slice_index(n) {
               Ok(input.take_split(index))
             } else {
-              Err(Err::Error(Error::from_error_kind(
+              Err(Outcome::Failure(Context::from_parser_kind(
                 input,
-                ErrorKind::TakeWhileMN,
+                ParserKind::TakeWhileMN,
               )))
             };
             res
           }
         } else {
-          let e = ErrorKind::TakeWhileMN;
-          Err(Err::Error(Error::from_error_kind(input, e)))
+          let e = ParserKind::TakeWhileMN;
+          Err(Outcome::Failure(Context::from_parser_kind(input, e)))
         }
       }
       None => {
@@ -292,17 +292,17 @@ where
         if len >= n {
           match input.slice_index(n) {
             Ok(index) => Ok(input.take_split(index)),
-            Err(_needed) => Err(Err::Error(Error::from_error_kind(
+            Err(_needed) => Err(Outcome::Failure(Context::from_parser_kind(
               input,
-              ErrorKind::TakeWhileMN,
+              ParserKind::TakeWhileMN,
             ))),
           }
         } else if len >= m && len <= n {
-          let res: IResult<_, _, Error> = Ok((input.slice(len..), input));
+          let res: ParseResult<_, _, Context> = Ok((input.slice(len..), input));
           res
         } else {
-          let e = ErrorKind::TakeWhileMN;
-          Err(Err::Error(Error::from_error_kind(input, e)))
+          let e = ParserKind::TakeWhileMN;
+          Err(Outcome::Failure(Context::from_parser_kind(input, e)))
         }
       }
     }
@@ -315,10 +315,10 @@ where
 /// takes the input and returns a bool)*.
 /// # Example
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use nom::{Outcome, error::ParserKind, Needed, ParseResult};
 /// use nom::bytes::complete::take_till;
 ///
-/// fn till_colon(s: &str) -> IResult<&str, &str> {
+/// fn till_colon(s: &str) -> ParseResult<&str, &str> {
 ///   take_till(|c| c == ':')(s)
 /// }
 ///
@@ -327,9 +327,9 @@ where
 /// assert_eq!(till_colon("12345"), Ok(("", "12345")));
 /// assert_eq!(till_colon(""), Ok(("", "")));
 /// ```
-pub fn take_till<F, Input, Error: ParseError<Input>>(
+pub fn take_till<F, Input, Context: ParseContext<Input>>(
   cond: F,
-) -> impl Fn(Input) -> IResult<Input, Input, Error>
+) -> impl Fn(Input) -> ParseResult<Input, Input, Context>
 where
   Input: InputTakeAtPosition,
   F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
@@ -342,95 +342,101 @@ where
 /// The parser will return the longest slice till the given predicate *(a function that
 /// takes the input and returns a bool)*.
 ///
-/// It will return `Err(Err::Error((_, ErrorKind::TakeTill1)))` if the input is empty or the
+/// It will return `Err(Outcome::Failure((_, ParserKind::TakeTill1)))` if the input is empty or the
 /// predicate matches the first input.
 /// # Example
 /// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::{Outcome, error::{Context, ParserKind}, Needed, ParseResult};
 /// use nom::bytes::complete::take_till1;
 ///
-/// fn till_colon(s: &str) -> IResult<&str, &str> {
+/// fn till_colon(s: &str) -> ParseResult<&str, &str> {
 ///   take_till1(|c| c == ':')(s)
 /// }
 ///
 /// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
-/// assert_eq!(till_colon(":empty matched"), Err(Err::Error(Error::new(":empty matched", ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon(":empty matched"), Err(Outcome::Failure(Context::new(":empty matched", ParserKind::TakeTill1))));
 /// assert_eq!(till_colon("12345"), Ok(("", "12345")));
-/// assert_eq!(till_colon(""), Err(Err::Error(Error::new("", ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon(""), Err(Outcome::Failure(Context::new("", ParserKind::TakeTill1))));
 /// ```
-pub fn take_till1<F, Input, Error: ParseError<Input>>(
+pub fn take_till1<F, Input, Context: ParseContext<Input>>(
   cond: F,
-) -> impl Fn(Input) -> IResult<Input, Input, Error>
+) -> impl Fn(Input) -> ParseResult<Input, Input, Context>
 where
   Input: InputTakeAtPosition,
   F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
 {
   move |i: Input| {
-    let e: ErrorKind = ErrorKind::TakeTill1;
+    let e: ParserKind = ParserKind::TakeTill1;
     i.split_at_position1_complete(|c| cond(c), e)
   }
 }
 
 /// Returns an input slice containing the first N input elements (Input[..N]).
 ///
-/// It will return `Err(Err::Error((_, ErrorKind::Eof)))` if the input is shorter than the argument.
+/// It will return `Err(Outcome::Failure((_, ParserKind::Eof)))` if the input is shorter than the argument.
 /// # Example
 /// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::{Outcome, error::{Context, ParserKind}, Needed, ParseResult};
 /// use nom::bytes::complete::take;
 ///
-/// fn take6(s: &str) -> IResult<&str, &str> {
+/// fn take6(s: &str) -> ParseResult<&str, &str> {
 ///   take(6usize)(s)
 /// }
 ///
 /// assert_eq!(take6("1234567"), Ok(("7", "123456")));
 /// assert_eq!(take6("things"), Ok(("", "things")));
-/// assert_eq!(take6("short"), Err(Err::Error(Error::new("short", ErrorKind::Eof))));
-/// assert_eq!(take6(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
+/// assert_eq!(take6("short"), Err(Outcome::Failure(Context::new("short", ParserKind::Eof))));
+/// assert_eq!(take6(""), Err(Outcome::Failure(Context::new("", ParserKind::Eof))));
 /// ```
-pub fn take<C, Input, Error: ParseError<Input>>(
+pub fn take<C, Input, Context: ParseContext<Input>>(
   count: C,
-) -> impl Fn(Input) -> IResult<Input, Input, Error>
+) -> impl Fn(Input) -> ParseResult<Input, Input, Context>
 where
   Input: InputIter + InputTake,
   C: ToUsize,
 {
   let c = count.to_usize();
   move |i: Input| match i.slice_index(c) {
-    Err(_needed) => Err(Err::Error(Error::from_error_kind(i, ErrorKind::Eof))),
+    Err(_needed) => Err(Outcome::Failure(Context::from_parser_kind(
+      i,
+      ParserKind::Eof,
+    ))),
     Ok(index) => Ok(i.take_split(index)),
   }
 }
 
 /// Returns the input slice up to the first occurrence of the pattern.
 ///
-/// It doesn't consume the pattern. It will return `Err(Err::Error((_, ErrorKind::TakeUntil)))`
+/// It doesn't consume the pattern. It will return `Err(Outcome::Failure((_, ParserKind::TakeUntil)))`
 /// if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::{Outcome, error::{Context, ParserKind}, Needed, ParseResult};
 /// use nom::bytes::complete::take_until;
 ///
-/// fn until_eof(s: &str) -> IResult<&str, &str> {
+/// fn until_eof(s: &str) -> ParseResult<&str, &str> {
 ///   take_until("eof")(s)
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
-/// assert_eq!(until_eof(""), Err(Err::Error(Error::new("", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("hello, world"), Err(Outcome::Failure(Context::new("hello, world", ParserKind::TakeUntil))));
+/// assert_eq!(until_eof(""), Err(Outcome::Failure(Context::new("", ParserKind::TakeUntil))));
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
 /// ```
-pub fn take_until<T, Input, Error: ParseError<Input>>(
+pub fn take_until<T, Input, Context: ParseContext<Input>>(
   tag: T,
-) -> impl Fn(Input) -> IResult<Input, Input, Error>
+) -> impl Fn(Input) -> ParseResult<Input, Input, Context>
 where
   Input: InputTake + FindSubstring<T>,
   T: InputLength + Clone,
 {
   move |i: Input| {
     let t = tag.clone();
-    let res: IResult<_, _, Error> = match i.find_substring(t) {
-      None => Err(Err::Error(Error::from_error_kind(i, ErrorKind::TakeUntil))),
+    let res: ParseResult<_, _, Context> = match i.find_substring(t) {
+      None => Err(Outcome::Failure(Context::from_parser_kind(
+        i,
+        ParserKind::TakeUntil,
+      ))),
       Some(index) => Ok(i.take_split(index)),
     };
     res
@@ -439,35 +445,41 @@ where
 
 /// Returns the non empty input slice up to the first occurrence of the pattern.
 ///
-/// It doesn't consume the pattern. It will return `Err(Err::Error((_, ErrorKind::TakeUntil)))`
+/// It doesn't consume the pattern. It will return `Err(Outcome::Failure((_, ParserKind::TakeUntil)))`
 /// if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::{Outcome, error::{Context, ParserKind}, Needed, ParseResult};
 /// use nom::bytes::complete::take_until1;
 ///
-/// fn until_eof(s: &str) -> IResult<&str, &str> {
+/// fn until_eof(s: &str) -> ParseResult<&str, &str> {
 ///   take_until1("eof")(s)
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
-/// assert_eq!(until_eof(""), Err(Err::Error(Error::new("", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("hello, world"), Err(Outcome::Failure(Context::new("hello, world", ParserKind::TakeUntil))));
+/// assert_eq!(until_eof(""), Err(Outcome::Failure(Context::new("", ParserKind::TakeUntil))));
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
-/// assert_eq!(until_eof("eof"), Err(Err::Error(Error::new("eof", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("eof"), Err(Outcome::Failure(Context::new("eof", ParserKind::TakeUntil))));
 /// ```
-pub fn take_until1<T, Input, Error: ParseError<Input>>(
+pub fn take_until1<T, Input, Context: ParseContext<Input>>(
   tag: T,
-) -> impl Fn(Input) -> IResult<Input, Input, Error>
+) -> impl Fn(Input) -> ParseResult<Input, Input, Context>
 where
   Input: InputTake + FindSubstring<T>,
   T: InputLength + Clone,
 {
   move |i: Input| {
     let t = tag.clone();
-    let res: IResult<_, _, Error> = match i.find_substring(t) {
-      None => Err(Err::Error(Error::from_error_kind(i, ErrorKind::TakeUntil))),
-      Some(0) => Err(Err::Error(Error::from_error_kind(i, ErrorKind::TakeUntil))),
+    let res: ParseResult<_, _, Context> = match i.find_substring(t) {
+      None => Err(Outcome::Failure(Context::from_parser_kind(
+        i,
+        ParserKind::TakeUntil,
+      ))),
+      Some(0) => Err(Outcome::Failure(Context::from_parser_kind(
+        i,
+        ParserKind::TakeUntil,
+      ))),
       Some(index) => Ok(i.take_split(index)),
     };
     res
@@ -481,12 +493,12 @@ where
 /// * The third argument matches the escaped characters
 /// # Example
 /// ```
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use nom::{Outcome, error::ParserKind, Needed, ParseResult};
 /// # use nom::character::complete::digit1;
 /// use nom::bytes::complete::escaped;
 /// use nom::character::complete::one_of;
 ///
-/// fn esc(s: &str) -> IResult<&str, &str> {
+/// fn esc(s: &str) -> ParseResult<&str, &str> {
 ///   escaped(digit1, '\\', one_of(r#""n\"#))(s)
 /// }
 ///
@@ -494,11 +506,11 @@ where
 /// assert_eq!(esc(r#"12\"34;"#), Ok((";", r#"12\"34"#)));
 /// ```
 ///
-pub fn escaped<'a, Input: 'a, Error, F, G, O1, O2>(
+pub fn escaped<'a, Input: 'a, Context, F, G, O1, O2>(
   mut normal: F,
   control_char: char,
   mut escapable: G,
-) -> impl FnMut(Input) -> IResult<Input, Input, Error>
+) -> impl FnMut(Input) -> ParseResult<Input, Input, Context>
 where
   Input: Clone
     + crate::traits::Offset
@@ -508,9 +520,9 @@ where
     + Slice<RangeFrom<usize>>
     + InputIter,
   <Input as InputIter>::Item: crate::traits::AsChar,
-  F: Parser<Input, O1, Error>,
-  G: Parser<Input, O2, Error>,
-  Error: ParseError<Input>,
+  F: Parser<Input, O1, Context>,
+  G: Parser<Input, O2, Context>,
+  Context: ParseContext<Input>,
 {
   use crate::traits::AsChar;
 
@@ -533,14 +545,14 @@ where
             i = i2;
           }
         }
-        Err(Err::Error(_)) => {
+        Err(Outcome::Failure(_)) => {
           // unwrap() should be safe here since index < $i.input_len()
           if i.iter_elements().next().unwrap().as_char() == control_char {
             let next = control_char.len_utf8();
             if next >= i.input_len() {
-              return Err(Err::Error(Error::from_error_kind(
+              return Err(Outcome::Failure(Context::from_parser_kind(
                 input,
-                ErrorKind::Escaped,
+                ParserKind::Escaped,
               )));
             } else {
               match escapable.parse(i.slice(next..)) {
@@ -557,9 +569,9 @@ where
           } else {
             let index = input.offset(&i);
             if index == 0 {
-              return Err(Err::Error(Error::from_error_kind(
+              return Err(Outcome::Failure(Context::from_parser_kind(
                 input,
-                ErrorKind::Escaped,
+                ParserKind::Escaped,
               )));
             }
             return Ok(input.take_split(index));
@@ -584,14 +596,14 @@ where
 /// As an example, the chain `abc\tdef` could be `abc    def` (it also consumes the control character)
 ///
 /// ```
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use nom::{Outcome, error::ParserKind, Needed, ParseResult};
 /// # use std::str::from_utf8;
 /// use nom::bytes::complete::{escaped_transform, tag};
 /// use nom::character::complete::alpha1;
 /// use nom::branch::alt;
 /// use nom::combinator::value;
 ///
-/// fn parser(input: &str) -> IResult<&str, String> {
+/// fn parser(input: &str) -> ParseResult<&str, String> {
 ///   escaped_transform(
 ///     alpha1,
 ///     '\\',
@@ -608,11 +620,11 @@ where
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
-pub fn escaped_transform<Input, Error, F, G, O1, O2, ExtendItem, Output>(
+pub fn escaped_transform<Input, Context, F, G, O1, O2, ExtendItem, Output>(
   mut normal: F,
   control_char: char,
   mut transform: G,
-) -> impl FnMut(Input) -> IResult<Input, Output, Error>
+) -> impl FnMut(Input) -> ParseResult<Input, Output, Context>
 where
   Input: Clone
     + crate::traits::Offset
@@ -625,9 +637,9 @@ where
   O1: crate::traits::ExtendInto<Item = ExtendItem, Extender = Output>,
   O2: crate::traits::ExtendInto<Item = ExtendItem, Extender = Output>,
   <Input as InputIter>::Item: crate::traits::AsChar,
-  F: Parser<Input, O1, Error>,
-  G: Parser<Input, O2, Error>,
-  Error: ParseError<Input>,
+  F: Parser<Input, O1, Context>,
+  G: Parser<Input, O2, Context>,
+  Context: ParseContext<Input>,
 {
   use crate::traits::AsChar;
 
@@ -651,16 +663,16 @@ where
             index = input.offset(&i2);
           }
         }
-        Err(Err::Error(_)) => {
+        Err(Outcome::Failure(_)) => {
           // unwrap() should be safe here since index < $i.input_len()
           if remainder.iter_elements().next().unwrap().as_char() == control_char {
             let next = index + control_char.len_utf8();
             let input_len = input.input_len();
 
             if next >= input_len {
-              return Err(Err::Error(Error::from_error_kind(
+              return Err(Outcome::Failure(Context::from_parser_kind(
                 remainder,
-                ErrorKind::EscapedTransform,
+                ParserKind::EscapedTransform,
               )));
             } else {
               match transform.parse(i.slice(next..)) {
@@ -677,9 +689,9 @@ where
             }
           } else {
             if index == 0 {
-              return Err(Err::Error(Error::from_error_kind(
+              return Err(Outcome::Failure(Context::from_parser_kind(
                 remainder,
-                ErrorKind::EscapedTransform,
+                ParserKind::EscapedTransform,
               )));
             }
             return Ok((remainder, res));
@@ -698,20 +710,20 @@ mod tests {
 
   #[test]
   fn complete_take_while_m_n_utf8_all_matching() {
-    let result: IResult<&str, &str> =
+    let result: ParseResult<&str, &str> =
       super::take_while_m_n(1, 4, |c: char| c.is_alphabetic())("øn");
     assert_eq!(result, Ok(("", "øn")));
   }
 
   #[test]
   fn complete_take_while_m_n_utf8_all_matching_substring() {
-    let result: IResult<&str, &str> =
+    let result: ParseResult<&str, &str> =
       super::take_while_m_n(1, 1, |c: char| c.is_alphabetic())("øn");
     assert_eq!(result, Ok(("n", "ø")));
   }
 
   // issue #1336 "escaped hangs if normal parser accepts empty"
-  fn escaped_string(input: &str) -> IResult<&str, &str> {
+  fn escaped_string(input: &str) -> ParseResult<&str, &str> {
     use crate::character::complete::{alpha0, one_of};
     escaped(alpha0, '\\', one_of("n"))(input)
   }
@@ -724,7 +736,7 @@ mod tests {
   }
 
   // issue ##1118 escaped does not work with empty string
-  fn unquote<'a>(input: &'a str) -> IResult<&'a str, &'a str> {
+  fn unquote<'a>(input: &'a str) -> ParseResult<&'a str, &'a str> {
     use crate::bytes::complete::*;
     use crate::character::complete::*;
     use crate::combinator::opt;

--- a/src/character/tests.rs
+++ b/src/character/tests.rs
@@ -1,10 +1,10 @@
 use super::streaming::*;
-use crate::error::ErrorKind;
-use crate::internal::{Err, IResult};
+use crate::error::ParserKind;
+use crate::internal::{Outcome, ParseResult};
 
 #[test]
 fn one_of_test() {
-  fn f(i: &[u8]) -> IResult<&[u8], char> {
+  fn f(i: &[u8]) -> ParseResult<&[u8], char> {
     one_of("ab")(i)
   }
 
@@ -12,9 +12,12 @@ fn one_of_test() {
   assert_eq!(f(a), Ok((&b"bcd"[..], 'a')));
 
   let b = &b"cde"[..];
-  assert_eq!(f(b), Err(Err::Error(error_position!(b, ErrorKind::OneOf))));
+  assert_eq!(
+    f(b),
+    Err(Outcome::Failure(error_position!(b, ParserKind::OneOf)))
+  );
 
-  fn utf8(i: &str) -> IResult<&str, char> {
+  fn utf8(i: &str) -> ParseResult<&str, char> {
     one_of("+\u{FF0B}")(i)
   }
 
@@ -24,12 +27,15 @@ fn one_of_test() {
 
 #[test]
 fn none_of_test() {
-  fn f(i: &[u8]) -> IResult<&[u8], char> {
+  fn f(i: &[u8]) -> ParseResult<&[u8], char> {
     none_of("ab")(i)
   }
 
   let a = &b"abcd"[..];
-  assert_eq!(f(a), Err(Err::Error(error_position!(a, ErrorKind::NoneOf))));
+  assert_eq!(
+    f(a),
+    Err(Outcome::Failure(error_position!(a, ParserKind::NoneOf)))
+  );
 
   let b = &b"cde"[..];
   assert_eq!(f(b), Ok((&b"de"[..], 'c')));
@@ -37,12 +43,15 @@ fn none_of_test() {
 
 #[test]
 fn char_byteslice() {
-  fn f(i: &[u8]) -> IResult<&[u8], char> {
+  fn f(i: &[u8]) -> ParseResult<&[u8], char> {
     char('c')(i)
   }
 
   let a = &b"abcd"[..];
-  assert_eq!(f(a), Err(Err::Error(error_position!(a, ErrorKind::Char))));
+  assert_eq!(
+    f(a),
+    Err(Outcome::Failure(error_position!(a, ParserKind::Char)))
+  );
 
   let b = &b"cde"[..];
   assert_eq!(f(b), Ok((&b"de"[..], 'c')));
@@ -50,12 +59,15 @@ fn char_byteslice() {
 
 #[test]
 fn char_str() {
-  fn f(i: &str) -> IResult<&str, char> {
+  fn f(i: &str) -> ParseResult<&str, char> {
     char('c')(i)
   }
 
   let a = &"abcd"[..];
-  assert_eq!(f(a), Err(Err::Error(error_position!(a, ErrorKind::Char))));
+  assert_eq!(
+    f(a),
+    Err(Outcome::Failure(error_position!(a, ParserKind::Char)))
+  );
 
   let b = &"cde"[..];
   assert_eq!(f(b), Ok((&"de"[..], 'c')));

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,44 +1,44 @@
 //! Basic types to build the parsers
 
 use self::Needed::*;
-use crate::error::{self, ErrorKind};
+use crate::error::{self, ParserKind};
 use crate::lib::std::fmt;
 use core::num::NonZeroUsize;
 
 /// Holds the result of parsing functions
 ///
 /// It depends on the input type `I`, the output type `O`, and the error type `E`
-/// (by default `(I, nom::ErrorKind)`)
+/// (by default `(I, nom::ParserKind)`)
 ///
 /// The `Ok` side is a pair containing the remainder of the input (the part of the data that
 /// was not parsed) and the produced value. The `Err` side contains an instance of `nom::Err`.
 ///
 /// Outside of the parsing code, you can use the [Finish::finish] method to convert
 /// it to a more common result type
-pub type IResult<I, O, E = error::Error<I>> = Result<(I, O), Err<E>>;
+pub type ParseResult<I, O, E = error::Context<I>> = Result<(I, O), Outcome<E>>;
 
 /// Helper trait to convert a parser's result to a more manageable type
 pub trait Finish<I, O, E> {
   /// converts the parser's result to a type that is more consumable by error
-  /// management libraries. It keeps the same `Ok` branch, and merges `Err::Error`
-  /// and `Err::Failure` into the `Err` side.
+  /// management libraries. It keeps the same `Ok` branch, and merges `Outcome::Error`
+  /// and `Outcome::Failure` into the `Err` side.
   ///
-  /// *warning*: if the result is `Err(Err::Incomplete(_))`, this method will panic.
+  /// *warning*: if the result is `Err(Outcome::Incomplete(_))`, this method will panic.
   /// - "complete" parsers: It will not be an issue, `Incomplete` is never used
   /// - "streaming" parsers: `Incomplete` will be returned if there's not enough data
   /// for the parser to decide, and you should gather more data before parsing again.
-  /// Once the parser returns either `Ok(_)`, `Err(Err::Error(_))` or `Err(Err::Failure(_))`,
+  /// Once the parser returns either `Ok(_)`, `Err(Outcome::Failure(_))` or `Err(Outcome::Failure(_))`,
   /// you can get out of the parsing loop and call `finish()` on the parser's result
   fn finish(self) -> Result<(I, O), E>;
 }
 
-impl<I, O, E> Finish<I, O, E> for IResult<I, O, E> {
+impl<I, O, E> Finish<I, O, E> for ParseResult<I, O, E> {
   fn finish(self) -> Result<(I, O), E> {
     match self {
       Ok(res) => Ok(res),
-      Err(Err::Error(e)) | Err(Err::Failure(e)) => Err(e),
-      Err(Err::Incomplete(_)) => {
-        panic!("Cannot call `finish()` on `Err(Err::Incomplete(_))`: this result means that the parser does not have enough data to decide, you should gather more data and try to reapply  the parser instead")
+      Err(Outcome::Failure(e)) | Err(Outcome::Invalid(e)) => Err(e),
+      Err(Outcome::Incomplete(_)) => {
+        panic!("Cannot call `finish()` on `Err(Outcome::Incomplete(_))`: this result means that the parser does not have enough data to decide, you should gather more data and try to reapply  the parser instead")
       }
     }
   }
@@ -94,21 +94,21 @@ impl Needed {
 ///
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
-pub enum Err<E> {
+pub enum Outcome<Context> {
   /// There was not enough data
   Incomplete(Needed),
   /// The parser had an error (recoverable)
-  Error(E),
+  Failure(Context),
   /// The parser had an unrecoverable error: we got to the right
   /// branch and we know other branches won't work, so backtrack
   /// as fast as possible
-  Failure(E),
+  Invalid(Context),
 }
 
-impl<E> Err<E> {
+impl<E> Outcome<E> {
   /// Tests if the result is Incomplete
   pub fn is_incomplete(&self) -> bool {
-    if let Err::Incomplete(_) = self {
+    if let Outcome::Incomplete(_) = self {
       true
     } else {
       false
@@ -116,19 +116,19 @@ impl<E> Err<E> {
   }
 
   /// Applies the given function to the inner error
-  pub fn map<E2, F>(self, f: F) -> Err<E2>
+  pub fn map<E2, F>(self, f: F) -> Outcome<E2>
   where
     F: FnOnce(E) -> E2,
   {
     match self {
-      Err::Incomplete(n) => Err::Incomplete(n),
-      Err::Failure(t) => Err::Failure(f(t)),
-      Err::Error(t) => Err::Error(f(t)),
+      Outcome::Incomplete(n) => Outcome::Incomplete(n),
+      Outcome::Invalid(t) => Outcome::Invalid(f(t)),
+      Outcome::Failure(t) => Outcome::Failure(f(t)),
     }
   }
 
   /// Automatically converts between errors if the underlying type supports it
-  pub fn convert<F>(e: Err<F>) -> Self
+  pub fn convert<F>(e: Outcome<F>) -> Self
   where
     E: From<F>,
   {
@@ -136,33 +136,33 @@ impl<E> Err<E> {
   }
 }
 
-impl<T> Err<(T, ErrorKind)> {
-  /// Maps `Err<(T, ErrorKind)>` to `Err<(U, ErrorKind)>` with the given `F: T -> U`
-  pub fn map_input<U, F>(self, f: F) -> Err<(U, ErrorKind)>
+impl<T> Outcome<(T, ParserKind)> {
+  /// Maps `Err<(T, ParserKind)>` to `Err<(U, ParserKind)>` with the given `F: T -> U`
+  pub fn map_input<U, F>(self, f: F) -> Outcome<(U, ParserKind)>
   where
     F: FnOnce(T) -> U,
   {
     match self {
-      Err::Incomplete(n) => Err::Incomplete(n),
-      Err::Failure((input, k)) => Err::Failure((f(input), k)),
-      Err::Error((input, k)) => Err::Error((f(input), k)),
+      Outcome::Incomplete(n) => Outcome::Incomplete(n),
+      Outcome::Invalid((input, k)) => Outcome::Invalid((f(input), k)),
+      Outcome::Failure((input, k)) => Outcome::Failure((f(input), k)),
     }
   }
 }
 
-impl<T> Err<error::Error<T>> {
+impl<T> Outcome<error::Context<T>> {
   /// Maps `Err<error::Error<T>>` to `Err<error::Error<U>>` with the given `F: T -> U`
-  pub fn map_input<U, F>(self, f: F) -> Err<error::Error<U>>
+  pub fn map_input<U, F>(self, f: F) -> Outcome<error::Context<U>>
   where
     F: FnOnce(T) -> U,
   {
     match self {
-      Err::Incomplete(n) => Err::Incomplete(n),
-      Err::Failure(error::Error { input, code }) => Err::Failure(error::Error {
+      Outcome::Incomplete(n) => Outcome::Incomplete(n),
+      Outcome::Invalid(error::Context { input, code }) => Outcome::Invalid(error::Context {
         input: f(input),
         code,
       }),
-      Err::Error(error::Error { input, code }) => Err::Error(error::Error {
+      Outcome::Failure(error::Context { input, code }) => Outcome::Failure(error::Context {
         input: f(input),
         code,
       }),
@@ -173,53 +173,53 @@ impl<T> Err<error::Error<T>> {
 #[cfg(feature = "alloc")]
 use crate::lib::std::{borrow::ToOwned, string::String, vec::Vec};
 #[cfg(feature = "alloc")]
-impl Err<(&[u8], ErrorKind)> {
+impl Outcome<(&[u8], ParserKind)> {
   /// Obtaining ownership
   #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
-  pub fn to_owned(self) -> Err<(Vec<u8>, ErrorKind)> {
+  pub fn to_owned(self) -> Outcome<(Vec<u8>, ParserKind)> {
     self.map_input(ToOwned::to_owned)
   }
 }
 
 #[cfg(feature = "alloc")]
-impl Err<(&str, ErrorKind)> {
+impl Outcome<(&str, ParserKind)> {
   /// Obtaining ownership
   #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
-  pub fn to_owned(self) -> Err<(String, ErrorKind)> {
+  pub fn to_owned(self) -> Outcome<(String, ParserKind)> {
     self.map_input(ToOwned::to_owned)
   }
 }
 
 #[cfg(feature = "alloc")]
-impl Err<error::Error<&[u8]>> {
+impl Outcome<error::Context<&[u8]>> {
   /// Obtaining ownership
   #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
-  pub fn to_owned(self) -> Err<error::Error<Vec<u8>>> {
+  pub fn to_owned(self) -> Outcome<error::Context<Vec<u8>>> {
     self.map_input(ToOwned::to_owned)
   }
 }
 
 #[cfg(feature = "alloc")]
-impl Err<error::Error<&str>> {
+impl Outcome<error::Context<&str>> {
   /// Obtaining ownership
   #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
-  pub fn to_owned(self) -> Err<error::Error<String>> {
+  pub fn to_owned(self) -> Outcome<error::Context<String>> {
     self.map_input(ToOwned::to_owned)
   }
 }
 
-impl<E: Eq> Eq for Err<E> {}
+impl<E: Eq> Eq for Outcome<E> {}
 
-impl<E> fmt::Display for Err<E>
+impl<E> fmt::Display for Outcome<E>
 where
   E: fmt::Debug,
 {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
-      Err::Incomplete(Needed::Size(u)) => write!(f, "Parsing requires {} bytes/chars", u),
-      Err::Incomplete(Needed::Unknown) => write!(f, "Parsing requires more data"),
-      Err::Failure(c) => write!(f, "Parsing Failure: {:?}", c),
-      Err::Error(c) => write!(f, "Parsing Error: {:?}", c),
+      Outcome::Incomplete(Needed::Size(u)) => write!(f, "Parsing requires {} bytes/chars", u),
+      Outcome::Incomplete(Needed::Unknown) => write!(f, "Parsing requires more data"),
+      Outcome::Invalid(c) => write!(f, "Parsing Failure: {:?}", c),
+      Outcome::Failure(c) => write!(f, "Parsing Context: {:?}", c),
     }
   }
 }
@@ -228,7 +228,7 @@ where
 use std::error::Error;
 
 #[cfg(feature = "std")]
-impl<E> Error for Err<E>
+impl<E> Error for Outcome<E>
 where
   E: fmt::Debug,
 {
@@ -241,7 +241,7 @@ where
 pub trait Parser<I, O, E> {
   /// A parser takes in input type, and returns a `Result` containing
   /// either the remaining input and the output value, or an error
-  fn parse(&mut self, input: I) -> IResult<I, O, E>;
+  fn parse(&mut self, input: I) -> ParseResult<I, O, E>;
 
   /// Maps a function over the result of a parser
   fn map<G, O2>(self, g: G) -> Map<Self, G, O>
@@ -319,9 +319,9 @@ pub trait Parser<I, O, E> {
 
 impl<'a, I, O, E, F> Parser<I, O, E> for F
 where
-  F: FnMut(I) -> IResult<I, O, E> + 'a,
+  F: FnMut(I) -> ParseResult<I, O, E> + 'a,
 {
-  fn parse(&mut self, i: I) -> IResult<I, O, E> {
+  fn parse(&mut self, i: I) -> ParseResult<I, O, E> {
     self(i)
   }
 }
@@ -331,7 +331,7 @@ use alloc::boxed::Box;
 
 #[cfg(feature = "alloc")]
 impl<'a, I, O, E> Parser<I, O, E> for Box<dyn Parser<I, O, E> + 'a> {
-  fn parse(&mut self, input: I) -> IResult<I, O, E> {
+  fn parse(&mut self, input: I) -> ParseResult<I, O, E> {
     (**self).parse(input)
   }
 }
@@ -345,7 +345,7 @@ pub struct Map<F, G, O1> {
 }
 
 impl<'a, I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> O2> Parser<I, O2, E> for Map<F, G, O1> {
-  fn parse(&mut self, i: I) -> IResult<I, O2, E> {
+  fn parse(&mut self, i: I) -> ParseResult<I, O2, E> {
     match self.f.parse(i) {
       Err(e) => Err(e),
       Ok((i, o)) => Ok((i, (self.g)(o))),
@@ -364,7 +364,7 @@ pub struct FlatMap<F, G, O1> {
 impl<'a, I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> H, H: Parser<I, O2, E>> Parser<I, O2, E>
   for FlatMap<F, G, O1>
 {
-  fn parse(&mut self, i: I) -> IResult<I, O2, E> {
+  fn parse(&mut self, i: I) -> ParseResult<I, O2, E> {
     let (i, o1) = self.f.parse(i)?;
     (self.g)(o1).parse(i)
   }
@@ -381,7 +381,7 @@ pub struct AndThen<F, G, O1> {
 impl<'a, I, O1, O2, E, F: Parser<I, O1, E>, G: Parser<O1, O2, E>> Parser<I, O2, E>
   for AndThen<F, G, O1>
 {
-  fn parse(&mut self, i: I) -> IResult<I, O2, E> {
+  fn parse(&mut self, i: I) -> ParseResult<I, O2, E> {
     let (i, o1) = self.f.parse(i)?;
     let (_, o2) = self.g.parse(o1)?;
     Ok((i, o2))
@@ -398,7 +398,7 @@ pub struct And<F, G> {
 impl<'a, I, O1, O2, E, F: Parser<I, O1, E>, G: Parser<I, O2, E>> Parser<I, (O1, O2), E>
   for And<F, G>
 {
-  fn parse(&mut self, i: I) -> IResult<I, (O1, O2), E> {
+  fn parse(&mut self, i: I) -> ParseResult<I, (O1, O2), E> {
     let (i, o1) = self.f.parse(i)?;
     let (i, o2) = self.g.parse(i)?;
     Ok((i, (o1, o2)))
@@ -412,13 +412,13 @@ pub struct Or<F, G> {
   g: G,
 }
 
-impl<'a, I: Clone, O, E: crate::error::ParseError<I>, F: Parser<I, O, E>, G: Parser<I, O, E>>
+impl<'a, I: Clone, O, E: crate::error::ParseContext<I>, F: Parser<I, O, E>, G: Parser<I, O, E>>
   Parser<I, O, E> for Or<F, G>
 {
-  fn parse(&mut self, i: I) -> IResult<I, O, E> {
+  fn parse(&mut self, i: I) -> ParseResult<I, O, E> {
     match self.f.parse(i.clone()) {
-      Err(Err::Error(e1)) => match self.g.parse(i) {
-        Err(Err::Error(e2)) => Err(Err::Error(e1.or(e2))),
+      Err(Outcome::Failure(e1)) => match self.g.parse(i) {
+        Err(Outcome::Failure(e2)) => Err(Outcome::Failure(e1.or(e2))),
         res => res,
       },
       res => res,
@@ -442,16 +442,16 @@ impl<
     O1,
     O2: From<O1>,
     E1,
-    E2: crate::error::ParseError<I> + From<E1>,
+    E2: crate::error::ParseContext<I> + From<E1>,
     F: Parser<I, O1, E1>,
   > Parser<I, O2, E2> for Into<F, O1, O2, E1, E2>
 {
-  fn parse(&mut self, i: I) -> IResult<I, O2, E2> {
+  fn parse(&mut self, i: I) -> ParseResult<I, O2, E2> {
     match self.f.parse(i) {
       Ok((i, o)) => Ok((i, o.into())),
-      Err(Err::Error(e)) => Err(Err::Error(e.into())),
-      Err(Err::Failure(e)) => Err(Err::Failure(e.into())),
-      Err(Err::Incomplete(e)) => Err(Err::Incomplete(e)),
+      Err(Outcome::Failure(e)) => Err(Outcome::Failure(e.into())),
+      Err(Outcome::Invalid(e)) => Err(Outcome::Invalid(e.into())),
+      Err(Outcome::Incomplete(e)) => Err(Outcome::Incomplete(e)),
     }
   }
 }
@@ -459,7 +459,7 @@ impl<
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::error::ErrorKind;
+  use crate::error::ParserKind;
 
   #[doc(hidden)]
   #[macro_export]
@@ -472,16 +472,16 @@ mod tests {
   #[test]
   #[cfg(target_pointer_width = "64")]
   fn size_test() {
-    assert_size!(IResult<&[u8], &[u8], (&[u8], u32)>, 40);
-    assert_size!(IResult<&str, &str, u32>, 40);
+    assert_size!(ParseResult<&[u8], &[u8], (&[u8], u32)>, 40);
+    assert_size!(ParseResult<&str, &str, u32>, 40);
     assert_size!(Needed, 8);
-    assert_size!(Err<u32>, 16);
-    assert_size!(ErrorKind, 1);
+    assert_size!(Outcome<u32>, 16);
+    assert_size!(ParserKind, 1);
   }
 
   #[test]
   fn err_map_test() {
-    let e = Err::Error(1);
-    assert_eq!(e.map(|v| v + 1), Err::Error(2));
+    let e = Outcome::Failure(1);
+    assert_eq!(e.map(|v| v + 1), Outcome::Failure(2));
   }
 }

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -4,8 +4,8 @@ use crate::branch::alt;
 use crate::bytes::complete::tag;
 use crate::character::complete::{char, digit1, sign};
 use crate::combinator::{cut, map, opt, recognize};
-use crate::error::ParseError;
-use crate::error::{make_error, ErrorKind};
+use crate::error::ParseContext;
+use crate::error::{make_error, ParserKind};
 use crate::internal::*;
 use crate::lib::std::ops::{Range, RangeFrom, RangeTo};
 use crate::sequence::{pair, tuple};
@@ -37,7 +37,7 @@ macro_rules! call (
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::be_u8;
 ///
@@ -46,16 +46,16 @@ macro_rules! call (
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Outcome::Failure((&[][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn be_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
+pub fn be_u8<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 1;
   if input.input_len() < bound {
-    Err(Err::Error(make_error(input, ErrorKind::Eof)))
+    Err(Outcome::Failure(make_error(input, ParserKind::Eof)))
   } else {
     let res = input.iter_elements().next().unwrap();
 
@@ -67,7 +67,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::be_u16;
 ///
@@ -76,16 +76,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn be_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
+pub fn be_u16<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 2;
   if input.input_len() < bound {
-    Err(Err::Error(make_error(input, ErrorKind::Eof)))
+    Err(Outcome::Failure(make_error(input, ParserKind::Eof)))
   } else {
     let mut res = 0u16;
     for byte in input.iter_elements().take(bound) {
@@ -100,7 +100,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::be_u24;
 ///
@@ -109,16 +109,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn be_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
+pub fn be_u24<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 3;
   if input.input_len() < bound {
-    Err(Err::Error(make_error(input, ErrorKind::Eof)))
+    Err(Outcome::Failure(make_error(input, ParserKind::Eof)))
   } else {
     let mut res = 0u32;
     for byte in input.iter_elements().take(bound) {
@@ -133,7 +133,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::be_u32;
 ///
@@ -142,16 +142,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn be_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
+pub fn be_u32<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 4;
   if input.input_len() < bound {
-    Err(Err::Error(make_error(input, ErrorKind::Eof)))
+    Err(Outcome::Failure(make_error(input, ParserKind::Eof)))
   } else {
     let mut res = 0u32;
     for byte in input.iter_elements().take(bound) {
@@ -166,7 +166,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::be_u64;
 ///
@@ -175,16 +175,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn be_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
+pub fn be_u64<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 8;
   if input.input_len() < bound {
-    Err(Err::Error(make_error(input, ErrorKind::Eof)))
+    Err(Outcome::Failure(make_error(input, ParserKind::Eof)))
   } else {
     let mut res = 0u64;
     for byte in input.iter_elements().take(bound) {
@@ -199,7 +199,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::be_u128;
 ///
@@ -208,17 +208,17 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
 #[cfg(stable_i128)]
-pub fn be_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
+pub fn be_u128<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 16;
   if input.input_len() < bound {
-    Err(Err::Error(make_error(input, ErrorKind::Eof)))
+    Err(Outcome::Failure(make_error(input, ParserKind::Eof)))
   } else {
     let mut res = 0u128;
     for byte in input.iter_elements().take(bound) {
@@ -233,7 +233,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::be_i8;
 ///
@@ -242,10 +242,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Outcome::Failure((&[][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn be_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
+pub fn be_i8<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -256,7 +256,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::be_i16;
 ///
@@ -265,10 +265,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn be_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
+pub fn be_i16<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -279,7 +279,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::be_i24;
 ///
@@ -288,10 +288,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn be_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
+pub fn be_i24<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -307,7 +307,7 @@ where
 ///
 /// *Complete version*: Teturns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::be_i32;
 ///
@@ -316,10 +316,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn be_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
+pub fn be_i32<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -330,7 +330,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::be_i64;
 ///
@@ -339,10 +339,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn be_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
+pub fn be_i64<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -353,7 +353,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::be_i128;
 ///
@@ -362,11 +362,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
 #[cfg(stable_i128)]
-pub fn be_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
+pub fn be_i128<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -377,7 +377,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::le_u8;
 ///
@@ -386,16 +386,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Outcome::Failure((&[][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn le_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
+pub fn le_u8<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 1;
   if input.input_len() < bound {
-    Err(Err::Error(make_error(input, ErrorKind::Eof)))
+    Err(Outcome::Failure(make_error(input, ParserKind::Eof)))
   } else {
     let res = input.iter_elements().next().unwrap();
 
@@ -407,7 +407,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::le_u16;
 ///
@@ -416,16 +416,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn le_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
+pub fn le_u16<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 2;
   if input.input_len() < bound {
-    Err(Err::Error(make_error(input, ErrorKind::Eof)))
+    Err(Outcome::Failure(make_error(input, ParserKind::Eof)))
   } else {
     let mut res = 0u16;
     for (index, byte) in input.iter_indices().take(bound) {
@@ -440,7 +440,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::le_u24;
 ///
@@ -449,16 +449,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn le_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
+pub fn le_u24<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 3;
   if input.input_len() < bound {
-    Err(Err::Error(make_error(input, ErrorKind::Eof)))
+    Err(Outcome::Failure(make_error(input, ParserKind::Eof)))
   } else {
     let mut res = 0u32;
     for (index, byte) in input.iter_indices().take(bound) {
@@ -473,7 +473,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::le_u32;
 ///
@@ -482,16 +482,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn le_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
+pub fn le_u32<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 4;
   if input.input_len() < bound {
-    Err(Err::Error(make_error(input, ErrorKind::Eof)))
+    Err(Outcome::Failure(make_error(input, ParserKind::Eof)))
   } else {
     let mut res = 0u32;
     for (index, byte) in input.iter_indices().take(bound) {
@@ -506,7 +506,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::le_u64;
 ///
@@ -515,16 +515,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn le_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
+pub fn le_u64<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 8;
   if input.input_len() < bound {
-    Err(Err::Error(make_error(input, ErrorKind::Eof)))
+    Err(Outcome::Failure(make_error(input, ParserKind::Eof)))
   } else {
     let mut res = 0u64;
     for (index, byte) in input.iter_indices().take(bound) {
@@ -539,7 +539,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::le_u128;
 ///
@@ -548,17 +548,17 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
 #[cfg(stable_i128)]
-pub fn le_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
+pub fn le_u128<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 16;
   if input.input_len() < bound {
-    Err(Err::Error(make_error(input, ErrorKind::Eof)))
+    Err(Outcome::Failure(make_error(input, ParserKind::Eof)))
   } else {
     let mut res = 0u128;
     for (index, byte) in input.iter_indices().take(bound) {
@@ -573,7 +573,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::le_i8;
 ///
@@ -582,10 +582,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Outcome::Failure((&[][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn le_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
+pub fn le_i8<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -596,7 +596,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::le_i16;
 ///
@@ -605,10 +605,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn le_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
+pub fn le_i16<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -619,7 +619,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::le_i24;
 ///
@@ -628,10 +628,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn le_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
+pub fn le_i24<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -647,7 +647,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::le_i32;
 ///
@@ -656,10 +656,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn le_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
+pub fn le_i32<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -670,7 +670,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::le_i64;
 ///
@@ -679,10 +679,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn le_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
+pub fn le_i64<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -693,7 +693,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::le_i128;
 ///
@@ -702,11 +702,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
 #[cfg(stable_i128)]
-pub fn le_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
+pub fn le_i128<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -718,7 +718,7 @@ where
 /// Note that endianness does not apply to 1 byte numbers.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::u8;
 ///
@@ -727,16 +727,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Outcome::Failure((&[][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
+pub fn u8<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 1;
   if input.input_len() < bound {
-    Err(Err::Error(make_error(input, ErrorKind::Eof)))
+    Err(Outcome::Failure(make_error(input, ParserKind::Eof)))
   } else {
     let res = input.iter_elements().next().unwrap();
 
@@ -751,7 +751,7 @@ where
 /// *complete version*: returns an error if there is not enough input data
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::u16;
 ///
@@ -760,17 +760,19 @@ where
 /// };
 ///
 /// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u16(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 ///
 /// let le_u16 = |s| {
 ///   u16(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u16(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn u16<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u16, E>
+pub fn u16<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, u16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -790,7 +792,7 @@ where
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u24 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::u24;
 ///
@@ -799,17 +801,19 @@ where
 /// };
 ///
 /// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u24(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 ///
 /// let le_u24 = |s| {
 ///   u24(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u24(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn u24<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u32, E>
+pub fn u24<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -829,7 +833,7 @@ where
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u32 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::u32;
 ///
@@ -838,17 +842,19 @@ where
 /// };
 ///
 /// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u32(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 ///
 /// let le_u32 = |s| {
 ///   u32(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u32(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn u32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u32, E>
+pub fn u32<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -868,7 +874,7 @@ where
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u64 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::u64;
 ///
@@ -877,17 +883,19 @@ where
 /// };
 ///
 /// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u64(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 ///
 /// let le_u64 = |s| {
 ///   u64(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u64(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn u64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u64, E>
+pub fn u64<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, u64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -907,7 +915,7 @@ where
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u128 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::u128;
 ///
@@ -916,18 +924,20 @@ where
 /// };
 ///
 /// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u128(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 ///
 /// let le_u128 = |s| {
 ///   u128(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u128(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
 #[cfg(stable_i128)]
-pub fn u128<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u128, E>
+pub fn u128<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, u128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -946,7 +956,7 @@ where
 /// Note that endianness does not apply to 1 byte numbers.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::i8;
 ///
@@ -955,10 +965,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Outcome::Failure((&[][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn i8<I, E: ParseError<I>>(i: I) -> IResult<I, i8, E>
+pub fn i8<I, E: ParseContext<I>>(i: I) -> ParseResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -971,7 +981,7 @@ where
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i16 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::i16;
 ///
@@ -980,17 +990,19 @@ where
 /// };
 ///
 /// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i16(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 ///
 /// let le_i16 = |s| {
 ///   i16(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i16(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn i16<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i16, E>
+pub fn i16<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1010,7 +1022,7 @@ where
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i24 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::i24;
 ///
@@ -1019,17 +1031,19 @@ where
 /// };
 ///
 /// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i24(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 ///
 /// let le_i24 = |s| {
 ///   i24(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i24(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn i24<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i32, E>
+pub fn i24<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1049,7 +1063,7 @@ where
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i32 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::i32;
 ///
@@ -1058,17 +1072,19 @@ where
 /// };
 ///
 /// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i32(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 ///
 /// let le_i32 = |s| {
 ///   i32(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i32(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn i32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i32, E>
+pub fn i32<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1088,7 +1104,7 @@ where
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i64 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::i64;
 ///
@@ -1097,17 +1113,19 @@ where
 /// };
 ///
 /// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i64(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 ///
 /// let le_i64 = |s| {
 ///   i64(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i64(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn i64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i64, E>
+pub fn i64<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1127,7 +1145,7 @@ where
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i128 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::i128;
 ///
@@ -1136,18 +1154,20 @@ where
 /// };
 ///
 /// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i128(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 ///
 /// let le_i128 = |s| {
 ///   i128(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i128(&b"\x01"[..]), Err(Outcome::Failure((&[0x01][..], ParserKind::Eof))));
 /// ```
 #[inline]
 #[cfg(stable_i128)]
-pub fn i128<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i128, E>
+pub fn i128<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1165,7 +1185,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::be_f32;
 ///
@@ -1174,10 +1194,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(Outcome::Failure((&b"abc"[..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn be_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
+pub fn be_f32<I, E: ParseContext<I>>(input: I) -> ParseResult<I, f32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1191,7 +1211,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::be_f64;
 ///
@@ -1200,10 +1220,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(Outcome::Failure((&b"abc"[..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn be_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
+pub fn be_f64<I, E: ParseContext<I>>(input: I) -> ParseResult<I, f64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1217,7 +1237,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::le_f32;
 ///
@@ -1226,10 +1246,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(Outcome::Failure((&b"abc"[..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn le_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
+pub fn le_f32<I, E: ParseContext<I>>(input: I) -> ParseResult<I, f32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1243,7 +1263,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::le_f64;
 ///
@@ -1252,10 +1272,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(Outcome::Failure((&b"abc"[..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn le_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
+pub fn le_f64<I, E: ParseContext<I>>(input: I) -> ParseResult<I, f64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1271,7 +1291,7 @@ where
 /// otherwise if `nom::number::Endianness::Little` parse a little endian f32 float.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::f32;
 ///
@@ -1280,17 +1300,19 @@ where
 /// };
 ///
 /// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f32(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(be_f32(&b"abc"[..]), Err(Outcome::Failure((&b"abc"[..], ParserKind::Eof))));
 ///
 /// let le_f32 = |s| {
 ///   f32(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f32(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(le_f32(&b"abc"[..]), Err(Outcome::Failure((&b"abc"[..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn f32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f32, E>
+pub fn f32<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, f32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1310,7 +1332,7 @@ where
 /// otherwise if `nom::number::Endianness::Little` parse a little endian f64 float.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::f64;
 ///
@@ -1319,17 +1341,19 @@ where
 /// };
 ///
 /// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f64(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(be_f64(&b"abc"[..]), Err(Outcome::Failure((&b"abc"[..], ParserKind::Eof))));
 ///
 /// let le_f64 = |s| {
 ///   f64(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f64(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(le_f64(&b"abc"[..]), Err(Outcome::Failure((&b"abc"[..], ParserKind::Eof))));
 /// ```
 #[inline]
-pub fn f64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f64, E>
+pub fn f64<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, f64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1347,7 +1371,7 @@ where
 ///
 /// *Complete version*: Will parse until the end of input if it has less than 8 bytes.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::hex_u32;
 ///
@@ -1357,10 +1381,10 @@ where
 ///
 /// assert_eq!(parser(&b"01AE"[..]), Ok((&b""[..], 0x01AE)));
 /// assert_eq!(parser(&b"abc"[..]), Ok((&b""[..], 0x0ABC)));
-/// assert_eq!(parser(&b"ggg"[..]), Err(Err::Error((&b"ggg"[..], ErrorKind::IsA))));
+/// assert_eq!(parser(&b"ggg"[..]), Err(Outcome::Failure((&b"ggg"[..], ParserKind::IsA))));
 /// ```
 #[inline]
-pub fn hex_u32<'a, E: ParseError<&'a [u8]>>(input: &'a [u8]) -> IResult<&'a [u8], u32, E> {
+pub fn hex_u32<'a, E: ParseContext<&'a [u8]>>(input: &'a [u8]) -> ParseResult<&'a [u8], u32, E> {
   let (i, o) = crate::bytes::complete::is_a(&b"0123456789abcdefABCDEF"[..])(input)?;
   // Do not parse more than 8 characters for a u32
   let (parsed, remaining) = if o.len() <= 8 {
@@ -1387,7 +1411,7 @@ pub fn hex_u32<'a, E: ParseError<&'a [u8]>>(input: &'a [u8]) -> IResult<&'a [u8]
 /// *Complete version*: Can parse until the end of input.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::recognize_float;
 ///
@@ -1398,10 +1422,10 @@ pub fn hex_u32<'a, E: ParseError<&'a [u8]>>(input: &'a [u8]) -> IResult<&'a [u8]
 /// assert_eq!(parser("11e-1"), Ok(("", "11e-1")));
 /// assert_eq!(parser("123E-02"), Ok(("", "123E-02")));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Char))));
+/// assert_eq!(parser("abc"), Err(Outcome::Failure(("abc", ParserKind::Char))));
 /// ```
 #[rustfmt::skip]
-pub fn recognize_float<T, E:ParseError<T>>(input: T) -> IResult<T, T, E>
+pub fn recognize_float<T, E:ParseContext<T>>(input: T) -> ParseResult<T, T, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
   T: Clone + Offset,
@@ -1430,7 +1454,9 @@ where
 ///
 /// *Complete version*: Can parse until the end of input.
 ///
-pub fn recognize_float_parts<T, E: ParseError<T>>(input: T) -> IResult<T, (bool, T, T, i32), E>
+pub fn recognize_float_parts<T, E: ParseContext<T>>(
+  input: T,
+) -> ParseResult<T, (bool, T, T, i32), E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
   T: Clone + Offset,
@@ -1498,7 +1524,10 @@ where
   };
 
   if integer.input_len() == 0 && fraction.input_len() == 0 {
-    return Err(Err::Error(E::from_error_kind(input, ErrorKind::Float)));
+    return Err(Outcome::Failure(E::from_parser_kind(
+      input,
+      ParserKind::Float,
+    )));
   }
 
   let i2 = i.clone();
@@ -1521,7 +1550,7 @@ where
 ///
 /// *Complete version*: Can parse until the end of input.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::float;
 ///
@@ -1532,9 +1561,9 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(Outcome::Failure(("abc", ParserKind::Float))));
 /// ```
-pub fn float<T, E: ParseError<T>>(input: T) -> IResult<T, f32, E>
+pub fn float<T, E: ParseContext<T>>(input: T) -> ParseResult<T, f32, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
   T: Clone + Offset,
@@ -1564,7 +1593,7 @@ where
 ///
 /// *Complete version*: Can parse until the end of input.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::double;
 ///
@@ -1575,9 +1604,9 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(Outcome::Failure(("abc", ParserKind::Float))));
 /// ```
-pub fn double<T, E: ParseError<T>>(input: T) -> IResult<T, f64, E>
+pub fn double<T, E: ParseContext<T>>(input: T) -> ParseResult<T, f64, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
   T: Clone + Offset,
@@ -1606,13 +1635,13 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::error::ErrorKind;
-  use crate::internal::Err;
+  use crate::error::ParserKind;
+  use crate::internal::Outcome;
   use proptest::prelude::*;
 
   macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
-      let res: $crate::IResult<_, _, (_, ErrorKind)> = $left;
+      let res: $crate::ParseResult<_, _, (_, ParserKind)> = $left;
       assert_eq!(res, $right);
     };
   );
@@ -1905,7 +1934,10 @@ mod tests {
   fn hex_u32_tests() {
     assert_parse!(
       hex_u32(&b";"[..]),
-      Err(Err::Error(error_position!(&b";"[..], ErrorKind::IsA)))
+      Err(Outcome::Failure(error_position!(
+        &b";"[..],
+        ParserKind::IsA
+      )))
     );
     assert_parse!(hex_u32(&b"ff;"[..]), Ok((&b";"[..], 255)));
     assert_parse!(hex_u32(&b"1be2;"[..]), Ok((&b";"[..], 7138)));
@@ -1962,7 +1994,7 @@ mod tests {
     let remaining_exponent = "-1.234E-";
     assert_parse!(
       recognize_float(remaining_exponent),
-      Err(Err::Failure(("", ErrorKind::Digit)))
+      Err(Outcome::Invalid(("", ParserKind::Digit)))
     );
   }
 
@@ -1970,19 +2002,19 @@ mod tests {
   fn configurable_endianness() {
     use crate::number::Endianness;
 
-    fn be_tst16(i: &[u8]) -> IResult<&[u8], u16> {
+    fn be_tst16(i: &[u8]) -> ParseResult<&[u8], u16> {
       u16(Endianness::Big)(i)
     }
-    fn le_tst16(i: &[u8]) -> IResult<&[u8], u16> {
+    fn le_tst16(i: &[u8]) -> ParseResult<&[u8], u16> {
       u16(Endianness::Little)(i)
     }
     assert_eq!(be_tst16(&[0x80, 0x00]), Ok((&b""[..], 32_768_u16)));
     assert_eq!(le_tst16(&[0x80, 0x00]), Ok((&b""[..], 128_u16)));
 
-    fn be_tst32(i: &[u8]) -> IResult<&[u8], u32> {
+    fn be_tst32(i: &[u8]) -> ParseResult<&[u8], u32> {
       u32(Endianness::Big)(i)
     }
-    fn le_tst32(i: &[u8]) -> IResult<&[u8], u32> {
+    fn le_tst32(i: &[u8]) -> ParseResult<&[u8], u32> {
       u32(Endianness::Little)(i)
     }
     assert_eq!(
@@ -1994,10 +2026,10 @@ mod tests {
       Ok((&b""[..], 6_291_474_u32))
     );
 
-    fn be_tst64(i: &[u8]) -> IResult<&[u8], u64> {
+    fn be_tst64(i: &[u8]) -> ParseResult<&[u8], u64> {
       u64(Endianness::Big)(i)
     }
-    fn le_tst64(i: &[u8]) -> IResult<&[u8], u64> {
+    fn le_tst64(i: &[u8]) -> ParseResult<&[u8], u64> {
       u64(Endianness::Little)(i)
     }
     assert_eq!(
@@ -2009,19 +2041,19 @@ mod tests {
       Ok((&b""[..], 36_028_874_334_666_770_u64))
     );
 
-    fn be_tsti16(i: &[u8]) -> IResult<&[u8], i16> {
+    fn be_tsti16(i: &[u8]) -> ParseResult<&[u8], i16> {
       i16(Endianness::Big)(i)
     }
-    fn le_tsti16(i: &[u8]) -> IResult<&[u8], i16> {
+    fn le_tsti16(i: &[u8]) -> ParseResult<&[u8], i16> {
       i16(Endianness::Little)(i)
     }
     assert_eq!(be_tsti16(&[0x00, 0x80]), Ok((&b""[..], 128_i16)));
     assert_eq!(le_tsti16(&[0x00, 0x80]), Ok((&b""[..], -32_768_i16)));
 
-    fn be_tsti32(i: &[u8]) -> IResult<&[u8], i32> {
+    fn be_tsti32(i: &[u8]) -> ParseResult<&[u8], i32> {
       i32(Endianness::Big)(i)
     }
-    fn le_tsti32(i: &[u8]) -> IResult<&[u8], i32> {
+    fn le_tsti32(i: &[u8]) -> ParseResult<&[u8], i32> {
       i32(Endianness::Little)(i)
     }
     assert_eq!(
@@ -2033,10 +2065,10 @@ mod tests {
       Ok((&b""[..], 6_296_064_i32))
     );
 
-    fn be_tsti64(i: &[u8]) -> IResult<&[u8], i64> {
+    fn be_tsti64(i: &[u8]) -> ParseResult<&[u8], i64> {
       i64(Endianness::Big)(i)
     }
-    fn le_tsti64(i: &[u8]) -> IResult<&[u8], i64> {
+    fn le_tsti64(i: &[u8]) -> ParseResult<&[u8], i64> {
       i64(Endianness::Little)(i)
     }
     assert_eq!(
@@ -2050,17 +2082,17 @@ mod tests {
   }
 
   #[cfg(feature = "std")]
-  fn parse_f64(i: &str) -> IResult<&str, f64, ()> {
+  fn parse_f64(i: &str) -> ParseResult<&str, f64, ()> {
     use crate::traits::ParseTo;
     match recognize_float(i) {
       Err(e) => Err(e),
       Ok((i, s)) => {
         if s.is_empty() {
-          return Err(Err::Error(()));
+          return Err(Outcome::Failure(()));
         }
         match s.parse_to() {
           Some(n) => Ok((i, n)),
-          None => Err(Err::Error(())),
+          None => Err(Outcome::Failure(())),
         }
       }
     }

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -4,7 +4,7 @@ use crate::branch::alt;
 use crate::bytes::streaming::tag;
 use crate::character::streaming::{char, digit1, sign};
 use crate::combinator::{cut, map, opt, recognize};
-use crate::error::{ErrorKind, ParseError};
+use crate::error::{ParseContext, ParserKind};
 use crate::internal::*;
 use crate::lib::std::ops::{RangeFrom, RangeTo};
 use crate::sequence::{pair, tuple};
@@ -34,26 +34,26 @@ macro_rules! call (
 
 /// Recognizes an unsigned 1 byte integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::be_u8;
 ///
 /// let parser = |s| {
-///   be_u8::<_, (_, ErrorKind)>(s)
+///   be_u8::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b""[..]), Err(Outcome::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
-pub fn be_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
+pub fn be_u8<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 1;
   if input.input_len() < bound {
-    Err(Err::Incomplete(Needed::new(1)))
+    Err(Outcome::Incomplete(Needed::new(1)))
   } else {
     let res = input.iter_elements().next().unwrap();
 
@@ -63,27 +63,27 @@ where
 
 /// Recognizes a big endian unsigned 2 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::be_u16;
 ///
 /// let parser = |s| {
-///   be_u16::<_, (_, ErrorKind)>(s)
+///   be_u16::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0001)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
-pub fn be_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
+pub fn be_u16<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 2;
   if input.input_len() < bound {
-    Err(Err::Incomplete(Needed::new(bound - input.input_len())))
+    Err(Outcome::Incomplete(Needed::new(bound - input.input_len())))
   } else {
     let mut res = 0u16;
     for byte in input.iter_elements().take(bound) {
@@ -96,27 +96,27 @@ where
 
 /// Recognizes a big endian unsigned 3 byte integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::be_u24;
 ///
 /// let parser = |s| {
-///   be_u24::<_, (_, ErrorKind)>(s)
+///   be_u24::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x000102)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
-pub fn be_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
+pub fn be_u24<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 3;
   if input.input_len() < bound {
-    Err(Err::Incomplete(Needed::new(bound - input.input_len())))
+    Err(Outcome::Incomplete(Needed::new(bound - input.input_len())))
   } else {
     let mut res = 0u32;
     for byte in input.iter_elements().take(bound) {
@@ -129,27 +129,27 @@ where
 
 /// Recognizes a big endian unsigned 4 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::be_u32;
 ///
 /// let parser = |s| {
-///   be_u32::<_, (_, ErrorKind)>(s)
+///   be_u32::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x00010203)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
-pub fn be_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
+pub fn be_u32<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 4;
   if input.input_len() < bound {
-    Err(Err::Incomplete(Needed::new(bound - input.input_len())))
+    Err(Outcome::Incomplete(Needed::new(bound - input.input_len())))
   } else {
     let mut res = 0u32;
     for byte in input.iter_elements().take(bound) {
@@ -162,27 +162,27 @@ where
 
 /// Recognizes a big endian unsigned 8 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::be_u64;
 ///
 /// let parser = |s| {
-///   be_u64::<_, (_, ErrorKind)>(s)
+///   be_u64::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
-pub fn be_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
+pub fn be_u64<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 8;
   if input.input_len() < bound {
-    Err(Err::Incomplete(Needed::new(bound - input.input_len())))
+    Err(Outcome::Incomplete(Needed::new(bound - input.input_len())))
   } else {
     let mut res = 0u64;
     for byte in input.iter_elements().take(bound) {
@@ -195,27 +195,27 @@ where
 
 /// Recognizes a big endian unsigned 16 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::be_u128;
 ///
 /// let parser = |s| {
-///   be_u128::<_, (_, ErrorKind)>(s)
+///   be_u128::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x00010203040506070809101112131415)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
 #[cfg(stable_i128)]
-pub fn be_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
+pub fn be_u128<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 16;
   if input.input_len() < bound {
-    Err(Err::Incomplete(Needed::new(bound - input.input_len())))
+    Err(Outcome::Incomplete(Needed::new(bound - input.input_len())))
   } else {
     let mut res = 0u128;
     for byte in input.iter_elements().take(bound) {
@@ -228,18 +228,18 @@ where
 
 /// Recognizes a signed 1 byte integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::be_i8;
 ///
-/// let parser = be_i8::<_, (_, ErrorKind)>;
+/// let parser = be_i8::<_, (_, ParserKind)>;
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b""[..]), Err(Outcome::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
-pub fn be_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
+pub fn be_i8<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -248,18 +248,18 @@ where
 
 /// Recognizes a big endian signed 2 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::be_i16;
 ///
-/// let parser = be_i16::<_, (_, ErrorKind)>;
+/// let parser = be_i16::<_, (_, ParserKind)>;
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0001)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(&b""[..]), Err(Outcome::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
-pub fn be_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
+pub fn be_i16<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -268,18 +268,18 @@ where
 
 /// Recognizes a big endian signed 3 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::be_i24;
 ///
-/// let parser = be_i24::<_, (_, ErrorKind)>;
+/// let parser = be_i24::<_, (_, ParserKind)>;
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x000102)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(&b""[..]), Err(Outcome::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
-pub fn be_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
+pub fn be_i24<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -293,18 +293,18 @@ where
 
 /// Recognizes a big endian signed 4 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::be_i32;
 ///
-/// let parser = be_i32::<_, (_, ErrorKind)>;
+/// let parser = be_i32::<_, (_, ParserKind)>;
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x00010203)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(4))));
+/// assert_eq!(parser(&b""[..]), Err(Outcome::Incomplete(Needed::new(4))));
 /// ```
 #[inline]
-pub fn be_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
+pub fn be_i32<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -313,19 +313,19 @@ where
 
 /// Recognizes a big endian signed 8 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::be_i64;
 ///
-/// let parser = be_i64::<_, (_, ErrorKind)>;
+/// let parser = be_i64::<_, (_, ParserKind)>;
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
-pub fn be_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
+pub fn be_i64<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -334,19 +334,19 @@ where
 
 /// Recognizes a big endian signed 16 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::be_i128;
 ///
-/// let parser = be_i128::<_, (_, ErrorKind)>;
+/// let parser = be_i128::<_, (_, ParserKind)>;
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x00010203040506070809101112131415)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
 #[cfg(stable_i128)]
-pub fn be_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
+pub fn be_i128<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -355,24 +355,24 @@ where
 
 /// Recognizes an unsigned 1 byte integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::le_u8;
 ///
-/// let parser = le_u8::<_, (_, ErrorKind)>;
+/// let parser = le_u8::<_, (_, ParserKind)>;
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b""[..]), Err(Outcome::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
-pub fn le_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
+pub fn le_u8<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 1;
   if input.input_len() < bound {
-    Err(Err::Incomplete(Needed::new(1)))
+    Err(Outcome::Incomplete(Needed::new(1)))
   } else {
     let res = input.iter_elements().next().unwrap();
 
@@ -382,27 +382,27 @@ where
 
 /// Recognizes a little endian unsigned 2 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::le_u16;
 ///
 /// let parser = |s| {
-///   le_u16::<_, (_, ErrorKind)>(s)
+///   le_u16::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
-pub fn le_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
+pub fn le_u16<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 2;
   if input.input_len() < bound {
-    Err(Err::Incomplete(Needed::new(bound - input.input_len())))
+    Err(Outcome::Incomplete(Needed::new(bound - input.input_len())))
   } else {
     let mut res = 0u16;
     for (index, byte) in input.iter_indices().take(bound) {
@@ -415,27 +415,27 @@ where
 
 /// Recognizes a little endian unsigned 3 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::le_u24;
 ///
 /// let parser = |s| {
-///   le_u24::<_, (_, ErrorKind)>(s)
+///   le_u24::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
-pub fn le_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
+pub fn le_u24<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 3;
   if input.input_len() < bound {
-    Err(Err::Incomplete(Needed::new(bound - input.input_len())))
+    Err(Outcome::Incomplete(Needed::new(bound - input.input_len())))
   } else {
     let mut res = 0u32;
     for (index, byte) in input.iter_indices().take(bound) {
@@ -448,27 +448,27 @@ where
 
 /// Recognizes a little endian unsigned 4 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::le_u32;
 ///
 /// let parser = |s| {
-///   le_u32::<_, (_, ErrorKind)>(s)
+///   le_u32::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x03020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
-pub fn le_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
+pub fn le_u32<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 4;
   if input.input_len() < bound {
-    Err(Err::Incomplete(Needed::new(bound - input.input_len())))
+    Err(Outcome::Incomplete(Needed::new(bound - input.input_len())))
   } else {
     let mut res = 0u32;
     for (index, byte) in input.iter_indices().take(bound) {
@@ -481,27 +481,27 @@ where
 
 /// Recognizes a little endian unsigned 8 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::le_u64;
 ///
 /// let parser = |s| {
-///   le_u64::<_, (_, ErrorKind)>(s)
+///   le_u64::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
-pub fn le_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
+pub fn le_u64<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 8;
   if input.input_len() < bound {
-    Err(Err::Incomplete(Needed::new(bound - input.input_len())))
+    Err(Outcome::Incomplete(Needed::new(bound - input.input_len())))
   } else {
     let mut res = 0u64;
     for (index, byte) in input.iter_indices().take(bound) {
@@ -514,28 +514,28 @@ where
 
 /// Recognizes a little endian unsigned 16 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::le_u128;
 ///
 /// let parser = |s| {
-///   le_u128::<_, (_, ErrorKind)>(s)
+///   le_u128::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x15141312111009080706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
 #[cfg(stable_i128)]
-pub fn le_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
+pub fn le_u128<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 16;
   if input.input_len() < bound {
-    Err(Err::Incomplete(Needed::new(bound - input.input_len())))
+    Err(Outcome::Incomplete(Needed::new(bound - input.input_len())))
   } else {
     let mut res = 0u128;
     for (index, byte) in input.iter_indices().take(bound) {
@@ -548,18 +548,18 @@ where
 
 /// Recognizes a signed 1 byte integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::le_i8;
 ///
-/// let parser = le_i8::<_, (_, ErrorKind)>;
+/// let parser = le_i8::<_, (_, ParserKind)>;
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b""[..]), Err(Outcome::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
-pub fn le_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
+pub fn le_i8<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -568,21 +568,21 @@ where
 
 /// Recognizes a little endian signed 2 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::le_i16;
 ///
 /// let parser = |s| {
-///   le_i16::<_, (_, ErrorKind)>(s)
+///   le_i16::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
-pub fn le_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
+pub fn le_i16<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -591,21 +591,21 @@ where
 
 /// Recognizes a little endian signed 3 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::le_i24;
 ///
 /// let parser = |s| {
-///   le_i24::<_, (_, ErrorKind)>(s)
+///   le_i24::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
-pub fn le_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
+pub fn le_i24<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -619,21 +619,21 @@ where
 
 /// Recognizes a little endian signed 4 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::le_i32;
 ///
 /// let parser = |s| {
-///   le_i32::<_, (_, ErrorKind)>(s)
+///   le_i32::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x03020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
-pub fn le_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
+pub fn le_i32<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -642,21 +642,21 @@ where
 
 /// Recognizes a little endian signed 8 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::le_i64;
 ///
 /// let parser = |s| {
-///   le_i64::<_, (_, ErrorKind)>(s)
+///   le_i64::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
-pub fn le_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
+pub fn le_i64<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -665,22 +665,22 @@ where
 
 /// Recognizes a little endian signed 16 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::le_i128;
 ///
 /// let parser = |s| {
-///   le_i128::<_, (_, ErrorKind)>(s)
+///   le_i128::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x15141312111009080706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
 #[cfg(stable_i128)]
-pub fn le_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
+pub fn le_i128<I, E: ParseContext<I>>(input: I) -> ParseResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -690,27 +690,27 @@ where
 /// Recognizes an unsigned 1 byte integer
 ///
 /// Note that endianness does not apply to 1 byte numbers.
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::streaming::u8;
 ///
 /// let parser = |s| {
-///   u8::<_, (_, ErrorKind)>(s)
+///   u8::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b""[..]), Err(Outcome::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
-pub fn u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
+pub fn u8<I, E: ParseContext<I>>(input: I) -> ParseResult<I, u8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
   let bound: usize = 1;
   if input.input_len() < bound {
-    Err(Err::Incomplete(Needed::new(1)))
+    Err(Outcome::Incomplete(Needed::new(1)))
   } else {
     let res = input.iter_elements().next().unwrap();
 
@@ -722,29 +722,31 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u16 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u16 integer.
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::streaming::u16;
 ///
 /// let be_u16 = |s| {
-///   u16::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
+///   u16::<_, (_, ParserKind)>(nom::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(be_u16(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(1))));
 ///
 /// let le_u16 = |s| {
-///   u16::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
+///   u16::<_, (_, ParserKind)>(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(le_u16(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
-pub fn u16<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u16, E>
+pub fn u16<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, u16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -762,28 +764,30 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u24 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u24 integer.
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::streaming::u24;
 ///
 /// let be_u24 = |s| {
-///   u24::<_,(_, ErrorKind)>(nom::number::Endianness::Big)(s)
+///   u24::<_,(_, ParserKind)>(nom::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(be_u24(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(2))));
 ///
 /// let le_u24 = |s| {
-///   u24::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
+///   u24::<_, (_, ParserKind)>(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(le_u24(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
-pub fn u24<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u32, E>
+pub fn u24<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -801,28 +805,30 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u32 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u32 integer.
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::streaming::u32;
 ///
 /// let be_u32 = |s| {
-///   u32::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
+///   u32::<_, (_, ParserKind)>(nom::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(be_u32(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(3))));
 ///
 /// let le_u32 = |s| {
-///   u32::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
+///   u32::<_, (_, ParserKind)>(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(le_u32(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
-pub fn u32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u32, E>
+pub fn u32<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -840,28 +846,30 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u64 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u64 integer.
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::streaming::u64;
 ///
 /// let be_u64 = |s| {
-///   u64::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
+///   u64::<_, (_, ParserKind)>(nom::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(be_u64(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(7))));
 ///
 /// let le_u64 = |s| {
-///   u64::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
+///   u64::<_, (_, ParserKind)>(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(le_u64(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
-pub fn u64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u64, E>
+pub fn u64<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, u64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -879,29 +887,31 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u128 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u128 integer.
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::streaming::u128;
 ///
 /// let be_u128 = |s| {
-///   u128::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
+///   u128::<_, (_, ParserKind)>(nom::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(be_u128(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(15))));
 ///
 /// let le_u128 = |s| {
-///   u128::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
+///   u128::<_, (_, ParserKind)>(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(le_u128(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
 #[cfg(stable_i128)]
-pub fn u128<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u128, E>
+pub fn u128<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, u128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -918,21 +928,21 @@ where
 /// Recognizes a signed 1 byte integer
 ///
 /// Note that endianness does not apply to 1 byte numbers.
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::streaming::i8;
 ///
 /// let parser = |s| {
-///   i8::<_, (_, ErrorKind)>(s)
+///   i8::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b""[..]), Err(Outcome::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
-pub fn i8<I, E: ParseError<I>>(i: I) -> IResult<I, i8, E>
+pub fn i8<I, E: ParseContext<I>>(i: I) -> ParseResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -943,28 +953,30 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i16 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i16 integer.
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::streaming::i16;
 ///
 /// let be_i16 = |s| {
-///   i16::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
+///   i16::<_, (_, ParserKind)>(nom::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(be_i16(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(1))));
 ///
 /// let le_i16 = |s| {
-///   i16::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
+///   i16::<_, (_, ParserKind)>(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(le_i16(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
-pub fn i16<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i16, E>
+pub fn i16<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -982,28 +994,30 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i24 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i24 integer.
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::streaming::i24;
 ///
 /// let be_i24 = |s| {
-///   i24::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
+///   i24::<_, (_, ParserKind)>(nom::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(be_i24(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(2))));
 ///
 /// let le_i24 = |s| {
-///   i24::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
+///   i24::<_, (_, ParserKind)>(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(le_i24(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
-pub fn i24<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i32, E>
+pub fn i24<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1021,28 +1035,30 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i32 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i32 integer.
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::streaming::i32;
 ///
 /// let be_i32 = |s| {
-///   i32::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
+///   i32::<_, (_, ParserKind)>(nom::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(be_i32(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(3))));
 ///
 /// let le_i32 = |s| {
-///   i32::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
+///   i32::<_, (_, ParserKind)>(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(le_i32(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
-pub fn i32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i32, E>
+pub fn i32<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1060,28 +1076,30 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i64 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i64 integer.
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::streaming::i64;
 ///
 /// let be_i64 = |s| {
-///   i64::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
+///   i64::<_, (_, ParserKind)>(nom::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(be_i64(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(7))));
 ///
 /// let le_i64 = |s| {
-///   i64::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
+///   i64::<_, (_, ParserKind)>(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(le_i64(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
-pub fn i64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i64, E>
+pub fn i64<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1099,29 +1117,31 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i128 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i128 integer.
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::streaming::i128;
 ///
 /// let be_i128 = |s| {
-///   i128::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
+///   i128::<_, (_, ParserKind)>(nom::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(be_i128(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(15))));
 ///
 /// let le_i128 = |s| {
-///   i128::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
+///   i128::<_, (_, ParserKind)>(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(le_i128(&b"\x01"[..]), Err(Outcome::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
 #[cfg(stable_i128)]
-pub fn i128<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i128, E>
+pub fn i128<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1137,20 +1157,20 @@ where
 
 /// Recognizes a big endian 4 bytes floating point number.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::be_f32;
 ///
 /// let parser = |s| {
-///   be_f32::<_, (_, ErrorKind)>(s)
+///   be_f32::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00][..]), Ok((&b""[..], 2.640625)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(&[0x01][..]), Err(Outcome::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
-pub fn be_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
+pub fn be_f32<I, E: ParseContext<I>>(input: I) -> ParseResult<I, f32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1162,20 +1182,20 @@ where
 
 /// Recognizes a big endian 8 bytes floating point number.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::be_f64;
 ///
 /// let parser = |s| {
-///   be_f64::<_, (_, ErrorKind)>(s)
+///   be_f64::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(&[0x01][..]), Err(Outcome::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
-pub fn be_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
+pub fn be_f64<I, E: ParseContext<I>>(input: I) -> ParseResult<I, f64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1187,20 +1207,20 @@ where
 
 /// Recognizes a little endian 4 bytes floating point number.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::le_f32;
 ///
 /// let parser = |s| {
-///   le_f32::<_, (_, ErrorKind)>(s)
+///   le_f32::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(&[0x01][..]), Err(Outcome::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
-pub fn le_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
+pub fn le_f32<I, E: ParseContext<I>>(input: I) -> ParseResult<I, f32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1212,20 +1232,20 @@ where
 
 /// Recognizes a little endian 8 bytes floating point number.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::le_f64;
 ///
 /// let parser = |s| {
-///   le_f64::<_, (_, ErrorKind)>(s)
+///   le_f64::<_, (_, ParserKind)>(s)
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 3145728.0)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(&[0x01][..]), Err(Outcome::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
-pub fn le_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
+pub fn le_f64<I, E: ParseContext<I>>(input: I) -> ParseResult<I, f64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1239,28 +1259,30 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian f32 float,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian f32 float.
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::streaming::f32;
 ///
 /// let be_f32 = |s| {
-///   f32::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
+///   f32::<_, (_, ParserKind)>(nom::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f32(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(be_f32(&b"abc"[..]), Err(Outcome::Incomplete(Needed::new(1))));
 ///
 /// let le_f32 = |s| {
-///   f32::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
+///   f32::<_, (_, ParserKind)>(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f32(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(le_f32(&b"abc"[..]), Err(Outcome::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
-pub fn f32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f32, E>
+pub fn f32<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, f32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1278,28 +1300,30 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian f64 float,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian f64 float.
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::streaming::f64;
 ///
 /// let be_f64 = |s| {
-///   f64::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
+///   f64::<_, (_, ParserKind)>(nom::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f64(&b"abc"[..]), Err(Err::Incomplete(Needed::new(5))));
+/// assert_eq!(be_f64(&b"abc"[..]), Err(Outcome::Incomplete(Needed::new(5))));
 ///
 /// let le_f64 = |s| {
-///   f64::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
+///   f64::<_, (_, ParserKind)>(nom::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f64(&b"abc"[..]), Err(Err::Incomplete(Needed::new(5))));
+/// assert_eq!(le_f64(&b"abc"[..]), Err(Outcome::Incomplete(Needed::new(5))));
 /// ```
 #[inline]
-pub fn f64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f64, E>
+pub fn f64<I, E: ParseContext<I>>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> ParseResult<I, f64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
@@ -1315,9 +1339,9 @@ where
 
 /// Recognizes a hex-encoded integer.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::hex_u32;
 ///
 /// let parser = |s| {
@@ -1325,11 +1349,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(b"01AE;"), Ok((&b";"[..], 0x01AE)));
-/// assert_eq!(parser(b"abc"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(parser(b"ggg"), Err(Err::Error((&b"ggg"[..], ErrorKind::IsA))));
+/// assert_eq!(parser(b"abc"), Err(Outcome::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(b"ggg"), Err(Outcome::Failure((&b"ggg"[..], ParserKind::IsA))));
 /// ```
 #[inline]
-pub fn hex_u32<'a, E: ParseError<&'a [u8]>>(input: &'a [u8]) -> IResult<&'a [u8], u32, E> {
+pub fn hex_u32<'a, E: ParseContext<&'a [u8]>>(input: &'a [u8]) -> ParseResult<&'a [u8], u32, E> {
   let (i, o) = crate::bytes::streaming::is_a(&b"0123456789abcdefABCDEF"[..])(input)?;
 
   // Do not parse more than 8 characters for a u32
@@ -1354,10 +1378,10 @@ pub fn hex_u32<'a, E: ParseError<&'a [u8]>>(input: &'a [u8]) -> IResult<&'a [u8]
 
 /// Recognizes a floating point number in text format and returns the corresponding part of the input.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if it reaches the end of input.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if it reaches the end of input.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// use nom::number::streaming::recognize_float;
 ///
 /// let parser = |s| {
@@ -1367,10 +1391,10 @@ pub fn hex_u32<'a, E: ParseError<&'a [u8]>>(input: &'a [u8]) -> IResult<&'a [u8]
 /// assert_eq!(parser("11e-1;"), Ok((";", "11e-1")));
 /// assert_eq!(parser("123E-02;"), Ok((";", "123E-02")));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Char))));
+/// assert_eq!(parser("abc"), Err(Outcome::Failure(("abc", ParserKind::Char))));
 /// ```
 #[rustfmt::skip]
-pub fn recognize_float<T, E:ParseError<T>>(input: T) -> IResult<T, T, E>
+pub fn recognize_float<T, E:ParseContext<T>>(input: T) -> ParseResult<T, T, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
   T: Clone + Offset,
@@ -1397,9 +1421,11 @@ where
 
 /// Recognizes a floating point number in text format and returns the integer, fraction and exponent parts of the input data
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
-pub fn recognize_float_parts<T, E: ParseError<T>>(input: T) -> IResult<T, (bool, T, T, i32), E>
+pub fn recognize_float_parts<T, E: ParseContext<T>>(
+  input: T,
+) -> ParseResult<T, (bool, T, T, i32), E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
   T: Clone + Offset,
@@ -1456,7 +1482,7 @@ where
 
     let position = match position {
       Some(p) => p,
-      None => return Err(Err::Incomplete(Needed::new(1))),
+      None => return Err(Outcome::Incomplete(Needed::new(1))),
     };
 
     let index = if zero_count == 0 {
@@ -1471,7 +1497,10 @@ where
   };
 
   if integer.input_len() == 0 && fraction.input_len() == 0 {
-    return Err(Err::Error(E::from_error_kind(input, ErrorKind::Float)));
+    return Err(Outcome::Failure(E::from_parser_kind(
+      input,
+      ParserKind::Float,
+    )));
   }
 
   let i2 = i.clone();
@@ -1492,10 +1521,10 @@ where
 
 /// Recognizes floating point number in text format and returns a f32.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::float;
 ///
@@ -1506,9 +1535,9 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(Outcome::Failure(("abc", ParserKind::Float))));
 /// ```
-pub fn float<T, E: ParseError<T>>(input: T) -> IResult<T, f32, E>
+pub fn float<T, E: ParseContext<T>>(input: T) -> ParseResult<T, f32, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
   T: Clone + Offset,
@@ -1536,10 +1565,10 @@ where
 
 /// Recognizes floating point number in text format and returns a f64.
 ///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(nom::Outcome::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::number::complete::double;
 ///
@@ -1550,9 +1579,9 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(Outcome::Failure(("abc", ParserKind::Float))));
 /// ```
-pub fn double<T, E: ParseError<T>>(input: T) -> IResult<T, f64, E>
+pub fn double<T, E: ParseContext<T>>(input: T) -> ParseResult<T, f64, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
   T: Clone + Offset,
@@ -1581,13 +1610,13 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::error::ErrorKind;
-  use crate::internal::{Err, Needed};
+  use crate::error::ParserKind;
+  use crate::internal::{Needed, Outcome};
   use proptest::prelude::*;
 
   macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
-      let res: $crate::IResult<_, _, (_, ErrorKind)> = $left;
+      let res: $crate::ParseResult<_, _, (_, ParserKind)> = $left;
       assert_eq!(res, $right);
     };
   );
@@ -1598,7 +1627,7 @@ mod tests {
     assert_parse!(be_i8(&[0x7f][..]), Ok((&b""[..], 127)));
     assert_parse!(be_i8(&[0xff][..]), Ok((&b""[..], -1)));
     assert_parse!(be_i8(&[0x80][..]), Ok((&b""[..], -128)));
-    assert_parse!(be_i8(&[][..]), Err(Err::Incomplete(Needed::new(1))));
+    assert_parse!(be_i8(&[][..]), Err(Outcome::Incomplete(Needed::new(1))));
   }
 
   #[test]
@@ -1607,8 +1636,11 @@ mod tests {
     assert_parse!(be_i16(&[0x7f, 0xff][..]), Ok((&b""[..], 32_767_i16)));
     assert_parse!(be_i16(&[0xff, 0xff][..]), Ok((&b""[..], -1)));
     assert_parse!(be_i16(&[0x80, 0x00][..]), Ok((&b""[..], -32_768_i16)));
-    assert_parse!(be_i16(&[][..]), Err(Err::Incomplete(Needed::new(2))));
-    assert_parse!(be_i16(&[0x00][..]), Err(Err::Incomplete(Needed::new(1))));
+    assert_parse!(be_i16(&[][..]), Err(Outcome::Incomplete(Needed::new(2))));
+    assert_parse!(
+      be_i16(&[0x00][..]),
+      Err(Outcome::Incomplete(Needed::new(1)))
+    );
   }
 
   #[test]
@@ -1619,11 +1651,14 @@ mod tests {
       be_u24(&[0x12, 0x34, 0x56][..]),
       Ok((&b""[..], 1_193_046_u32))
     );
-    assert_parse!(be_u24(&[][..]), Err(Err::Incomplete(Needed::new(3))));
-    assert_parse!(be_u24(&[0x00][..]), Err(Err::Incomplete(Needed::new(2))));
+    assert_parse!(be_u24(&[][..]), Err(Outcome::Incomplete(Needed::new(3))));
+    assert_parse!(
+      be_u24(&[0x00][..]),
+      Err(Outcome::Incomplete(Needed::new(2)))
+    );
     assert_parse!(
       be_u24(&[0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(Outcome::Incomplete(Needed::new(1)))
     );
   }
 
@@ -1635,11 +1670,14 @@ mod tests {
       be_i24(&[0xED, 0xCB, 0xAA][..]),
       Ok((&b""[..], -1_193_046_i32))
     );
-    assert_parse!(be_i24(&[][..]), Err(Err::Incomplete(Needed::new(3))));
-    assert_parse!(be_i24(&[0x00][..]), Err(Err::Incomplete(Needed::new(2))));
+    assert_parse!(be_i24(&[][..]), Err(Outcome::Incomplete(Needed::new(3))));
+    assert_parse!(
+      be_i24(&[0x00][..]),
+      Err(Outcome::Incomplete(Needed::new(2)))
+    );
     assert_parse!(
       be_i24(&[0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(Outcome::Incomplete(Needed::new(1)))
     );
   }
 
@@ -1655,15 +1693,18 @@ mod tests {
       be_i32(&[0x80, 0x00, 0x00, 0x00][..]),
       Ok((&b""[..], -2_147_483_648_i32))
     );
-    assert_parse!(be_i32(&[][..]), Err(Err::Incomplete(Needed::new(4))));
-    assert_parse!(be_i32(&[0x00][..]), Err(Err::Incomplete(Needed::new(3))));
+    assert_parse!(be_i32(&[][..]), Err(Outcome::Incomplete(Needed::new(4))));
+    assert_parse!(
+      be_i32(&[0x00][..]),
+      Err(Outcome::Incomplete(Needed::new(3)))
+    );
     assert_parse!(
       be_i32(&[0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(Outcome::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       be_i32(&[0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(Outcome::Incomplete(Needed::new(1)))
     );
   }
 
@@ -1685,31 +1726,34 @@ mod tests {
       be_i64(&[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
       Ok((&b""[..], -9_223_372_036_854_775_808_i64))
     );
-    assert_parse!(be_i64(&[][..]), Err(Err::Incomplete(Needed::new(8))));
-    assert_parse!(be_i64(&[0x00][..]), Err(Err::Incomplete(Needed::new(7))));
+    assert_parse!(be_i64(&[][..]), Err(Outcome::Incomplete(Needed::new(8))));
+    assert_parse!(
+      be_i64(&[0x00][..]),
+      Err(Outcome::Incomplete(Needed::new(7)))
+    );
     assert_parse!(
       be_i64(&[0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(6)))
+      Err(Outcome::Incomplete(Needed::new(6)))
     );
     assert_parse!(
       be_i64(&[0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(5)))
+      Err(Outcome::Incomplete(Needed::new(5)))
     );
     assert_parse!(
       be_i64(&[0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(4)))
+      Err(Outcome::Incomplete(Needed::new(4)))
     );
     assert_parse!(
       be_i64(&[0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(3)))
+      Err(Outcome::Incomplete(Needed::new(3)))
     );
     assert_parse!(
       be_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(Outcome::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       be_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(Outcome::Incomplete(Needed::new(1)))
     );
   }
 
@@ -1758,68 +1802,71 @@ mod tests {
         -170_141_183_460_469_231_731_687_303_715_884_105_728_i128
       ))
     );
-    assert_parse!(be_i128(&[][..]), Err(Err::Incomplete(Needed::new(16))));
-    assert_parse!(be_i128(&[0x00][..]), Err(Err::Incomplete(Needed::new(15))));
+    assert_parse!(be_i128(&[][..]), Err(Outcome::Incomplete(Needed::new(16))));
+    assert_parse!(
+      be_i128(&[0x00][..]),
+      Err(Outcome::Incomplete(Needed::new(15)))
+    );
     assert_parse!(
       be_i128(&[0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(14)))
+      Err(Outcome::Incomplete(Needed::new(14)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(13)))
+      Err(Outcome::Incomplete(Needed::new(13)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(12)))
+      Err(Outcome::Incomplete(Needed::new(12)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(11)))
+      Err(Outcome::Incomplete(Needed::new(11)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(10)))
+      Err(Outcome::Incomplete(Needed::new(10)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(9)))
+      Err(Outcome::Incomplete(Needed::new(9)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(8)))
+      Err(Outcome::Incomplete(Needed::new(8)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(7)))
+      Err(Outcome::Incomplete(Needed::new(7)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(6)))
+      Err(Outcome::Incomplete(Needed::new(6)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(5)))
+      Err(Outcome::Incomplete(Needed::new(5)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(4)))
+      Err(Outcome::Incomplete(Needed::new(4)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(3)))
+      Err(Outcome::Incomplete(Needed::new(3)))
     );
     assert_parse!(
       be_i128(
         &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
       ),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(Outcome::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       be_i128(
         &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
           [..]
       ),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(Outcome::Incomplete(Needed::new(1)))
     );
   }
 
@@ -1986,7 +2033,10 @@ mod tests {
   fn hex_u32_tests() {
     assert_parse!(
       hex_u32(&b";"[..]),
-      Err(Err::Error(error_position!(&b";"[..], ErrorKind::IsA)))
+      Err(Outcome::Failure(error_position!(
+        &b";"[..],
+        ParserKind::IsA
+      )))
     );
     assert_parse!(hex_u32(&b"ff;"[..]), Ok((&b";"[..], 255)));
     assert_parse!(hex_u32(&b"1be2;"[..]), Ok((&b";"[..], 7138)));
@@ -1999,7 +2049,10 @@ mod tests {
     );
     assert_parse!(hex_u32(&b"ffffffff;"[..]), Ok((&b";"[..], 4_294_967_295)));
     assert_parse!(hex_u32(&b"0x1be2;"[..]), Ok((&b"x1be2;"[..], 0)));
-    assert_parse!(hex_u32(&b"12af"[..]), Err(Err::Incomplete(Needed::new(1))));
+    assert_parse!(
+      hex_u32(&b"12af"[..]),
+      Err(Outcome::Incomplete(Needed::new(1)))
+    );
   }
 
   #[test]
@@ -2043,7 +2096,7 @@ mod tests {
     let remaining_exponent = "-1.234E-";
     assert_parse!(
       recognize_float(remaining_exponent),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(Outcome::Incomplete(Needed::new(1)))
     );
   }
 
@@ -2051,19 +2104,19 @@ mod tests {
   fn configurable_endianness() {
     use crate::number::Endianness;
 
-    fn be_tst16(i: &[u8]) -> IResult<&[u8], u16> {
+    fn be_tst16(i: &[u8]) -> ParseResult<&[u8], u16> {
       u16(Endianness::Big)(i)
     }
-    fn le_tst16(i: &[u8]) -> IResult<&[u8], u16> {
+    fn le_tst16(i: &[u8]) -> ParseResult<&[u8], u16> {
       u16(Endianness::Little)(i)
     }
     assert_eq!(be_tst16(&[0x80, 0x00]), Ok((&b""[..], 32_768_u16)));
     assert_eq!(le_tst16(&[0x80, 0x00]), Ok((&b""[..], 128_u16)));
 
-    fn be_tst32(i: &[u8]) -> IResult<&[u8], u32> {
+    fn be_tst32(i: &[u8]) -> ParseResult<&[u8], u32> {
       u32(Endianness::Big)(i)
     }
-    fn le_tst32(i: &[u8]) -> IResult<&[u8], u32> {
+    fn le_tst32(i: &[u8]) -> ParseResult<&[u8], u32> {
       u32(Endianness::Little)(i)
     }
     assert_eq!(
@@ -2075,10 +2128,10 @@ mod tests {
       Ok((&b""[..], 6_291_474_u32))
     );
 
-    fn be_tst64(i: &[u8]) -> IResult<&[u8], u64> {
+    fn be_tst64(i: &[u8]) -> ParseResult<&[u8], u64> {
       u64(Endianness::Big)(i)
     }
-    fn le_tst64(i: &[u8]) -> IResult<&[u8], u64> {
+    fn le_tst64(i: &[u8]) -> ParseResult<&[u8], u64> {
       u64(Endianness::Little)(i)
     }
     assert_eq!(
@@ -2090,19 +2143,19 @@ mod tests {
       Ok((&b""[..], 36_028_874_334_666_770_u64))
     );
 
-    fn be_tsti16(i: &[u8]) -> IResult<&[u8], i16> {
+    fn be_tsti16(i: &[u8]) -> ParseResult<&[u8], i16> {
       i16(Endianness::Big)(i)
     }
-    fn le_tsti16(i: &[u8]) -> IResult<&[u8], i16> {
+    fn le_tsti16(i: &[u8]) -> ParseResult<&[u8], i16> {
       i16(Endianness::Little)(i)
     }
     assert_eq!(be_tsti16(&[0x00, 0x80]), Ok((&b""[..], 128_i16)));
     assert_eq!(le_tsti16(&[0x00, 0x80]), Ok((&b""[..], -32_768_i16)));
 
-    fn be_tsti32(i: &[u8]) -> IResult<&[u8], i32> {
+    fn be_tsti32(i: &[u8]) -> ParseResult<&[u8], i32> {
       i32(Endianness::Big)(i)
     }
-    fn le_tsti32(i: &[u8]) -> IResult<&[u8], i32> {
+    fn le_tsti32(i: &[u8]) -> ParseResult<&[u8], i32> {
       i32(Endianness::Little)(i)
     }
     assert_eq!(
@@ -2114,10 +2167,10 @@ mod tests {
       Ok((&b""[..], 6_296_064_i32))
     );
 
-    fn be_tsti64(i: &[u8]) -> IResult<&[u8], i64> {
+    fn be_tsti64(i: &[u8]) -> ParseResult<&[u8], i64> {
       i64(Endianness::Big)(i)
     }
-    fn le_tsti64(i: &[u8]) -> IResult<&[u8], i64> {
+    fn le_tsti64(i: &[u8]) -> ParseResult<&[u8], i64> {
       i64(Endianness::Little)(i)
     }
     assert_eq!(
@@ -2131,17 +2184,17 @@ mod tests {
   }
 
   #[cfg(feature = "std")]
-  fn parse_f64(i: &str) -> IResult<&str, f64, ()> {
+  fn parse_f64(i: &str) -> ParseResult<&str, f64, ()> {
     use crate::traits::ParseTo;
     match recognize_float(i) {
       Err(e) => Err(e),
       Ok((i, s)) => {
         if s.is_empty() {
-          return Err(Err::Error(()));
+          return Err(Outcome::Failure(()));
         }
         match s.parse_to() {
           Some(n) => Ok((i, n)),
-          None => Err(Err::Error(())),
+          None => Err(Outcome::Failure(())),
         }
       }
     }

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -3,8 +3,8 @@
 #[cfg(test)]
 mod tests;
 
-use crate::error::ParseError;
-use crate::internal::{IResult, Parser};
+use crate::error::ParseContext;
+use crate::internal::{ParseResult, Parser};
 
 /// Gets an object from the first parser,
 /// then gets another object from the second parser.
@@ -13,7 +13,7 @@ use crate::internal::{IResult, Parser};
 /// * `first` The first parser to apply.
 /// * `second` The second parser to apply.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::sequence::pair;
 /// use nom::bytes::complete::tag;
@@ -22,13 +22,13 @@ use crate::internal::{IResult, Parser};
 ///
 /// assert_eq!(parser("abcefg"), Ok(("", ("abc", "efg"))));
 /// assert_eq!(parser("abcefghij"), Ok(("hij", ("abc", "efg"))));
-/// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(Err::Error(("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(Outcome::Failure(("", ParserKind::Tag))));
+/// assert_eq!(parser("123"), Err(Outcome::Failure(("123", ParserKind::Tag))));
 /// ```
-pub fn pair<I, O1, O2, E: ParseError<I>, F, G>(
+pub fn pair<I, O1, O2, E: ParseContext<I>, F, G>(
   mut first: F,
   mut second: G,
-) -> impl FnMut(I) -> IResult<I, (O1, O2), E>
+) -> impl FnMut(I) -> ParseResult<I, (O1, O2), E>
 where
   F: Parser<I, O1, E>,
   G: Parser<I, O2, E>,
@@ -46,7 +46,7 @@ where
 /// * `first` The opening parser.
 /// * `second` The second parser to get object.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::sequence::preceded;
 /// use nom::bytes::complete::tag;
@@ -55,13 +55,13 @@ where
 ///
 /// assert_eq!(parser("abcefg"), Ok(("", "efg")));
 /// assert_eq!(parser("abcefghij"), Ok(("hij", "efg")));
-/// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(Err::Error(("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(Outcome::Failure(("", ParserKind::Tag))));
+/// assert_eq!(parser("123"), Err(Outcome::Failure(("123", ParserKind::Tag))));
 /// ```
-pub fn preceded<I, O1, O2, E: ParseError<I>, F, G>(
+pub fn preceded<I, O1, O2, E: ParseContext<I>, F, G>(
   mut first: F,
   mut second: G,
-) -> impl FnMut(I) -> IResult<I, O2, E>
+) -> impl FnMut(I) -> ParseResult<I, O2, E>
 where
   F: Parser<I, O1, E>,
   G: Parser<I, O2, E>,
@@ -79,7 +79,7 @@ where
 /// * `first` The first parser to apply.
 /// * `second` The second parser to match an object.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::sequence::terminated;
 /// use nom::bytes::complete::tag;
@@ -88,13 +88,13 @@ where
 ///
 /// assert_eq!(parser("abcefg"), Ok(("", "abc")));
 /// assert_eq!(parser("abcefghij"), Ok(("hij", "abc")));
-/// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(Err::Error(("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(Outcome::Failure(("", ParserKind::Tag))));
+/// assert_eq!(parser("123"), Err(Outcome::Failure(("123", ParserKind::Tag))));
 /// ```
-pub fn terminated<I, O1, O2, E: ParseError<I>, F, G>(
+pub fn terminated<I, O1, O2, E: ParseContext<I>, F, G>(
   mut first: F,
   mut second: G,
-) -> impl FnMut(I) -> IResult<I, O1, E>
+) -> impl FnMut(I) -> ParseResult<I, O1, E>
 where
   F: Parser<I, O1, E>,
   G: Parser<I, O2, E>,
@@ -114,7 +114,7 @@ where
 /// * `sep` The separator parser to apply.
 /// * `second` The second parser to apply.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::sequence::separated_pair;
 /// use nom::bytes::complete::tag;
@@ -123,14 +123,14 @@ where
 ///
 /// assert_eq!(parser("abc|efg"), Ok(("", ("abc", "efg"))));
 /// assert_eq!(parser("abc|efghij"), Ok(("hij", ("abc", "efg"))));
-/// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(Err::Error(("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(Outcome::Failure(("", ParserKind::Tag))));
+/// assert_eq!(parser("123"), Err(Outcome::Failure(("123", ParserKind::Tag))));
 /// ```
-pub fn separated_pair<I, O1, O2, O3, E: ParseError<I>, F, G, H>(
+pub fn separated_pair<I, O1, O2, O3, E: ParseContext<I>, F, G, H>(
   mut first: F,
   mut sep: G,
   mut second: H,
-) -> impl FnMut(I) -> IResult<I, (O1, O3), E>
+) -> impl FnMut(I) -> ParseResult<I, (O1, O3), E>
 where
   F: Parser<I, O1, E>,
   G: Parser<I, O2, E>,
@@ -152,7 +152,7 @@ where
 /// * `second` The second parser to apply.
 /// * `third` The third parser to apply and discard.
 /// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::{Outcome, error::ParserKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::sequence::delimited;
 /// use nom::bytes::complete::tag;
@@ -161,14 +161,14 @@ where
 ///
 /// assert_eq!(parser("(abc)"), Ok(("", "abc")));
 /// assert_eq!(parser("(abc)def"), Ok(("def", "abc")));
-/// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(Err::Error(("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(Outcome::Failure(("", ParserKind::Tag))));
+/// assert_eq!(parser("123"), Err(Outcome::Failure(("123", ParserKind::Tag))));
 /// ```
-pub fn delimited<I, O1, O2, O3, E: ParseError<I>, F, G, H>(
+pub fn delimited<I, O1, O2, O3, E: ParseContext<I>, F, G, H>(
   mut first: F,
   mut second: G,
   mut third: H,
-) -> impl FnMut(I) -> IResult<I, O2, E>
+) -> impl FnMut(I) -> ParseResult<I, O2, E>
 where
   F: Parser<I, O1, E>,
   G: Parser<I, O2, E>,
@@ -186,13 +186,13 @@ where
 /// This trait is implemented for tuples of parsers of up to 21 elements.
 pub trait Tuple<I, O, E> {
   /// Parses the input and returns a tuple of results of each parser.
-  fn parse(&mut self, input: I) -> IResult<I, O, E>;
+  fn parse(&mut self, input: I) -> ParseResult<I, O, E>;
 }
 
-impl<Input, Output, Error: ParseError<Input>, F: Parser<Input, Output, Error>>
-  Tuple<Input, (Output,), Error> for (F,)
+impl<Input, Output, Context: ParseContext<Input>, F: Parser<Input, Output, Context>>
+  Tuple<Input, (Output,), Context> for (F,)
 {
-  fn parse(&mut self, input: Input) -> IResult<Input, (Output,), Error> {
+  fn parse(&mut self, input: Input) -> ParseResult<Input, (Output,), Context> {
     self.0.parse(input).map(|(i, o)| (i, (o,)))
   }
 }
@@ -214,11 +214,11 @@ macro_rules! tuple_trait(
 macro_rules! tuple_trait_impl(
   ($($name:ident $ty: ident),+) => (
     impl<
-      Input: Clone, $($ty),+ , Error: ParseError<Input>,
-      $($name: Parser<Input, $ty, Error>),+
-    > Tuple<Input, ( $($ty),+ ), Error> for ( $($name),+ ) {
+      Input: Clone, $($ty),+ , Context: ParseContext<Input>,
+      $($name: Parser<Input, $ty, Context>),+
+    > Tuple<Input, ( $($ty),+ ), Context> for ( $($name),+ ) {
 
-      fn parse(&mut self, input: Input) -> IResult<Input, ( $($ty),+ ), Error> {
+      fn parse(&mut self, input: Input) -> ParseResult<Input, ( $($ty),+ ), Context> {
         tuple_trait_inner!(0, self, input, (), $($name)+)
 
       }
@@ -250,16 +250,16 @@ tuple_trait!(FnA A, FnB B, FnC C, FnD D, FnE E, FnF F, FnG G, FnH H, FnI I, FnJ 
 ///Applies a tuple of parsers one by one and returns their results as a tuple.
 ///
 /// ```rust
-/// # use nom::{Err, error::ErrorKind};
+/// # use nom::{Outcome, error::ParserKind};
 /// use nom::sequence::tuple;
 /// use nom::character::complete::{alpha1, digit1};
 /// let mut parser = tuple((alpha1, digit1, alpha1));
 ///
 /// assert_eq!(parser("abc123def"), Ok(("", ("abc", "123", "def"))));
-/// assert_eq!(parser("123def"), Err(Err::Error(("123def", ErrorKind::Alpha))));
+/// assert_eq!(parser("123def"), Err(Outcome::Failure(("123def", ParserKind::Alpha))));
 /// ```
-pub fn tuple<I, O, E: ParseError<I>, List: Tuple<I, O, E>>(
+pub fn tuple<I, O, E: ParseContext<I>, List: Tuple<I, O, E>>(
   mut l: List,
-) -> impl FnMut(I) -> IResult<I, O, E> {
+) -> impl FnMut(I) -> ParseResult<I, O, E> {
   move |i: I| l.parse(i)
 }

--- a/tests/arithmetic.rs
+++ b/tests/arithmetic.rs
@@ -6,7 +6,7 @@ use nom::{
   combinator::map_res,
   multi::fold_many0,
   sequence::{delimited, pair},
-  IResult,
+  ParseResult,
 };
 
 // Parser definition
@@ -14,7 +14,7 @@ use nom::{
 use std::str::FromStr;
 
 // We parse any expr surrounded by parens, ignoring all whitespaces around those
-fn parens(i: &str) -> IResult<&str, i64> {
+fn parens(i: &str) -> ParseResult<&str, i64> {
   delimited(space, delimited(tag("("), expr, tag(")")), space)(i)
 }
 
@@ -22,7 +22,7 @@ fn parens(i: &str) -> IResult<&str, i64> {
 // We look for a digit suite, and try to convert it.
 // If either str::from_utf8 or FromStr::from_str fail,
 // we fallback to the parens parser defined above
-fn factor(i: &str) -> IResult<&str, i64> {
+fn factor(i: &str) -> ParseResult<&str, i64> {
   alt((
     map_res(delimited(space, digit, space), FromStr::from_str),
     parens,
@@ -32,7 +32,7 @@ fn factor(i: &str) -> IResult<&str, i64> {
 // We read an initial factor and for each time we find
 // a * or / operator followed by another factor, we do
 // the math by folding everything
-fn term(i: &str) -> IResult<&str, i64> {
+fn term(i: &str) -> ParseResult<&str, i64> {
   let (i, init) = factor(i)?;
 
   fold_many0(
@@ -48,7 +48,7 @@ fn term(i: &str) -> IResult<&str, i64> {
   )(i)
 }
 
-fn expr(i: &str) -> IResult<&str, i64> {
+fn expr(i: &str) -> ParseResult<&str, i64> {
   let (i, init) = term(i)?;
 
   fold_many0(

--- a/tests/arithmetic_ast.rs
+++ b/tests/arithmetic_ast.rs
@@ -10,7 +10,7 @@ use nom::{
   combinator::{map, map_res},
   multi::many0,
   sequence::{delimited, preceded},
-  IResult,
+  ParseResult,
 };
 
 pub enum Expr {
@@ -58,7 +58,7 @@ impl Debug for Expr {
   }
 }
 
-fn parens(i: &str) -> IResult<&str, Expr> {
+fn parens(i: &str) -> ParseResult<&str, Expr> {
   delimited(
     multispace,
     delimited(tag("("), map(expr, |e| Expr::Paren(Box::new(e))), tag(")")),
@@ -66,7 +66,7 @@ fn parens(i: &str) -> IResult<&str, Expr> {
   )(i)
 }
 
-fn factor(i: &str) -> IResult<&str, Expr> {
+fn factor(i: &str) -> ParseResult<&str, Expr> {
   alt((
     map(
       map_res(delimited(multispace, digit, multispace), FromStr::from_str),
@@ -88,7 +88,7 @@ fn fold_exprs(initial: Expr, remainder: Vec<(Oper, Expr)>) -> Expr {
   })
 }
 
-fn term(i: &str) -> IResult<&str, Expr> {
+fn term(i: &str) -> ParseResult<&str, Expr> {
   let (i, initial) = factor(i)?;
   let (i, remainder) = many0(alt((
     |i| {
@@ -104,7 +104,7 @@ fn term(i: &str) -> IResult<&str, Expr> {
   Ok((i, fold_exprs(initial, remainder)))
 }
 
-fn expr(i: &str) -> IResult<&str, Expr> {
+fn expr(i: &str) -> ParseResult<&str, Expr> {
   let (i, initial) = term(i)?;
   let (i, remainder) = many0(alt((
     |i| {

--- a/tests/blockbuf-arithmetic.rs
+++ b/tests/blockbuf-arithmetic.rs
@@ -216,12 +216,12 @@ macro_rules! block_eat_separator (
 #[macro_export]
 macro_rules! block_named (
   ($name:ident, $submac:ident!( $($args:tt)* )) => (
-    fn $name<'a>( i: BlockSlice<'a> ) -> nom::IResult<BlockSlice<'a>, BlockSlice<'a>, u32> {
+    fn $name<'a>( i: BlockSlice<'a> ) -> nom::ParseResult<BlockSlice<'a>, BlockSlice<'a>, u32> {
       $submac!(i, $($args)*)
     }
   );
   ($name:ident<$o:ty>, $submac:ident!( $($args:tt)* )) => (
-    fn $name<'a>( i: BlockSlice<'a> ) -> nom::IResult<BlockSlice<'a>, $o, u32> {
+    fn $name<'a>( i: BlockSlice<'a> ) -> nom::ParseResult<BlockSlice<'a>, $o, u32> {
       $submac!(i, $($args)*)
     }
   );

--- a/tests/css.rs
+++ b/tests/css.rs
@@ -1,7 +1,7 @@
 use nom::bytes::complete::{tag, take_while_m_n};
 use nom::combinator::map_res;
 use nom::sequence::tuple;
-use nom::IResult;
+use nom::ParseResult;
 
 #[derive(Debug, PartialEq)]
 pub struct Color {
@@ -18,11 +18,11 @@ fn is_hex_digit(c: char) -> bool {
   c.is_digit(16)
 }
 
-fn hex_primary(input: &str) -> IResult<&str, u8> {
+fn hex_primary(input: &str) -> ParseResult<&str, u8> {
   map_res(take_while_m_n(2, 2, is_hex_digit), from_hex)(input)
 }
 
-fn hex_color(input: &str) -> IResult<&str, Color> {
+fn hex_color(input: &str) -> ParseResult<&str, Color> {
   let (input, _) = tag("#")(input)?;
   let (input, (red, green, blue)) = tuple((hex_primary, hex_primary, hex_primary))(input)?;
 

--- a/tests/custom_errors.rs
+++ b/tests/custom_errors.rs
@@ -3,46 +3,46 @@
 use nom::bytes::streaming::tag;
 use nom::character::streaming::digit1 as digit;
 use nom::combinator::verify;
-use nom::error::{ErrorKind, ParseError};
+use nom::error::{ParseContext, ParserKind};
 #[cfg(feature = "alloc")]
 use nom::multi::count;
 use nom::sequence::terminated;
-use nom::IResult;
+use nom::ParseResult;
 
 #[derive(Debug)]
 pub struct CustomError(String);
 
-impl<'a> From<(&'a str, ErrorKind)> for CustomError {
-  fn from(error: (&'a str, ErrorKind)) -> Self {
+impl<'a> From<(&'a str, ParserKind)> for CustomError {
+  fn from(error: (&'a str, ParserKind)) -> Self {
     CustomError(format!("error code was: {:?}", error))
   }
 }
 
-impl<'a> ParseError<&'a str> for CustomError {
-  fn from_error_kind(_: &'a str, kind: ErrorKind) -> Self {
+impl<'a> ParseContext<&'a str> for CustomError {
+  fn from_parser_kind(_: &'a str, kind: ParserKind) -> Self {
     CustomError(format!("error code was: {:?}", kind))
   }
 
-  fn append(_: &'a str, kind: ErrorKind, other: CustomError) -> Self {
+  fn append(_: &'a str, kind: ParserKind, other: CustomError) -> Self {
     CustomError(format!("{:?}\nerror code was: {:?}", other, kind))
   }
 }
 
-fn test1(input: &str) -> IResult<&str, &str, CustomError> {
+fn test1(input: &str) -> ParseResult<&str, &str, CustomError> {
   //fix_error!(input, CustomError, tag!("abcd"))
   tag("abcd")(input)
 }
 
-fn test2(input: &str) -> IResult<&str, &str, CustomError> {
+fn test2(input: &str) -> ParseResult<&str, &str, CustomError> {
   //terminated!(input, test1, fix_error!(CustomError, digit))
   terminated(test1, digit)(input)
 }
 
-fn test3(input: &str) -> IResult<&str, &str, CustomError> {
+fn test3(input: &str) -> ParseResult<&str, &str, CustomError> {
   verify(test1, |s: &str| s.starts_with("abcd"))(input)
 }
 
 #[cfg(feature = "alloc")]
-fn test4(input: &str) -> IResult<&str, Vec<&str>, CustomError> {
+fn test4(input: &str) -> ParseResult<&str, Vec<&str>, CustomError> {
   count(test1, 4)(input)
 }

--- a/tests/escaped.rs
+++ b/tests/escaped.rs
@@ -1,21 +1,24 @@
 use nom::bytes::complete::escaped;
 use nom::character::complete::digit1;
 use nom::character::complete::one_of;
-use nom::{error::ErrorKind, Err, IResult};
+use nom::{error::ParserKind, Outcome, ParseResult};
 
-fn esc(s: &str) -> IResult<&str, &str, (&str, ErrorKind)> {
+fn esc(s: &str) -> ParseResult<&str, &str, (&str, ParserKind)> {
   escaped(digit1, '\\', one_of("\"n\\"))(s)
 }
 
 #[cfg(feature = "alloc")]
-fn esc_trans(s: &str) -> IResult<&str, String, (&str, ErrorKind)> {
+fn esc_trans(s: &str) -> ParseResult<&str, String, (&str, ParserKind)> {
   use nom::bytes::complete::{escaped_transform, tag};
   escaped_transform(digit1, '\\', tag("n"))(s)
 }
 
 #[test]
 fn test_escaped() {
-  assert_eq!(esc("abcd"), Err(Err::Error(("abcd", ErrorKind::Escaped))));
+  assert_eq!(
+    esc("abcd"),
+    Err(Outcome::Failure(("abcd", ParserKind::Escaped)))
+  );
 }
 
 #[test]
@@ -23,6 +26,6 @@ fn test_escaped() {
 fn test_escaped_transform() {
   assert_eq!(
     esc_trans("abcd"),
-    Err(Err::Error(("abcd", ErrorKind::EscapedTransform)))
+    Err(Outcome::Failure(("abcd", ParserKind::EscapedTransform)))
   );
 }

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -3,12 +3,12 @@ use nom::bytes::complete::tag;
 use nom::character::streaming::digit1 as digit;
 use nom::combinator::{map, map_res, opt, recognize};
 use nom::sequence::{delimited, pair};
-use nom::IResult;
+use nom::ParseResult;
 
 use std::str;
 use std::str::FromStr;
 
-fn unsigned_float(i: &[u8]) -> IResult<&[u8], f32> {
+fn unsigned_float(i: &[u8]) -> ParseResult<&[u8], f32> {
   let float_bytes = recognize(alt((
     delimited(digit, tag("."), opt(digit)),
     delimited(opt(digit), tag("."), digit),
@@ -17,7 +17,7 @@ fn unsigned_float(i: &[u8]) -> IResult<&[u8], f32> {
   map_res(float_str, FromStr::from_str)(i)
 }
 
-fn float(i: &[u8]) -> IResult<&[u8], f32> {
+fn float(i: &[u8]) -> ParseResult<&[u8], f32> {
   map(
     pair(opt(alt((tag("+"), tag("-")))), unsigned_float),
     |(sign, value)| {

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -4,7 +4,7 @@ use nom::{
   combinator::opt,
   multi::many0,
   sequence::{delimited, pair, terminated, tuple},
-  IResult,
+  ParseResult,
 };
 
 use std::collections::HashMap;
@@ -13,22 +13,22 @@ fn is_line_ending_or_comment(chr: char) -> bool {
   chr == ';' || chr == '\n'
 }
 
-fn not_line_ending(i: &str) -> IResult<&str, &str> {
+fn not_line_ending(i: &str) -> ParseResult<&str, &str> {
   take_while(|c| c != '\r' && c != '\n')(i)
 }
 
-fn space_or_line_ending(i: &str) -> IResult<&str, &str> {
+fn space_or_line_ending(i: &str) -> ParseResult<&str, &str> {
   is_a(" \r\n")(i)
 }
 
-fn category(i: &str) -> IResult<&str, &str> {
+fn category(i: &str) -> ParseResult<&str, &str> {
   terminated(
     delimited(char('['), take_while(|c| c != ']'), char(']')),
     opt(is_a(" \r\n")),
   )(i)
 }
 
-fn key_value(i: &str) -> IResult<&str, (&str, &str)> {
+fn key_value(i: &str) -> ParseResult<&str, (&str, &str)> {
   let (i, key) = alphanumeric(i)?;
   let (i, _) = tuple((opt(space), tag("="), opt(space)))(i)?;
   let (i, val) = take_till(is_line_ending_or_comment)(i)?;
@@ -39,26 +39,26 @@ fn key_value(i: &str) -> IResult<&str, (&str, &str)> {
   Ok((i, (key, val)))
 }
 
-fn keys_and_values_aggregator(i: &str) -> IResult<&str, Vec<(&str, &str)>> {
+fn keys_and_values_aggregator(i: &str) -> ParseResult<&str, Vec<(&str, &str)>> {
   many0(key_value)(i)
 }
 
-fn keys_and_values(input: &str) -> IResult<&str, HashMap<&str, &str>> {
+fn keys_and_values(input: &str) -> ParseResult<&str, HashMap<&str, &str>> {
   match keys_and_values_aggregator(input) {
     Ok((i, tuple_vec)) => Ok((i, tuple_vec.into_iter().collect())),
     Err(e) => Err(e),
   }
 }
 
-fn category_and_keys(i: &str) -> IResult<&str, (&str, HashMap<&str, &str>)> {
+fn category_and_keys(i: &str) -> ParseResult<&str, (&str, HashMap<&str, &str>)> {
   pair(category, keys_and_values)(i)
 }
 
-fn categories_aggregator(i: &str) -> IResult<&str, Vec<(&str, HashMap<&str, &str>)>> {
+fn categories_aggregator(i: &str) -> ParseResult<&str, Vec<(&str, HashMap<&str, &str>)>> {
   many0(category_and_keys)(i)
 }
 
-fn categories(input: &str) -> IResult<&str, HashMap<&str, HashMap<&str, &str>>> {
+fn categories(input: &str) -> ParseResult<&str, HashMap<&str, HashMap<&str, &str>>> {
   match categories_aggregator(input) {
     Ok((i, tuple_vec)) => Ok((i, tuple_vec.into_iter().collect())),
     Err(e) => Err(e),

--- a/tests/multiline.rs
+++ b/tests/multiline.rs
@@ -2,10 +2,10 @@ use nom::{
   character::complete::{alphanumeric1 as alphanumeric, line_ending as eol},
   multi::many0,
   sequence::terminated,
-  IResult,
+  ParseResult,
 };
 
-pub fn end_of_line(input: &str) -> IResult<&str, &str> {
+pub fn end_of_line(input: &str) -> ParseResult<&str, &str> {
   if input.is_empty() {
     Ok((input, input))
   } else {
@@ -13,11 +13,11 @@ pub fn end_of_line(input: &str) -> IResult<&str, &str> {
   }
 }
 
-pub fn read_line(input: &str) -> IResult<&str, &str> {
+pub fn read_line(input: &str) -> ParseResult<&str, &str> {
   terminated(alphanumeric, end_of_line)(input)
 }
 
-pub fn read_lines(input: &str) -> IResult<&str, Vec<&str>> {
+pub fn read_lines(input: &str) -> ParseResult<&str, Vec<&str>> {
   many0(read_line)(input)
 }
 

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -7,12 +7,12 @@ use nom::multi::{length_data, many0};
 #[cfg(feature = "alloc")]
 use nom::number::streaming::be_u64;
 use nom::sequence::tuple;
-use nom::{Err, IResult, Needed};
+use nom::{Needed, Outcome, ParseResult};
 
 // Parser definition
 
 // We request a length that would trigger an overflow if computing consumed + requested
-fn parser02(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
+fn parser02(i: &[u8]) -> ParseResult<&[u8], (&[u8], &[u8])> {
   tuple((take(1_usize), take(18446744073709551615_usize)))(i)
 }
 
@@ -20,35 +20,35 @@ fn parser02(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
 fn overflow_incomplete_tuple() {
   assert_eq!(
     parser02(&b"3"[..]),
-    Err(Err::Incomplete(Needed::new(18446744073709551615)))
+    Err(Outcome::Incomplete(Needed::new(18446744073709551615)))
   );
 }
 
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_length_bytes() {
-  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi(i: &[u8]) -> ParseResult<&[u8], Vec<&[u8]>> {
     many0(length_data(be_u64))(i)
   }
 
   // Trigger an overflow in length_data
   assert_eq!(
     multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff"[..]),
-    Err(Err::Incomplete(Needed::new(18446744073709551615)))
+    Err(Outcome::Incomplete(Needed::new(18446744073709551615)))
   );
 }
 
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_many0() {
-  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi(i: &[u8]) -> ParseResult<&[u8], Vec<&[u8]>> {
     many0(length_data(be_u64))(i)
   }
 
   // Trigger an overflow in many0
   assert_eq!(
     multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]),
-    Err(Err::Incomplete(Needed::new(18446744073709551599)))
+    Err(Outcome::Incomplete(Needed::new(18446744073709551599)))
   );
 }
 
@@ -57,14 +57,14 @@ fn overflow_incomplete_many0() {
 fn overflow_incomplete_many1() {
   use nom::multi::many1;
 
-  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi(i: &[u8]) -> ParseResult<&[u8], Vec<&[u8]>> {
     many1(length_data(be_u64))(i)
   }
 
   // Trigger an overflow in many1
   assert_eq!(
     multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]),
-    Err(Err::Incomplete(Needed::new(18446744073709551599)))
+    Err(Outcome::Incomplete(Needed::new(18446744073709551599)))
   );
 }
 
@@ -73,14 +73,14 @@ fn overflow_incomplete_many1() {
 fn overflow_incomplete_many_till() {
   use nom::{bytes::complete::tag, multi::many_till};
 
-  fn multi(i: &[u8]) -> IResult<&[u8], (Vec<&[u8]>, &[u8])> {
+  fn multi(i: &[u8]) -> ParseResult<&[u8], (Vec<&[u8]>, &[u8])> {
     many_till(length_data(be_u64), tag("abc"))(i)
   }
 
   // Trigger an overflow in many_till
   assert_eq!(
     multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]),
-    Err(Err::Incomplete(Needed::new(18446744073709551599)))
+    Err(Outcome::Incomplete(Needed::new(18446744073709551599)))
   );
 }
 
@@ -89,14 +89,14 @@ fn overflow_incomplete_many_till() {
 fn overflow_incomplete_many_m_n() {
   use nom::multi::many_m_n;
 
-  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi(i: &[u8]) -> ParseResult<&[u8], Vec<&[u8]>> {
     many_m_n(2, 4, length_data(be_u64))(i)
   }
 
   // Trigger an overflow in many_m_n
   assert_eq!(
     multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]),
-    Err(Err::Incomplete(Needed::new(18446744073709551599)))
+    Err(Outcome::Incomplete(Needed::new(18446744073709551599)))
   );
 }
 
@@ -105,13 +105,13 @@ fn overflow_incomplete_many_m_n() {
 fn overflow_incomplete_count() {
   use nom::multi::count;
 
-  fn counter(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn counter(i: &[u8]) -> ParseResult<&[u8], Vec<&[u8]>> {
     count(length_data(be_u64), 2)(i)
   }
 
   assert_eq!(
     counter(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]),
-    Err(Err::Incomplete(Needed::new(18446744073709551599)))
+    Err(Outcome::Incomplete(Needed::new(18446744073709551599)))
   );
 }
 
@@ -121,25 +121,25 @@ fn overflow_incomplete_length_count() {
   use nom::multi::length_count;
   use nom::number::streaming::be_u8;
 
-  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi(i: &[u8]) -> ParseResult<&[u8], Vec<&[u8]>> {
     length_count(be_u8, length_data(be_u64))(i)
   }
 
   assert_eq!(
     multi(&b"\x04\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xee"[..]),
-    Err(Err::Incomplete(Needed::new(18446744073709551598)))
+    Err(Outcome::Incomplete(Needed::new(18446744073709551598)))
   );
 }
 
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_length_data() {
-  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi(i: &[u8]) -> ParseResult<&[u8], Vec<&[u8]>> {
     many0(length_data(be_u64))(i)
   }
 
   assert_eq!(
     multi(&b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff"[..]),
-    Err(Err::Incomplete(Needed::new(18446744073709551615)))
+    Err(Outcome::Incomplete(Needed::new(18446744073709551615)))
   );
 }

--- a/tests/reborrow_fold.rs
+++ b/tests/reborrow_fold.rs
@@ -8,9 +8,9 @@ use nom::character::complete::char;
 use nom::combinator::{map, map_res};
 use nom::multi::fold_many0;
 use nom::sequence::delimited;
-use nom::IResult;
+use nom::ParseResult;
 
-fn atom<'a>(_tomb: &'a mut ()) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], String> {
+fn atom<'a>(_tomb: &'a mut ()) -> impl FnMut(&'a [u8]) -> ParseResult<&'a [u8], String> {
   move |input| {
     map(
       map_res(is_not(" \t\r\n"), str::from_utf8),
@@ -20,7 +20,7 @@ fn atom<'a>(_tomb: &'a mut ()) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], Stri
 }
 
 // FIXME: should we support the use case of borrowing data mutably in a parser?
-fn list<'a>(i: &'a [u8], tomb: &'a mut ()) -> IResult<&'a [u8], String> {
+fn list<'a>(i: &'a [u8], tomb: &'a mut ()) -> ParseResult<&'a [u8], String> {
   delimited(
     char('('),
     fold_many0(atom(tomb), String::new, |acc: String, next: String| {


### PR DESCRIPTION
This is a "let's see what if" PR that rename thing, Quick&dirty, completely incomplete and full of error:

- [x] `Err` => `Outcome`
- [x] `Err::Error` => `Failure`
- [x] `Err::Failure` => `Invalid`
- [ ] `Needed` => `Hint` https://github.com/Geal/nom/issues/1365#issuecomment-903171045
- [x] `IResult` => `ParseResult`
- [x] `ErrorKind` => `ParserKind`
- [x] `VerboseErrorKind` => `VerboseParserKind`
- [x] `Error` => `Context`
- [x] `VerboseError` => `VerboseContext`
- [x] `ParseError` => `ParseContext` (meh)
- [ ] Add `PResult` shortcut
- [ ] Rewrite error guide
- [ ] make a script to reproduce this (or mostly)
- [ ] rename `error` module to `context` or `outcome`

Partial Fix of https://github.com/Geal/nom/issues/1356
