### PR TITLE
Clamp Vec::with_capacity to 64KiB to avoid OOM

### DIFF
--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -214,3 +214,18 @@ fn issue_1282_findtoken_char() {
   let parser = one_of::<_, _, Error<_>>(&['a', 'b', 'c'][..]);
   assert_eq!(parser("aaa"), Ok(("aa", 'a')));
 }
+
+#[test]
+fn issue_1459_clamp_capacity() {
+  use nom::character::complete::char;
+
+  // shouldn't panic
+  use nom::multi::many_m_n;
+  let mut parser = many_m_n::<_, _, (), _>(usize::MAX, usize::MAX, char('a'));
+  assert_eq!(parser("a"), Err(nom::Err::Error(())));
+
+  // shouldn't panic
+  use nom::multi::count;
+  let mut parser = count::<_, _, (), _>(char('a'), usize::MAX);
+  assert_eq!(parser("a"), Err(nom::Err::Error(())));
+}


### PR DESCRIPTION
Fuzz testers love to muck with length fields and trigger OOM panics. This is documented in https://github.com/Geal/nom/issues/1459.

This PR fixes the linked issue, though my solution is not the suggested one. Rather than adding a new combinator, I've updated `many_m_n` and `count` to clamp their `Vec::with_capacity` calls to 64KiB. This greatly reduces (though does not eliminate) the risk of OOM panics while still providing most of the benefit of preallocating memory.

Clamping initial capacity to 64KiB does not affect correctness. Nom will still read the full number of elements. The initial capacity is just a performance hint.