### PR TITLE
Make infinite loop check debug only

### DIFF
--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -53,7 +53,7 @@ fn separated_list0_test() {
   let i_err_pos = &i[3..];
   assert_eq!(
     empty_sep(i),
-    Err(Err::Error(error_position!(
+    Err(Err::Failure(error_position!(
       i_err_pos,
       ErrorKind::SeparatedList
     )))
@@ -122,7 +122,7 @@ fn many0_test() {
   assert_eq!(multi(&b""[..]), Err(Err::Incomplete(Needed::new(4))));
   assert_eq!(
     multi_empty(&b"abcdef"[..]),
-    Err(Err::Error(error_position!(
+    Err(Err::Failure(error_position!(
       &b"abcdef"[..],
       ErrorKind::Many0
     )))
@@ -439,7 +439,7 @@ fn fold_many0_test() {
   assert_eq!(multi(&b""[..]), Err(Err::Incomplete(Needed::new(4))));
   assert_eq!(
     multi_empty(&b"abcdef"[..]),
-    Err(Err::Error(error_position!(
+    Err(Err::Failure(error_position!(
       &b"abcdef"[..],
       ErrorKind::Many0
     )))


### PR DESCRIPTION
Closes https://github.com/Geal/nom/issues/1443

~~Big PR but not so big, I just rewrite the file using more explicit variable name instead of mono letter, the PR is more about make infinite check optional~~ I wonder if this should use a custom nom feature like `infinite_safe` instead of using `debug_assertions`. ~~This also add this check for `count()` `fill()` `length_count()` but I'm unsure of this move.~~ I also choice to return a `Failure` in case of infinite loop again not sure of this move.

I also notice `length_value()` and `length_data()` doesn't really make sense in `multi` module. I notice some parser don't have custom ErrorKInd, and that some of them don't append Error.

~~This PR affect several other PR and~~ require a rustc upper version of 1.41 but compile in 1.48, I don't know exactly when was added the feature to use cfg on if block.