### PR TITLE
Doc: fix 2 unresolved link to recipes.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //! There are a few [guides](https://github.com/Geal/nom/tree/main/doc) with more details
 //! about [how to write parsers](https://github.com/Geal/nom/blob/main/doc/making_a_new_parser_from_scratch.md),
 //! or the [error management system](https://github.com/Geal/nom/blob/main/doc/error_management.md).
-//! You can also check out the [recipes] module that contains examples of common patterns.
+//! You can also check out the [recipes](https://github.com/Geal/nom/blob/main/doc/nom_recipes.md) that contains examples of common patterns.
 //!
 //! **Looking for a specific combinator? Read the
 //! ["choose a combinator" guide](https://github.com/Geal/nom/blob/main/doc/choosing_a_combinator.md)**
@@ -370,7 +370,7 @@
 //! assert_eq!(alpha0_complete("abcd"), Ok(("", "abcd")));
 //! ```
 //! **Going further:** Read the [guides](https://github.com/Geal/nom/tree/main/doc),
-//! check out the [recipes]!
+//! check out the [recipes](https://github.com/Geal/nom/blob/main/doc/nom_recipes.md)!
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::doc_markdown))]
 #![cfg_attr(feature = "docsrs", feature(doc_cfg))]


### PR DESCRIPTION
Thanks for your awesome work on nom! It's a small doc fix links to `[recipes]` docs where broken. don't hesitate to close if it's a duplicate.

Found with `cargo doc --open`.