### PR TITLE
CI: Update tarpaulin and use Coveralls' action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,12 +185,15 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: cargo-tarpaulin --version 0.18.0-alpha3 # @TODO restore to normal (https://github.com/xd009642/tarpaulin/issues/756#issuecomment-838769320)
+          args: cargo-tarpaulin
 
       - name: Run cargo tarpaulin
         uses: actions-rs/cargo@v1
-        env:
-          TOKEN: ${{ secrets.COVERALLS_TOKEN }}
         with:
           command: tarpaulin
-          args: --coveralls "$TOKEN" --avoid-cfg-tarpaulin # @TODO restore to normal (https://github.com/xd009642/tarpaulin/issues/756#issuecomment-838769320)
+          args: --output-dir coverage --out Lcov
+      
+      - name: Publish to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It seems that coveralls did not receive any report from 3rd may 2021 (https://coveralls.io/github/Geal/nom). This lead to a wrong coverage in README.md.

This should fix the reporting.

I chose to use the dedicated Coveralls' action instead of tarpaulin's arguments for the report as it is an official action and could avoid some breaking changes.

References:
- https://github.com/xd009642/tarpaulin
- https://github.com/marketplace/actions/coveralls-github-action