### PR TITLE
Create Parser implementation for rest

### DIFF
--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -73,7 +73,7 @@ where
 ///   bits::<_, _, Error<(&[u8], usize)>, _, _>((
 ///     take(4usize),
 ///     take(8usize),
-///     bytes::<_, _, Error<&[u8]>, _, _>(rest)
+///     bytes::<_, _, Error<&[u8]>, _, _>(rest())
 ///   ))(input)
 /// }
 ///

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -7,6 +7,7 @@ use crate::internal::{Err, IResult, Needed};
 #[cfg(feature = "alloc")]
 use crate::lib::std::boxed::Box;
 use crate::number::complete::u8;
+use crate::Parser;
 
 macro_rules! assert_parse(
   ($left: expr, $right: expr) => {
@@ -73,14 +74,14 @@ fn end_of_input() {
 fn rest_on_slices() {
   let input: &[u8] = &b"Hello, world!"[..];
   let empty: &[u8] = &b""[..];
-  assert_parse!(rest(input), Ok((empty, input)));
+  assert_parse!(rest().parse_complete(input), Ok((empty, input)));
 }
 
 #[test]
 fn rest_on_strs() {
   let input: &str = "Hello, world!";
   let empty: &str = "";
-  assert_parse!(rest(input), Ok((empty, input)));
+  assert_parse!(rest().parse_complete(input), Ok((empty, input)));
 }
 
 #[test]


### PR DESCRIPTION
<!--
Hello, and thank you for submitting a pull request to nom!

First, please note that, for family reasons, I have limited time to work on
nom, so following the advice here will make sure I will quickly understand
your work and be able to merge it early.
Second, if I don't get to work on your PR quickly, that does not mean I won't
include it later. Major version releases happen once a year, and a lot of
interesting work is merged for the occasion. So I will get back to you :)

## Prerequisites

Please provide the following information with this pull request:

- related issue number (I need some context to understand a PR with a lot of
code, except for documentation typos)
- a test case reproducing the issue. You can write it in [issues.rs](https://github.com/rust-bakery/nom/blob/main/tests/issues.rs)
- if adding a new combinator, please add code documentation and some unit tests
in the same file. Also, please update the [combinator list](https://github.com/rust-bakery/nom/blob/main/doc/choosing_a_combinator.md)

## Code style

This project follows a [code style](https://github.com/rust-bakery/nom/blob/main/rustfmt.toml)
checked by [rustfmt](https://github.com/rust-lang/rustfmt).

Please avoid cosmetic fixes unrelated to the pull request. Keeping the changes
as small as possible increase your chances of getting this merged quickly.

## Rebasing

To make sure the changes will work properly once merged into the main branch
(which might have changed while you were working on your PR), please
[rebase your PR on main](https://git-scm.com/book/en/v2/Git-Branching-Rebasing).

## Squashing the commits

If the pull request include a lot of small commits used for testing, debugging,
or correcting previous work, it might be useful to
[squash the commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
to make the code easier to merge.
-->
This PR changes the `rest` combinator so that it now returns an `impl Parser`.  I've updated the old tests for `rest` as well as any test/documentation that made  use of the combinator. 