### PR TITLE
Line ending fix

### DIFF
--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -41,7 +41,7 @@ where
 
     let res: IResult<_, _, Error> = match i.compare(t) {
       CompareResult::Ok => Ok(i.take_split(tag_len)),
-      CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(tag_len - i.input_len()))),
+      CompareResult::Incomplete(n) => Err(Err::Incomplete(n)),
       CompareResult::Error => {
         let e: ErrorKind = ErrorKind::Tag;
         Err(Err::Error(Error::from_error_kind(i, e)))
@@ -83,7 +83,7 @@ where
 
     let res: IResult<_, _, Error> = match (i).compare_no_case(t) {
       CompareResult::Ok => Ok(i.take_split(tag_len)),
-      CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(tag_len - i.input_len()))),
+      CompareResult::Incomplete(n) => Err(Err::Incomplete(n)),
       CompareResult::Error => {
         let e: ErrorKind = ErrorKind::Tag;
         Err(Err::Error(Error::from_error_kind(i, e)))

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -147,7 +147,7 @@ where
   match input.compare("\r\n") {
     //FIXME: is this the right index?
     CompareResult::Ok => Ok((input.slice(2..), input.slice(0..2))),
-    CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(2))),
+    CompareResult::Incomplete(n) => Err(Err::Incomplete(n)),
     CompareResult::Error => {
       let e: ErrorKind = ErrorKind::CrLf;
       Err(Err::Error(E::from_error_kind(input, e)))
@@ -190,7 +190,7 @@ where
         let comp = sliced.compare("\r\n");
         match comp {
           //FIXME: calculate the right index
-          CompareResult::Incomplete => Err(Err::Incomplete(Needed::Unknown)),
+          CompareResult::Incomplete(n) => Err(Err::Incomplete(n)),
           CompareResult::Error => {
             let e: ErrorKind = ErrorKind::Tag;
             Err(Err::Error(E::from_error_kind(input, e)))
@@ -1073,14 +1073,14 @@ mod tests {
   #[test]
   fn cr_lf() {
     assert_parse!(crlf(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
-    assert_parse!(crlf(&b"\r"[..]), Err(Err::Incomplete(Needed::new(2))));
+    assert_parse!(crlf(&b"\r"[..]), Err(Err::Incomplete(Needed::new(1))));
     assert_parse!(
       crlf(&b"\ra"[..]),
       Err(Err::Error(error_position!(&b"\ra"[..], ErrorKind::CrLf)))
     );
 
     assert_parse!(crlf("\r\na"), Ok(("a", "\r\n")));
-    assert_parse!(crlf("\r"), Err(Err::Incomplete(Needed::new(2))));
+    assert_parse!(crlf("\r"), Err(Err::Incomplete(Needed::new(1))));
     assert_parse!(
       crlf("\ra"),
       Err(Err::Error(error_position!("\ra", ErrorKind::CrLf)))

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -8,6 +8,7 @@ use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::internal::{Err, IResult, Needed};
 use crate::lib::std::ops::{Range, RangeFrom, RangeTo};
+use crate::sequence::pair;
 use crate::traits::{
   AsChar, FindToken, InputIter, InputLength, InputTake, InputTakeAtPosition, Slice,
 };
@@ -211,28 +212,17 @@ where
 /// ```
 /// # use nom::{Err, error::ErrorKind, IResult, Needed};
 /// # use nom::character::streaming::line_ending;
-/// assert_eq!(line_ending::<_, (_, ErrorKind)>("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(line_ending::<_, (_, ErrorKind)>("ab\r\nc"), Err(Err::Error(("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(line_ending::<_, (_, ErrorKind)>("\r\nc"), Ok(("c", (Some('\r'), '\n'))));
+/// assert_eq!(line_ending::<_, (_, ErrorKind)>("ab\r\nc"), Err(Err::Error(("ab\r\nc", ErrorKind::Char))));
 /// assert_eq!(line_ending::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
-pub fn line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
+pub fn line_ending<I, E>(input: I) -> IResult<I, (Option<char>, char), E>
 where
-  T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
-  T: InputIter + InputLength,
-  T: Compare<&'static str>,
+  I: InputIter + Slice<RangeFrom<usize>> + Clone + InputLength,
+  <I as InputIter>::Item: AsChar,
+  E: ParseError<I>,
 {
-  match input.compare("\n") {
-    CompareResult::Ok => Ok((input.slice(1..), input.slice(0..1))),
-    CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(1))),
-    CompareResult::Error => {
-      match input.compare("\r\n") {
-        //FIXME: is this the right index?
-        CompareResult::Ok => Ok((input.slice(2..), input.slice(0..2))),
-        CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(2))),
-        CompareResult::Error => Err(Err::Error(E::from_error_kind(input, ErrorKind::CrLf))),
-      }
-    }
-  }
+  pair(opt(char('\r')), char('\n'))(input)
 }
 
 /// Matches a newline character '\\n'.
@@ -1048,36 +1038,36 @@ mod tests {
 
   #[test]
   fn full_line_windows() {
-    fn take_full_line(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
+    fn take_full_line(i: &[u8]) -> IResult<&[u8], (&[u8], (Option<char>, char))> {
       pair(not_line_ending, line_ending)(i)
     }
     let input = b"abc\r\n";
     let output = take_full_line(input);
-    assert_eq!(output, Ok((&b""[..], (&b"abc"[..], &b"\r\n"[..]))));
+    assert_eq!(output, Ok((&b""[..], (&b"abc"[..], (Some('\r'), '\n')))));
   }
 
   #[test]
   fn full_line_unix() {
-    fn take_full_line(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
+    fn take_full_line(i: &[u8]) -> IResult<&[u8], (&[u8], (Option<char>, char))> {
       pair(not_line_ending, line_ending)(i)
     }
     let input = b"abc\n";
     let output = take_full_line(input);
-    assert_eq!(output, Ok((&b""[..], (&b"abc"[..], &b"\n"[..]))));
+    assert_eq!(output, Ok((&b""[..], (&b"abc"[..], (None, '\n')))));
   }
 
   #[test]
   fn check_windows_lineending() {
     let input = b"\r\n";
     let output = line_ending(&input[..]);
-    assert_parse!(output, Ok((&b""[..], &b"\r\n"[..])));
+    assert_parse!(output, Ok((&b""[..], (Some('\r'), '\n'))));
   }
 
   #[test]
   fn check_unix_lineending() {
     let input = b"\n";
     let output = line_ending(&input[..]);
-    assert_parse!(output, Ok((&b""[..], &b"\n"[..])));
+    assert_parse!(output, Ok((&b""[..], (None, '\n'))));
   }
 
   #[test]
@@ -1099,23 +1089,26 @@ mod tests {
 
   #[test]
   fn end_of_line() {
-    assert_parse!(line_ending(&b"\na"[..]), Ok((&b"a"[..], &b"\n"[..])));
-    assert_parse!(line_ending(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
+    assert_parse!(line_ending(&b"\na"[..]), Ok((&b"a"[..], (None, '\n'))));
+    assert_parse!(
+      line_ending(&b"\r\na"[..]),
+      Ok((&b"a"[..], (Some('\r'), '\n')))
+    );
     assert_parse!(
       line_ending(&b"\r"[..]),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(Err::Incomplete(Needed::new(1)))
     );
     assert_parse!(
       line_ending(&b"\ra"[..]),
-      Err(Err::Error(error_position!(&b"\ra"[..], ErrorKind::CrLf)))
+      Err(Err::Error(error_position!(&b"a"[..], ErrorKind::Char)))
     );
 
-    assert_parse!(line_ending("\na"), Ok(("a", "\n")));
-    assert_parse!(line_ending("\r\na"), Ok(("a", "\r\n")));
-    assert_parse!(line_ending("\r"), Err(Err::Incomplete(Needed::new(2))));
+    assert_parse!(line_ending("\na"), Ok(("a", (None, '\n'))));
+    assert_parse!(line_ending("\r\na"), Ok(("a", (Some('\r'), '\n'))));
+    assert_parse!(line_ending("\r"), Err(Err::Incomplete(Needed::new(1))));
     assert_parse!(
       line_ending("\ra"),
-      Err(Err::Error(error_position!("\ra", ErrorKind::CrLf)))
+      Err(Err::Error(error_position!("a", ErrorKind::Char)))
     );
   }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -708,7 +708,7 @@ pub enum CompareResult {
   /// Comparison was successful
   Ok,
   /// We need more data to be sure
-  Incomplete,
+  Incomplete(Needed),
   /// Comparison failed
   Error,
 }
@@ -745,7 +745,7 @@ impl<'a, 'b> Compare<&'b [u8]> for &'a [u8] {
         if self.len() >= t.len() {
           CompareResult::Ok
         } else {
-          CompareResult::Incomplete
+          CompareResult::Incomplete(Needed::new(t.len() - self.len()))
         }
       }
     }
@@ -776,7 +776,7 @@ impl<'a, 'b> Compare<&'b [u8]> for &'a [u8] {
     {
       CompareResult::Error
     } else if self.len() < t.len() {
-      CompareResult::Incomplete
+      CompareResult::Incomplete(Needed::new(t.len() - self.len()))
     } else {
       CompareResult::Ok
     }
@@ -801,7 +801,7 @@ impl<
         if self.input_len() >= t.input_len() {
           CompareResult::Ok
         } else {
-          CompareResult::Incomplete
+          CompareResult::Incomplete(Needed::new(t.input_len() - self.input_len()))
         }
       }
     }
@@ -816,7 +816,7 @@ impl<
     {
       CompareResult::Error
     } else if self.input_len() < t.input_len() {
-      CompareResult::Incomplete
+      CompareResult::Incomplete(Needed::new(t.input_len() - self.input_len()))
     } else {
       CompareResult::Ok
     }
@@ -854,7 +854,7 @@ impl<'a, 'b> Compare<&'b str> for &'a str {
         if self.len() >= t.len() {
           CompareResult::Ok
         } else {
-          CompareResult::Incomplete
+          CompareResult::Incomplete(Needed::new(t.len() - self.len()))
         }
       }
     }

--- a/tests/multiline.rs
+++ b/tests/multiline.rs
@@ -1,5 +1,6 @@
 use nom::{
   character::complete::{alphanumeric1 as alphanumeric, line_ending as eol},
+  combinator::recognize,
   multi::many0,
   sequence::terminated,
   IResult,
@@ -9,7 +10,7 @@ pub fn end_of_line(input: &str) -> IResult<&str, &str> {
   if input.is_empty() {
     Ok((input, input))
   } else {
-    eol(input)
+    recognize(eol)(input)
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/Geal/nom/issues/1365

- [x] `line_ending()` now return `(Option<char>, char)` more precise
- [x] `CompareResult::Incomplete` now return `Needed`
- [x] crlf and line_ending now return the expected `Needed`
- [x] side effect `not_line_ending()` now return `Needed` sometime
- [ ] consider using a `LineEnding` enum instead of `(Option<char>, char)` like:
  ```rust
  enum LineEnding {
    Lf,
    CrLf,
  }
  ```
- [ ] Since `CompareResult::Incomplete` is fix for `Needed` maybe not change the return of `line_ending()`