### PR TITLE
Fix warn unecessary parentheses around match arm expression

### DIFF
--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -1595,7 +1595,7 @@ where
       */
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
-    Some(f) => (Ok((i, f))),
+    Some(f) => Ok((i, f)),
     None => Err(crate::Err::Error(E::from_error_kind(
       i,
       crate::error::ErrorKind::Float,
@@ -1648,7 +1648,7 @@ where
       */
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
-    Some(f) => (Ok((i, f))),
+    Some(f) => Ok((i, f)),
     None => Err(crate::Err::Error(E::from_error_kind(
       i,
       crate::error::ErrorKind::Float,

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -1567,7 +1567,7 @@ where
   */
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
-    Some(f) => (Ok((i, f))),
+    Some(f) => Ok((i, f)),
     None => Err(crate::Err::Error(E::from_error_kind(
       i,
       crate::error::ErrorKind::Float,
@@ -1621,7 +1621,7 @@ where
   */
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
-    Some(f) => (Ok((i, f))),
+    Some(f) => Ok((i, f)),
     None => Err(crate::Err::Error(E::from_error_kind(
       i,
       crate::error::ErrorKind::Float,


### PR DESCRIPTION
Found this warning while compiling with `rustc 1.65.0-nightly (40336865f 2022-08-15)`

```rust
cargo build                                                                                                                                                                                                                      Compiling memchr v2.5.0
   Compiling minimal-lexical v0.2.1
   Compiling nom v7.1.1 (/home/axel/repository/nom)
warning: unnecessary parentheses around match arm expression
    --> src/number/complete.rs:1598:16
     |
1598 |     Some(f) => (Ok((i, f))),
     |                ^          ^
     |
     = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
     |
1598 -     Some(f) => (Ok((i, f))),
1598 +     Some(f) => Ok((i, f)),
     |

warning: unnecessary parentheses around match arm expression
    --> src/number/complete.rs:1651:16
     |
1651 |     Some(f) => (Ok((i, f))),
     |                ^          ^
     |
help: remove these parentheses
     |
1651 -     Some(f) => (Ok((i, f))),
1651 +     Some(f) => Ok((i, f)),
     |

warning: unnecessary parentheses around match arm expression
    --> src/number/streaming.rs:1570:16
     |
1570 |     Some(f) => (Ok((i, f))),
     |                ^          ^
     |
help: remove these parentheses
     |
1570 -     Some(f) => (Ok((i, f))),
1570 +     Some(f) => Ok((i, f)),
     |

warning: unnecessary parentheses around match arm expression
    --> src/number/streaming.rs:1624:16
     |
1624 |     Some(f) => (Ok((i, f))),
     |                ^          ^
     |
help: remove these parentheses
     |
1624 -     Some(f) => (Ok((i, f))),
1624 +     Some(f) => Ok((i, f)),
     |

warning: `nom` (lib) generated 4 warnings
```