### PR TITLE
 Implement fold and try_fold using NomBounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ realworld/
 src/generator.rs
 .DS_Store
 private-docs/
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,11 @@ default-features = false
 
 [dev-dependencies]
 criterion = "0.3"
-jemallocator = "^0.3"
 doc-comment = "0.3"
 proptest = "1.0.0"
+
+[target.'cfg(not(all(target_os = "windows", target_env = "msvc")))'.dev-dependencies]
+jemallocator = "^0.3"
 
 [build-dependencies]
 version_check = "0.9"

--- a/benches/arithmetic.rs
+++ b/benches/arithmetic.rs
@@ -9,7 +9,7 @@ use nom::{
   branch::alt,
   character::complete::{char, digit1, one_of, space0},
   combinator::map_res,
-  multi::fold_many0,
+  multi::fold,
   sequence::{delimited, pair},
   IResult,
 };
@@ -37,7 +37,8 @@ fn factor(input: &[u8]) -> IResult<&[u8], i64> {
 // the math by folding everything
 fn term(input: &[u8]) -> IResult<&[u8], i64> {
   let (input, init) = factor(input)?;
-  fold_many0(
+  fold(
+    ..,
     pair(one_of("*/"), factor),
     move || init,
     |acc, (op, val)| {
@@ -52,7 +53,8 @@ fn term(input: &[u8]) -> IResult<&[u8], i64> {
 
 fn expr(input: &[u8]) -> IResult<&[u8], i64> {
   let (input, init) = term(input)?;
-  fold_many0(
+  fold(
+    ..,
     pair(one_of("+-"), term),
     move || init,
     |acc, (op, val)| {

--- a/benches/http.rs
+++ b/benches/http.rs
@@ -4,7 +4,7 @@
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use criterion::*;
-use nom::{IResult, bytes::complete::{tag, take_while1}, character::complete::{line_ending, char}, multi::many1};
+use nom::{IResult, bytes::complete::{tag, take_while1}, character::complete::{line_ending, char}, multi::many};
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 #[derive(Debug)]
@@ -96,14 +96,14 @@ fn message_header_value(input: &[u8]) -> IResult<&[u8], &[u8]> {
 fn message_header(input: &[u8]) -> IResult<&[u8], Header<'_>> {
   let (input, name) = take_while1(is_token)(input)?;
   let (input, _) = char(':')(input)?;
-  let (input, value) = many1(message_header_value)(input)?;
+  let (input, value) = many(1.., message_header_value)(input)?;
 
   Ok((input, Header{ name, value }))
 }
 
 fn request(input: &[u8]) -> IResult<&[u8], (Request<'_>, Vec<Header<'_>>)> {
   let (input, req) = request_line(input)?;
-  let (input, h) = many1(message_header)(input)?;
+  let (input, h) = many(1.., message_header)(input)?;
   let (input, _) = line_ending(input)?;
 
   Ok((input, (req, h)))

--- a/benches/ini.rs
+++ b/benches/ini.rs
@@ -9,7 +9,7 @@ use nom::{
     alphanumeric1 as alphanumeric, char, multispace1 as multispace, space1 as space,
   },
   combinator::{map, map_res, opt},
-  multi::many0,
+  multi::many,
   sequence::{delimited, pair, separated_pair, terminated, tuple},
   IResult,
 };
@@ -33,14 +33,17 @@ fn key_value(i: &[u8]) -> IResult<&[u8], (&str, &str)> {
 
 fn categories(i: &[u8]) -> IResult<&[u8], HashMap<&str, HashMap<&str, &str>>> {
   map(
-    many0(separated_pair(
-      category,
-      opt(multispace),
-      map(
-        many0(terminated(key_value, opt(multispace))),
-        |vec: Vec<_>| vec.into_iter().collect(),
+    many(
+      ..,
+      separated_pair(
+        category,
+        opt(multispace),
+        map(
+          many(.., terminated(key_value, opt(multispace))),
+          |vec: Vec<_>| vec.into_iter().collect(),
+        ),
       ),
-    )),
+    ),
     |vec: Vec<_>| vec.into_iter().collect(),
   )(i)
 }
@@ -70,7 +73,7 @@ file=payroll.dat
 \0";
 
   fn acc(i: &[u8]) -> IResult<&[u8], Vec<(&str, &str)>> {
-    many0(key_value)(i)
+    many(.., key_value)(i)
   }
 
   let mut group = c.benchmark_group("ini keys and values");

--- a/benches/ini_str.rs
+++ b/benches/ini_str.rs
@@ -7,7 +7,7 @@ use nom::{
   bytes::complete::{is_a, tag, take_till, take_while},
   character::complete::{alphanumeric1 as alphanumeric, char, not_line_ending, space0 as space},
   combinator::opt,
-  multi::many,
+  multi::fold,
   sequence::{delimited, pair, terminated, tuple},
   IResult,
 };
@@ -40,7 +40,10 @@ fn key_value(i: &str) -> IResult<&str, (&str, &str)> {
 }
 
 fn keys_and_values_aggregator(i: &str) -> IResult<&str, Vec<(&str, &str)>> {
-  many(.., key_value)(i)
+  fold(.., key_value, Vec::new, |mut acc, i| {
+    acc.push(i);
+    acc
+  })(i)
 }
 
 fn keys_and_values(input: &str) -> IResult<&str, HashMap<&str, &str>> {
@@ -55,7 +58,10 @@ fn category_and_keys(i: &str) -> IResult<&str, (&str, HashMap<&str, &str>)> {
 }
 
 fn categories_aggregator(i: &str) -> IResult<&str, Vec<(&str, HashMap<&str, &str>)>> {
-  many(.., category_and_keys)(i)
+  fold(.., category_and_keys, Vec::new, |mut acc, i| {
+    acc.push(i);
+    acc
+  })(i)
 }
 
 fn categories(input: &str) -> IResult<&str, HashMap<&str, HashMap<&str, &str>>> {

--- a/benches/ini_str.rs
+++ b/benches/ini_str.rs
@@ -7,7 +7,7 @@ use nom::{
   bytes::complete::{is_a, tag, take_till, take_while},
   character::complete::{alphanumeric1 as alphanumeric, char, not_line_ending, space0 as space},
   combinator::opt,
-  multi::many0,
+  multi::many,
   sequence::{delimited, pair, terminated, tuple},
   IResult,
 };
@@ -40,7 +40,7 @@ fn key_value(i: &str) -> IResult<&str, (&str, &str)> {
 }
 
 fn keys_and_values_aggregator(i: &str) -> IResult<&str, Vec<(&str, &str)>> {
-  many0(key_value)(i)
+  many(.., key_value)(i)
 }
 
 fn keys_and_values(input: &str) -> IResult<&str, HashMap<&str, &str>> {
@@ -55,7 +55,7 @@ fn category_and_keys(i: &str) -> IResult<&str, (&str, HashMap<&str, &str>)> {
 }
 
 fn categories_aggregator(i: &str) -> IResult<&str, Vec<(&str, HashMap<&str, &str>)>> {
-  many0(category_and_keys)(i)
+  many(.., category_and_keys)(i)
 }
 
 fn categories(input: &str) -> IResult<&str, HashMap<&str, HashMap<&str, &str>>> {

--- a/benches/json.rs
+++ b/benches/json.rs
@@ -11,7 +11,7 @@ use nom::{
   character::complete::{anychar, char, multispace0, none_of},
   combinator::{map, map_opt, map_res, value, verify},
   error::{ErrorKind, ParseError},
-  multi::{fold_many0, separated_list0},
+  multi::{fold, separated_list0},
   number::complete::{double, recognize_float},
   sequence::{delimited, preceded, separated_pair},
   IResult, Parser,
@@ -87,7 +87,7 @@ fn character(input: &str) -> IResult<&str, char> {
 fn string(input: &str) -> IResult<&str, String> {
   delimited(
     char('"'),
-    fold_many0(character, String::new, |mut string, c| {
+    fold(.., character, String::new, |mut string, c| {
       string.push(c);
       string
     }),

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,8 +1,5 @@
 #![cfg(feature = "alloc")]
 
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 use nom::{
   branch::alt,
   bytes::complete::{escaped, tag, take_while},

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -1,11 +1,5 @@
 #![cfg(feature = "alloc")]
 
-
-use jemallocator;
-
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 use nom::{
   branch::alt,
   bytes::complete::{escaped, tag, take_while},

--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -4,9 +4,6 @@
 
 #![cfg(feature = "alloc")]
 
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 use nom::{
   branch::alt,
   bytes::complete::tag,

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -11,9 +11,6 @@
 
 #![cfg(feature = "alloc")]
 
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 use nom::branch::alt;
 use nom::bytes::streaming::{is_not, take_while_m_n};
 use nom::character::streaming::{char, multispace1};

--- a/src/error.rs
+++ b/src/error.rs
@@ -417,6 +417,8 @@ pub enum ErrorKind {
   Float,
   Satisfy,
   Fail,
+  Fold,
+  TryFold,
 }
 
 #[rustfmt::skip]
@@ -477,6 +479,8 @@ pub fn error_to_u32(e: &ErrorKind) -> u32 {
     ErrorKind::Float                     => 73,
     ErrorKind::Satisfy                   => 74,
     ErrorKind::Fail                      => 75,
+    ErrorKind::Fold                      => 77,
+    ErrorKind::TryFold                   => 78,
   }
 }
 
@@ -539,6 +543,8 @@ impl ErrorKind {
       ErrorKind::Float                     => "Float",
       ErrorKind::Satisfy                   => "Satisfy",
       ErrorKind::Fail                      => "Fail",
+      ErrorKind::Fold                      => "Fold",
+      ErrorKind::TryFold                   => "TryFold",
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,6 +376,7 @@
 #![cfg_attr(nightly, feature(test))]
 #![cfg_attr(feature = "docsrs", feature(doc_cfg))]
 #![cfg_attr(feature = "docsrs", feature(extended_key_value_attributes))]
+#![cfg_attr(feature = "nightly", feature(try_trait_v2))]
 #![deny(missing_docs)]
 #[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
 #[cfg(feature = "alloc")]
@@ -445,16 +446,16 @@ pub use self::str::*;
 #[macro_use]
 pub mod error;
 
+pub mod combinator;
 mod internal;
 mod traits;
-pub mod combinator;
 #[macro_use]
 pub mod branch;
-pub mod sequence;
 pub mod multi;
+pub mod sequence;
 
-pub mod bytes;
 pub mod bits;
+pub mod bytes;
 
 pub mod character;
 

--- a/src/multi/fold.rs
+++ b/src/multi/fold.rs
@@ -1,0 +1,278 @@
+use crate::error::ErrorKind;
+use crate::error::ParseError;
+use crate::internal::{Err, IResult, Parser};
+use crate::traits::InputLength;
+use crate::Break;
+use crate::IntoNomBounds;
+use crate::NomBounds;
+
+use core::ops::ControlFlow;
+
+/// Applies a parser and accumulates the results using a given
+/// function and initial value.
+/// Fails if the amount of time the embedded parser is run is not
+/// within the specified range.
+///
+/// # Arguments
+/// * `range` Constrains the number of iterations.
+///   * A range without an upper bound `a..` allows the parser to run until it fails.
+///   * A single `usize` value is equivalent to `value..=value`.
+///   * An empty range is invalid.
+/// * `parse` The parser to apply.
+/// * `init` A function returning the initial value.
+/// * `fold` The function that combines a result of `f` with
+///       the current accumulator.
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// use nom::multi::fold;
+/// use nom::bytes::complete::tag;
+///
+/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+///   fold(
+///     ..2,
+///     tag("abc"),
+///     Vec::new,
+///     |mut acc: Vec<_>, item| {
+///       acc.push(item);
+///       acc
+///     }
+///   )(s)
+/// }
+///
+/// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
+/// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
+/// assert_eq!(parser("123123"), Ok(("123123", vec![])));
+/// assert_eq!(parser(""), Ok(("", vec![])));
+/// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
+/// ```
+pub fn fold<Bounds, IntoBounds, Input, Output, Error, P, Acc, Init, F>(
+  bounds: IntoBounds,
+  mut parser: P,
+  mut init: Init,
+  mut fold: F,
+) -> impl FnMut(Input) -> IResult<Input, Acc, Error>
+where
+  Bounds: NomBounds,
+  for<'a> &'a IntoBounds: IntoNomBounds<NomBounds = Bounds>,
+  Input: Clone + InputLength,
+  Error: ParseError<Input>,
+  P: Parser<Input, Output, Error>,
+  Init: FnMut() -> Acc,
+  F: FnMut(Acc, Output) -> Acc,
+{
+  move |mut input: Input| {
+    let mut bounds = bounds.into_nom_bounds();
+
+    if bounds.is_broken() {
+      return Err(Err::Failure(Error::from_error_kind(input, ErrorKind::Fold)));
+    }
+
+    let mut acc = init();
+
+    loop {
+      match bounds.next() {
+        ControlFlow::Continue(c) => match parser.parse(input.clone()) {
+          Ok((tail, value)) => {
+            if tail.input_len() == input.input_len() {
+              break Err(Err::Error(Error::from_error_kind(tail, ErrorKind::Fold)));
+            }
+
+            acc = fold(acc, value);
+            input = tail;
+          }
+          Err(Err::Error(e)) => {
+            break if bounds.is_min_reach(c) {
+              Ok((input, acc))
+            } else {
+              Err(Err::Error(e))
+            }
+          }
+          Err(e) => break Err(e),
+        },
+        ControlFlow::Break(Break::Infinite) => {
+          break loop {
+            match parser.parse(input.clone()) {
+              Ok((tail, value)) => {
+                if tail.input_len() == input.input_len() {
+                  break Err(Err::Error(Error::from_error_kind(tail, ErrorKind::Fold)));
+                }
+
+                acc = fold(acc, value);
+                input = tail;
+              }
+              Err(Err::Error(_)) => break Ok((input, acc)),
+              Err(e) => break Err(e),
+            }
+          };
+        }
+        ControlFlow::Break(Break::Finish) => break Ok((input, acc)),
+      }
+    }
+  }
+}
+
+#[test]
+#[cfg(feature = "alloc")]
+fn fold_test() {
+  use crate::{bytes::streaming::tag, lib::std::vec::Vec, Needed};
+  fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
+    acc.push(item);
+    acc
+  }
+
+  // should not go into an infinite loop
+  fn fold_error_0(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fn tst(input: &[u8]) -> IResult<&[u8], &[u8]> {
+      Err(Err::Error(error_position!(input, ErrorKind::Tag)))
+    }
+    fold(0.., tst, Vec::new, fold_into_vec)(i)
+  }
+
+  let a = &b"abcdef"[..];
+  assert_eq!(fold_error_0(a), Ok((a, Vec::new())));
+
+  fn fold_error_1(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fn tst(input: &[u8]) -> IResult<&[u8], &[u8]> {
+      Err(Err::Error(error_position!(input, ErrorKind::Tag)))
+    }
+    fold(1.., tst, Vec::new, fold_into_vec)(i)
+  }
+
+  let a = &b"abcdef"[..];
+  assert_eq!(
+    fold_error_1(a),
+    Err(Err::Error(error_position!(a, ErrorKind::Tag)))
+  );
+
+  fn fold_error(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fold(0.., tag(""), Vec::new, fold_into_vec)(i)
+  }
+
+  let a = &b"abcdef"[..];
+  assert_eq!(
+    fold_error(a),
+    Err(Err::Error(error_position!(a, ErrorKind::Fold)))
+  );
+
+  fn fold_invalid(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fold(3..=1, tag("a"), Vec::new, fold_into_vec)(i)
+  }
+
+  let a = &b"a"[..];
+  let b = &b"b"[..];
+  assert_eq!(
+    fold_invalid(a),
+    Err(Err::Failure(error_position!(a, ErrorKind::Fold)))
+  );
+  assert_eq!(
+    fold_invalid(b),
+    Err(Err::Failure(error_position!(b, ErrorKind::Fold)))
+  );
+
+  fn fold_any(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fold(0.., tag("abcd"), Vec::new, fold_into_vec)(i)
+  }
+
+  let a = &b"abcdef"[..];
+  let b = &b"abcdabcdefgh"[..];
+  let c = &b"azerty"[..];
+  let d = &b"abcdab"[..];
+  let e = &b"abcd"[..];
+  let f = &b""[..];
+  assert_eq!(fold_any(a), Ok((&b"ef"[..], vec![&b"abcd"[..]])));
+  assert_eq!(
+    fold_any(b),
+    Ok((&b"efgh"[..], vec![&b"abcd"[..], &b"abcd"[..]]))
+  );
+  assert_eq!(fold_any(c), Ok((c, Vec::new())));
+  assert_eq!(fold_any(d), Err(Err::Incomplete(Needed::new(2))));
+  assert_eq!(fold_any(e), Err(Err::Incomplete(Needed::new(4))));
+  assert_eq!(fold_any(f), Err(Err::Incomplete(Needed::new(4))));
+
+  fn fold_1(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fold(1.., tag("abcd"), Vec::new, fold_into_vec)(i)
+  }
+
+  let a = &b"abcdef"[..];
+  let b = &b"abcdabcdefgh"[..];
+  let c = &b"azerty"[..];
+  let d = &b"abcdab"[..];
+  let res1 = vec![&b"abcd"[..]];
+  assert_eq!(fold_1(a), Ok((&b"ef"[..], res1)));
+  let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
+  assert_eq!(fold_1(b), Ok((&b"efgh"[..], res2)));
+  assert_eq!(
+    fold_1(c),
+    Err(Err::Error(error_position!(c, ErrorKind::Tag)))
+  );
+  assert_eq!(fold_1(d), Err(Err::Incomplete(Needed::new(2))));
+
+  fn fold_m_n(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fold(2..=3, tag("Abcd"), Vec::new, fold_into_vec)(i)
+  }
+
+  let a = &b"Abcdef"[..];
+  let b = &b"AbcdAbcdefgh"[..];
+  let c = &b"AbcdAbcdAbcdAbcdefgh"[..];
+  let d = &b"AbcdAbcdAbcdAbcdAbcdefgh"[..];
+  let e = &b"AbcdAb"[..];
+  assert_eq!(
+    fold_m_n(a),
+    Err(Err::Error(error_position!(&b"ef"[..], ErrorKind::Tag)))
+  );
+  let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
+  assert_eq!(fold_m_n(b), Ok((&b"efgh"[..], res1)));
+  let res2 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
+  assert_eq!(fold_m_n(c), Ok((&b"efgh"[..], res2)));
+  let res3 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
+  assert_eq!(fold_m_n(d), Ok((&b"Abcdefgh"[..], res3)));
+  assert_eq!(fold_m_n(e), Err(Err::Incomplete(Needed::new(2))));
+
+  fn fold_fixed(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fold(2..2, tag("Abcd"), Vec::new, fold_into_vec)(i)
+  }
+
+  let a = &b"Abcdef"[..];
+  let b = &b"AbcdAbcdefgh"[..];
+  let c = &b"AbcdAbcdAbcdAbcdefgh"[..];
+  let d = &b"AbcdAb"[..];
+  assert_eq!(
+    fold_fixed(a),
+    Err(Err::Error(error_position!(&b"ef"[..], ErrorKind::Tag)))
+  );
+  let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
+  assert_eq!(fold_fixed(b), Ok((&b"efgh"[..], res1)));
+  let res2 = vec![&b"Abcd"[..], &b"Abcd"[..]];
+  assert_eq!(fold_fixed(c), Ok((&b"AbcdAbcdefgh"[..], res2)));
+  assert_eq!(fold_fixed(d), Err(Err::Incomplete(Needed::new(2))));
+
+  fn fold_exclusive(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fold(0..1, tag("Abcd"), Vec::new, fold_into_vec)(i)
+  }
+
+  let a = &b"AbcdAbcdAbcd"[..];
+  let b = &b"AAA"[..];
+  let res1 = vec![&b"Abcd"[..]];
+  assert_eq!(fold_exclusive(a), Ok((&b"AbcdAbcd"[..], res1)));
+  let res2 = vec![];
+  assert_eq!(fold_exclusive(b), Ok((&b"AAA"[..], res2)));
+
+  fn fold_never(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fold(0..=0, tag("A"), Vec::new, fold_into_vec)(i)
+  }
+
+  let a = &b"AAA"[..];
+  let b = &b"B"[..];
+  let res1 = vec![&b"A"[..]];
+  assert_eq!(fold_never(a), Ok((&b"AA"[..], res1)));
+  assert_eq!(fold_never(b), Ok((&b"B"[..], Vec::new())));
+
+  fn fold_usize(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fold(1, tag("A"), Vec::new, fold_into_vec)(i)
+  }
+
+  let a = &b"AAA"[..];
+  let res1 = vec![&b"A"[..], &b"A"[..]];
+  assert_eq!(fold_usize(a), Ok((&b"A"[..], res1)));
+}

--- a/src/multi/try_fold.rs
+++ b/src/multi/try_fold.rs
@@ -1,0 +1,136 @@
+use crate::error::ErrorKind;
+use crate::error::ParseError;
+use crate::internal::{Err, IResult, Parser};
+use crate::traits::{InputLength, NomBounds};
+use crate::Break;
+use crate::IntoNomBounds;
+
+use core::ops::ControlFlow;
+
+/// Applies a parser and accumulates the results using a given
+/// function and initial value.
+/// Fails if the amount of time the embedded parser is run is not
+/// within the specified range.
+///
+/// # Arguments
+/// * `range` Constrains the number of iterations.
+///   * A range without an upper bound `a..` allows the parser to run until it fails.
+///   * A single `usize` value is equivalent to `value..=value`.
+///   * An empty range is invalid.
+/// * `parse` The parser to apply.
+/// * `init` A function returning the initial value.
+/// * `fold` The function that combines a result of `f` with
+///       the current accumulator.
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// use nom::multi::fold;
+/// use nom::bytes::complete::tag;
+///
+/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+///   fold(
+///     ..2,
+///     tag("abc"),
+///     Vec::new,
+///     |mut acc: Vec<_>, item| {
+///       acc.push(item);
+///       acc
+///     }
+///   )(s)
+/// }
+///
+/// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
+/// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
+/// assert_eq!(parser("123123"), Ok(("123123", vec![])));
+/// assert_eq!(parser(""), Ok(("", vec![])));
+/// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
+/// ```
+pub fn try_fold<Bounds, IntoBounds, Input, Output, Error, P, Acc, Init, F>(
+  bounds: IntoBounds,
+  mut parser: P,
+  mut init: Init,
+  mut try_fold: F,
+) -> impl FnMut(Input) -> IResult<Input, Acc, Error>
+where
+  Bounds: NomBounds,
+  for<'a> &'a IntoBounds: IntoNomBounds<NomBounds = Bounds>,
+  Input: Clone + InputLength,
+  Error: ParseError<Input>,
+  P: Parser<Input, Output, Error>,
+  Init: FnMut() -> Acc,
+  F: FnMut(Acc, Output) -> Result<Acc, Err<Error>>,
+{
+  move |mut input: Input| {
+    let mut bounds = bounds.into_nom_bounds();
+    if bounds.is_broken() {
+      return Err(Err::Failure(Error::from_error_kind(
+        input,
+        ErrorKind::TryFold,
+      )));
+    }
+
+    let mut acc = init();
+
+    loop {
+      match bounds.next() {
+        ControlFlow::Continue(c) => match parser.parse(input.clone()) {
+          Ok((tail, value)) => {
+            if tail.input_len() == input.input_len() {
+              break Err(Err::Error(Error::from_error_kind(tail, ErrorKind::TryFold)));
+            }
+
+            acc = try_fold(acc, value)?;
+            input = tail;
+          }
+          Err(Err::Error(e)) => {
+            break if bounds.is_min_reach(c) {
+              Ok((input, acc))
+            } else {
+              Err(Err::Error(e))
+            }
+          }
+          Err(e) => break Err(e),
+        },
+
+        ControlFlow::Break(Break::Infinite) => {
+          break loop {
+            match parser.parse(input.clone()) {
+              Ok((tail, value)) => {
+                if tail.input_len() == input.input_len() {
+                  break Err(Err::Error(Error::from_error_kind(tail, ErrorKind::TryFold)));
+                }
+
+                acc = try_fold(acc, value)?;
+                input = tail;
+              }
+              Err(Err::Error(_)) => break Ok((input, acc)),
+              Err(e) => break Err(e),
+            }
+          };
+        }
+        ControlFlow::Break(Break::Finish) => break Ok((input, acc)),
+      }
+    }
+  }
+}
+
+#[test]
+fn try_fold_test() {
+  use super::try_fold;
+  use crate::{character::complete::anychar, error::Error};
+
+  let input = "it's my life";
+  let result = try_fold(.., anychar, usize::default, |_, _| {
+    Err(Err::Error(Error::from_error_kind(
+      input,
+      ErrorKind::TryFold,
+    )))
+  })(input);
+  assert_eq!(
+    result,
+    Err(Err::Error(Error::from_error_kind(
+      input,
+      ErrorKind::TryFold,
+    )))
+  );
+}

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,4 +1,8 @@
 //! Traits input types have to implement to work with nom combinators
+
+mod nom_bounds;
+pub use nom_bounds::*;
+
 use crate::error::{ErrorKind, ParseError};
 use crate::internal::{Err, IResult, Needed};
 use crate::lib::std::iter::{Copied, Enumerate};

--- a/src/traits/nom_bounds.rs
+++ b/src/traits/nom_bounds.rs
@@ -1,0 +1,354 @@
+use core::ops::{
+  Bound, ControlFlow, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
+};
+
+/// The value when next return to break
+pub enum Break {
+  /// Tell you can loop forever without call next anymore
+  Infinite,
+  /// We reach the upper bound
+  Finish,
+}
+
+/// This allow nom conbinator to be use with Range like `5..10`
+pub trait NomBounds {
+  /// next check if the current iteration is in bounds
+  /// this will mostly check for upper bound
+  /// if no check is needed anymore the return will be Break and Break value will
+  /// tell if it was an Out of Bound error or just that we reach the min bound and
+  /// we don't have any upper bound
+  fn next(&mut self) -> ControlFlow<Break, usize>;
+
+  /// this need to be call at the end to check if the min number of iteration have been reach
+  /// no need to call this when next return a Break::Infinite
+  fn is_min_reach(self, n: usize) -> bool;
+
+  /// todo
+  fn is_broken(&self) -> bool;
+}
+
+/// This trait help type inference of Rust to allow to transparently use Rust range
+pub trait IntoNomBounds {
+  /// todo
+  type NomBounds: NomBounds;
+
+  /// todo
+  fn into_nom_bounds(self) -> Self::NomBounds;
+}
+
+/// todo
+#[derive(Clone, Debug)]
+pub struct NomBoundsRange {
+  range: Range<usize>,
+  i: usize,
+}
+
+impl<'a> IntoNomBounds for &'a Range<usize> {
+  type NomBounds = NomBoundsRange;
+
+  fn into_nom_bounds(self) -> Self::NomBounds {
+    Self::NomBounds {
+      range: self.clone(),
+      i: 0,
+    } // https://github.com/rust-lang/rust/issues/90190
+  }
+}
+
+impl NomBounds for NomBoundsRange {
+  fn next(&mut self) -> ControlFlow<Break, usize> {
+    if self.i < self.range.end {
+      ControlFlow::Continue(replace(self.i + 1, &mut self.i))
+    } else {
+      ControlFlow::Break(Break::Finish)
+    }
+  }
+
+  fn is_min_reach(self, n: usize) -> bool {
+    n >= self.range.start
+  }
+
+  fn is_broken(&self) -> bool {
+    self.range.start > self.range.end
+  }
+}
+
+/// todo
+#[derive(Clone, Debug)]
+pub struct NomBoundsRangeInclusive {
+  range: RangeInclusive<usize>,
+  i: usize,
+  is_exhausted: bool,
+}
+
+impl<'a> IntoNomBounds for &'a RangeInclusive<usize> {
+  type NomBounds = NomBoundsRangeInclusive;
+
+  fn into_nom_bounds(self) -> Self::NomBounds {
+    Self::NomBounds {
+      range: self.clone(), // https://github.com/rust-lang/rust/issues/90190
+      i: 0,
+      is_exhausted: false,
+    }
+  }
+}
+
+impl<'a> IntoNomBounds for &'a usize {
+  type NomBounds = NomBoundsRangeInclusive;
+
+  fn into_nom_bounds(self) -> Self::NomBounds {
+    Self::NomBounds {
+      range: *self..=*self,
+      i: 0,
+      is_exhausted: false,
+    }
+  }
+}
+
+impl NomBounds for NomBoundsRangeInclusive {
+  fn next(&mut self) -> ControlFlow<Break, usize> {
+    if self.i < *self.range.end() {
+      ControlFlow::Continue(replace(self.i + 1, &mut self.i))
+    } else if self.i == *self.range.end() && !self.is_exhausted {
+      self.is_exhausted = true;
+      ControlFlow::Continue(self.i)
+    } else {
+      ControlFlow::Break(Break::Finish)
+    }
+  }
+
+  fn is_min_reach(self, n: usize) -> bool {
+    n >= *self.range.start()
+  }
+
+  fn is_broken(&self) -> bool {
+    self.range.start() > self.range.end()
+      && (*self.range.end() == usize::MAX || *self.range.start() > *self.range.end() + 1)
+  }
+}
+
+/// todo
+#[derive(Clone, Debug)]
+pub struct NomBoundsRangeFrom {
+  range: RangeFrom<usize>,
+  i: usize,
+}
+
+impl<'a> IntoNomBounds for &'a RangeFrom<usize> {
+  type NomBounds = NomBoundsRangeFrom;
+
+  fn into_nom_bounds(self) -> Self::NomBounds {
+    Self::NomBounds {
+      range: self.clone(),
+      i: 0,
+    } // https://github.com/rust-lang/rust/issues/90190
+  }
+}
+
+impl NomBounds for NomBoundsRangeFrom {
+  fn next(&mut self) -> ControlFlow<Break, usize> {
+    if self.i < self.range.start {
+      ControlFlow::Continue(replace(self.i + 1, &mut self.i))
+    } else {
+      ControlFlow::Break(Break::Infinite)
+    }
+  }
+
+  fn is_min_reach(self, n: usize) -> bool {
+    n >= self.range.start
+  }
+
+  fn is_broken(&self) -> bool {
+    false
+  }
+}
+
+/// todo
+#[derive(Clone, Debug)]
+pub struct NomBoundsRangeTo {
+  range: RangeTo<usize>,
+  i: usize,
+}
+
+impl<'a> IntoNomBounds for &'a RangeTo<usize> {
+  type NomBounds = NomBoundsRangeTo;
+
+  fn into_nom_bounds(self) -> Self::NomBounds {
+    Self::NomBounds { range: *self, i: 0 }
+  }
+}
+
+impl NomBounds for NomBoundsRangeTo {
+  fn next(&mut self) -> ControlFlow<Break, usize> {
+    if self.i < self.range.end {
+      ControlFlow::Continue(replace(self.i + 1, &mut self.i))
+    } else {
+      ControlFlow::Break(Break::Finish)
+    }
+  }
+
+  fn is_min_reach(self, _n: usize) -> bool {
+    true
+  }
+
+  fn is_broken(&self) -> bool {
+    false
+  }
+}
+
+/// todo
+#[derive(Clone, Debug)]
+pub struct NomBoundsRangeToInclusive {
+  range: RangeToInclusive<usize>,
+  i: usize,
+  is_exhausted: bool,
+}
+
+impl<'a> IntoNomBounds for &'a RangeToInclusive<usize> {
+  type NomBounds = NomBoundsRangeToInclusive;
+
+  fn into_nom_bounds(self) -> Self::NomBounds {
+    Self::NomBounds {
+      range: *self,
+      i: 0,
+      is_exhausted: false,
+    }
+  }
+}
+
+impl NomBounds for NomBoundsRangeToInclusive {
+  fn next(&mut self) -> ControlFlow<Break, usize> {
+    if self.i < self.range.end {
+      ControlFlow::Continue(replace(self.i + 1, &mut self.i))
+    } else if self.i == self.range.end && !self.is_exhausted {
+      self.is_exhausted = true;
+      ControlFlow::Continue(self.i)
+    } else {
+      ControlFlow::Break(Break::Finish)
+    }
+  }
+
+  fn is_min_reach(self, _n: usize) -> bool {
+    true
+  }
+
+  fn is_broken(&self) -> bool {
+    false
+  }
+}
+
+impl<'a> IntoNomBounds for &'a RangeFull {
+  type NomBounds = RangeFull;
+
+  fn into_nom_bounds(self) -> Self::NomBounds {
+    *self
+  }
+}
+
+impl NomBounds for RangeFull {
+  fn next(&mut self) -> ControlFlow<Break, usize> {
+    ControlFlow::Break(Break::Infinite)
+  }
+
+  fn is_min_reach(self, _n: usize) -> bool {
+    true
+  }
+
+  fn is_broken(&self) -> bool {
+    false
+  }
+}
+
+/// todo
+#[derive(Clone, Debug)]
+pub struct NomBoundsBounds {
+  i: usize,
+  start: Bound<usize>,
+  end: Bound<usize>,
+  is_exhausted: bool,
+}
+
+impl<'a> IntoNomBounds for &'a (Bound<usize>, Bound<usize>) {
+  type NomBounds = NomBoundsBounds;
+
+  fn into_nom_bounds(self) -> Self::NomBounds {
+    let (start, end) = *self;
+    Self::NomBounds {
+      i: 0,
+      start,
+      end,
+      is_exhausted: false,
+    }
+  }
+}
+
+impl NomBounds for NomBoundsBounds {
+  fn next(&mut self) -> ControlFlow<Break, usize> {
+    match self.end {
+      Bound::Included(end) => {
+        if self.i < end {
+          ControlFlow::Continue(replace(self.i + 1, &mut self.i))
+        } else if self.i == end && !self.is_exhausted {
+          self.is_exhausted = true;
+          ControlFlow::Continue(self.i)
+        } else {
+          ControlFlow::Break(Break::Finish)
+        }
+      }
+      Bound::Excluded(end) => {
+        if self.i < end {
+          ControlFlow::Continue(replace(self.i + 1, &mut self.i))
+        } else {
+          ControlFlow::Break(Break::Finish)
+        }
+      }
+      Bound::Unbounded => match self.start {
+        Bound::Included(start) => {
+          if self.i < start {
+            ControlFlow::Continue(replace(self.i + 1, &mut self.i))
+          } else {
+            ControlFlow::Break(Break::Infinite)
+          }
+        }
+        Bound::Excluded(start) => {
+          if self.i < start {
+            ControlFlow::Continue(replace(self.i + 1, &mut self.i))
+          } else if self.i == start && !self.is_exhausted {
+            self.is_exhausted = true;
+            ControlFlow::Continue(self.i)
+          } else {
+            ControlFlow::Break(Break::Infinite)
+          }
+        }
+        Bound::Unbounded => ControlFlow::Break(Break::Infinite),
+      },
+    }
+  }
+
+  fn is_min_reach(self, n: usize) -> bool {
+    match self.start {
+      Bound::Included(start) => n >= start,
+      Bound::Excluded(start) => n > start,
+      Bound::Unbounded => true,
+    }
+  }
+
+  fn is_broken(&self) -> bool {
+    match (self.start, self.end) {
+      (Bound::Included(start), Bound::Included(end)) => {
+        start > end && (end == usize::MAX || start > end + 1)
+      }
+      (Bound::Included(start), Bound::Excluded(end))
+      | (Bound::Excluded(start), Bound::Included(end)) => start > end,
+      (Bound::Excluded(start), Bound::Excluded(end)) => start >= end,
+      (Bound::Excluded(_), Bound::Unbounded)
+      | (Bound::Unbounded, Bound::Excluded(_))
+      | (Bound::Included(_), Bound::Unbounded)
+      | (Bound::Unbounded, Bound::Included(_))
+      | (Bound::Unbounded, Bound::Unbounded) => false,
+    }
+  }
+}
+
+fn replace<T>(src: T, dest: &mut T) -> T {
+  core::mem::replace(dest, src)
+}


### PR DESCRIPTION
This is yet another way to Closes https://github.com/Geal/nom/issues/1393 I like this very much I found it's like a fusion of https://github.com/Geal/nom/pull/1402 and https://github.com/Geal/nom/pull/1407

- More factorize than #1407
- More reusable, this way could be use by a lot of other nom parser every parser that have variant `0` `1` `n_m` etc... see https://github.com/Geal/nom/issues/1383
- Could be better, did someone say GaT ?
- more straightforward than #1402

It's hard to tell what implementation is faster between the 3 implementations, I think we need a benchmark, I expect #1407 faster than this faster than #1402 but anyway could be wrong and bench != real world application.

I'm still not a big fan to check https://github.com/Geal/nom/issues/1333 at least in the current state, I think it's should be user problem, but I did it anyway as a PoC.

Todo:

- [x] fold
- [x] try_fold
- [x] many with extend
- [x] usize for NomBounds
- [ ] doc
- [ ] tests
- [ ] benchmark 3 solutions (+1 old fold_many_n_m)

PS: `ControlFlow` is stable since `1.55` but I don't expect the range feature for any soon so will maybe fix if needed when the time will come.

@cenodis @epage