### PR TITLE
New combinator: `multi::reduce`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -417,6 +417,7 @@ pub enum ErrorKind {
   Float,
   Satisfy,
   Fail,
+  Reduce,
 }
 
 #[rustfmt::skip]
@@ -477,6 +478,7 @@ pub fn error_to_u32(e: &ErrorKind) -> u32 {
     ErrorKind::Float                     => 73,
     ErrorKind::Satisfy                   => 74,
     ErrorKind::Fail                      => 75,
+    ErrorKind::Reduce                    => 76,
   }
 }
 
@@ -539,6 +541,7 @@ impl ErrorKind {
       ErrorKind::Float                     => "Float",
       ErrorKind::Satisfy                   => "Satisfy",
       ErrorKind::Fail                      => "Fail",
+      ErrorKind::Reduce                    => "Reduce",
     }
   }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -473,7 +473,7 @@ mod tests {
   #[cfg(target_pointer_width = "64")]
   fn size_test() {
     assert_size!(IResult<&[u8], &[u8], (&[u8], u32)>, 40);
-    assert_size!(IResult<&str, &str, u32>, 40);
+    assert_size!(IResult<&str, &str, u32>, 32);
     assert_size!(Needed, 8);
     assert_size!(Err<u32>, 16);
     assert_size!(ErrorKind, 1);

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -1,4 +1,4 @@
-use super::{length_data, length_value, many0_count, many1_count};
+use super::{length_data, length_value, many0_count, many1_count, reduce};
 use crate::{
   bytes::streaming::tag,
   character::streaming::digit1 as digit,
@@ -6,7 +6,7 @@ use crate::{
   internal::{Err, IResult, Needed},
   lib::std::str::{self, FromStr},
   number::streaming::{be_u16, be_u8},
-  sequence::{pair, tuple},
+  sequence::{pair, terminated, tuple},
 };
 #[cfg(feature = "alloc")]
 use crate::{
@@ -531,4 +531,23 @@ fn many1_count_test() {
       ErrorKind::Many1Count
     )))
   );
+}
+
+#[test]
+fn reduce_test() {
+  fn max_num(i: &[u8]) -> IResult<&[u8], i32> {
+    reduce(
+      terminated(crate::character::complete::i32, tag(",")),
+      Ord::max,
+    )(i)
+  }
+
+  assert_eq!(max_num(&b"3,1,4,1,junk"[..]), Ok((&b"junk"[..], 4)));
+
+  assert_eq!(max_num(&b"42,"[..]), Ok((&b""[..], 42)));
+
+  assert_eq!(
+    max_num(&b"junk"[..]),
+    Err(Err::Error(error_position!(&b"junk"[..], ErrorKind::Reduce)))
+  )
 }

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -429,7 +429,7 @@ fn fold_many0_test() {
   assert_eq!(multi(&b""[..]), Err(Err::Incomplete(Needed::new(4))));
   assert_eq!(
     multi_empty(&b"abcdef"[..]),
-    Err(Err::Error(error_position!(
+    Err(Err::Failure(error_position!(
       &b"abcdef"[..],
       ErrorKind::Many0
     )))


### PR DESCRIPTION
<!--
Hello, and thank you for submitting a pull request to nom!

First, please note that, for family reasons, I have limited time to work on
nom, so following the advice here will make sure I will quickly understand
your work and be able to merge it early.
Second, if I don't get to work on your PR quickly, that does not mean I won't
include it later. Major version releases happen once a year, and a lot of
interesting work is merged for the occasion. So I will get back to you :)

## Prerequisites

Please provide the following information with this pull request:

- related issue number (I need some context to understand a PR with a lot of
code, except for documentation typos)
- a test case reproducing the issue. You can write it in [issues.rs](https://github.com/Geal/nom/blob/main/tests/issues.rs)
- if adding a new combinator, please add code documentation and some unit tests
in the same file. Also, please update the [combinator list](https://github.com/Geal/nom/blob/main/doc/choosing_a_combinator.md)

## Code style

This project follows a [code style](https://github.com/Geal/nom/blob/main/rustfmt.toml)
checked by [rustfmt][https://github.com/rust-lang-nursery/rustfmt].

Please avoid cosmetic fixes unrelated to the pull request. Keeping the changes
as small as possible increase your chances of getting this merged quickly.

## Rebasing

To make sure the changes will work properly once merged into the main branch
(which might have changed while you were working on your PR), please
[rebase your PR on main](https://git-scm.com/book/en/v2/Git-Branching-Rebasing).

## Squashing the commits

If the pull request include a lot of small commits used for testing, debugging,
or correcting previous work, it might be useful to
[squash the commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
to make the code easier to merge.
-->

This PR adds a new combinator: `multi::reduce`. It is essentially a special case of `multi::fold_many1` where the accumulator type is the same as the parsed type.

Analogous to `Iterator::reduce`, this new combinator takes the first parsed element as the initial value rather than use a separate initializer function. This is useful in many cases, but most commonly for when you do not have an easy base element for your reduction, for example when computing a minimum over a list of elements without a well-defined absolute maximum.

Aside from this new combinator, the PR also includes the following changes (in separate commits for easy review):

- Fix a test for a specific struct size. Apparently rustc got smarter?
- Refactor shared code between `fold_many0` and `fold_many1`
- **Breaking:** change the infinite loop error for `fold_many1` from `Error` to `Failure`. I believe this was always the correct version since it indicates a programming error and not a data issue.

Tests for new code included.