### PR TITLE
feat(readme): add Wordle result parser to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,8 @@ Here is a (non exhaustive) list of known projects using nom:
 [Telcordia/Bellcore SR-4731 SOR OTDR files](https://github.com/JamesHarrison/otdrs),
 [MySQL binary log](https://github.com/PrivateRookie/boxercrab),
 [URI](https://github.com/Skasselbard/nom-uri),
-[Furigana](https://github.com/sachaarbonel/furigana.rs)
+[Furigana](https://github.com/sachaarbonel/furigana.rs),
+[Wordle Result](https://github.com/Fyko/wordle-stats/tree/main/parser)
 
 Want to create a new parser using `nom`? A list of not yet implemented formats is available [here](https://github.com/Geal/nom/issues/14).
 


### PR DESCRIPTION
This PR adds another example to the "Parsers created with Nom" section.