### PR TITLE
Add Meilisearch to the list of project using nom

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Here is a (non exhaustive) list of known projects using nom:
 [CSML](https://github.com/CSML-by-Clevy/csml-interpreter),
 [Wasm](https://github.com/Strytyp/wasm-nom),
 [Pseudocode](https://github.com/Gungy2/pseudocode)
+[Filter for MeiliSearch](https://github.com/meilisearch/meilisearch)
 - Interface definition formats: [Thrift](https://github.com/thehydroimpulse/thrust)
 - Audio, video and image formats:
 [GIF](https://github.com/Geal/gif.rs),


### PR DESCRIPTION
Since this PR in milli meilisearch/milli#400 and its integration in [Meilisearch v0.25.0](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.25.0rc0) we use nom to parse our mini [filters](https://docs.meilisearch.com/reference/features/filtering_and_faceted_search.html#filtering-and-faceted-search) language.

Not sure we can call that a “programming language” but it's the best category it think :thinking: 