### PR TITLE
Implement `nom::sequence::Tuple` for `()` (Unit)

### DIFF
--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -252,6 +252,15 @@ macro_rules! tuple_trait_inner(
 tuple_trait!(FnA A, FnB B, FnC C, FnD D, FnE E, FnF F, FnG G, FnH H, FnI I, FnJ J, FnK K, FnL L,
   FnM M, FnN N, FnO O, FnP P, FnQ Q, FnR R, FnS S, FnT T, FnU U);
 
+// Special case: implement `Tuple` for `()`, the unit type.
+// This can come up in macros which accept a variable number of arguments.
+// Literally, `()` is an empty tuple, so it should simply parse nothing.
+impl<I, E: ParseError<I>> Tuple<I, (), E> for () {
+  fn parse(&mut self, input: I) -> IResult<I, (), E> {
+    Ok((input, ()))
+  }
+}
+
 ///Applies a tuple of parsers one by one and returns their results as a tuple.
 ///There is a maximum of 21 parsers
 /// ```rust

--- a/src/sequence/tests.rs
+++ b/src/sequence/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::bytes::streaming::{tag, take};
-use crate::error::ErrorKind;
+use crate::error::{ErrorKind, Error};
 use crate::internal::{Err, IResult, Needed};
 use crate::number::streaming::be_u16;
 
@@ -271,4 +271,11 @@ fn tuple_test() {
     tuple_3(&b"abcdejk"[..]),
     Err(Err::Error(error_position!(&b"jk"[..], ErrorKind::Tag)))
   );
+}
+
+#[test]
+fn unit_type() {
+  assert_eq!(tuple::<&'static str, (), Error<&'static str>, ()>(())("abxsbsh"), Ok(("abxsbsh", ())));
+  assert_eq!(tuple::<&'static str, (), Error<&'static str>, ()>(())("sdfjakdsas"), Ok(("sdfjakdsas", ())));
+  assert_eq!(tuple::<&'static str, (), Error<&'static str>, ()>(())(""), Ok(("", ())));
 }


### PR DESCRIPTION
Right now, `()` (Unit) does not implement the [`nom::sequence::Tuple` trait](https://docs.rs/nom/7.1.1/nom/sequence/trait.Tuple.html) required to use the [`tuple` combinator](https://docs.rs/nom/7.1.1/nom/sequence/fn.tuple.html). This makes it difficult to use in macros.

## Example

I'm currently mass-producing parsers using a macro for a fictional instruction set assembler. Each instruction may take a variable number of arguments so I am using this macro component to parse all arguments:

```rust
		tuple(($(
			preceded(space1, $parser)),*
		))
```

This works fine for any number of arguments `>=1` and `<=21`, but notably does not work for a number `==0`. Here's why: 

```
the trait bound `(): nom::sequence::Tuple<_, _, _>` is not satisfied
```

Looks like `()` does not implement `Tuple`, even though it could concievably implement a tuple of zero elements.

This pull request implements `Tuple` for `()` such that it will always succeed and it is always a no-op. It also adds a test case that verifies that `tuple(())` never fails and always returns the input unchanged.

I am unsure if the `ParseError<I>` bound is needed on the impl, but I figured it's better to be safe than sorry and stay consistent with the existing tuple impls. I would also appreciate assistance with removing the ugly turbofishes from the test.