### PR TITLE
length_count: use Vec::with_capacity

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -958,7 +958,7 @@ where
   move |i: I| {
     let (i, count) = f.parse(i)?;
     let mut input = i.clone();
-    let mut res = Vec::new();
+    let mut res = Vec::with_capacity(count.to_usize());
 
     for _ in 0..count.to_usize() {
       let input_ = input.clone();


### PR DESCRIPTION
This change avoids reallocation while filling in the array. In my case this causes a ~20% perf increase.

This might cause regressions if some users rely on nom *not* allocating the whole array before an error happens, causing their parsers to change behavior from "starts parsing, encounters an error, backtracks to a previous `alt`/`opt`/whatever" to "starts parsing, causes an OOM abort". I don't think nom provides any guarantees in either direction.