### PR TITLE
Add a binary parser example in README page

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Here is a (non exhaustive) list of known projects using nom:
 [Matroska (MKV)](https://github.com/rust-av/matroska)
 - Document formats:
 [TAR](https://github.com/Keruspe/tar-parser.rs),
-[GZ](https://github.com/nharward/nom-gzip)
+[GZ](https://github.com/nharward/nom-gzip),
 [GDSII](https://github.com/erihsu/gds2-io)
 - Cryptographic formats:
 [X.509](https://github.com/rusticata/x509-parser)

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Here is a (non exhaustive) list of known projects using nom:
 - Document formats:
 [TAR](https://github.com/Keruspe/tar-parser.rs),
 [GZ](https://github.com/nharward/nom-gzip)
+[GDSII](https://github.com/erihsu/gds2-io)
 - Cryptographic formats:
 [X.509](https://github.com/rusticata/x509-parser)
 - Network protocol formats:


### PR DESCRIPTION
Hi, Geal
I have released a new binary database parser([GDSII](https://en.wikipedia.org/wiki/GDSII)) based on nom on [crates.io](https://crates.io/crates/gds2_io). GDSII is an industrial binary format that is widely adopted in layout tool(semi-manual or full automatic). The code is in [gds-io](https://github.com/erihsu/gds2-io) repo

The gds-io crate support parse/save gds2 file and is already tested pass by self loopback

I have written several parsers based on nom but it's my first time want to share it because it's my first binary file parser. 
