### PR TITLE
iterator_complete for complete parsers

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -901,7 +901,10 @@ where
 }
 
 /// Same as [iterator] but for complete parsers
-pub fn iterator_complete<Input, Error, F>(input: Input, f: F) -> ParserIterator<Input, Error, F, Complete>
+pub fn iterator_complete<Input, Error, F>(
+  input: Input,
+  f: F,
+) -> ParserIterator<Input, Error, F, Complete>
 where
   F: Parser<Input>,
   Error: ParseError<Input>,
@@ -919,7 +922,7 @@ pub struct ParserIterator<I, E, F, S> {
   iterator: F,
   input: I,
   state: State<E>,
-  _streaming: std::marker::PhantomData<S>
+  _streaming: std::marker::PhantomData<S>,
 }
 
 impl<I: Clone, E, F, S> ParserIterator<I, E, F, S> {

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -869,8 +869,9 @@ where
 
 /// Creates an iterator from input data and a parser.
 ///
-/// Call the iterator's [ParserIterator::finish] method to get the remaining input if successful,
-/// or the error value if we encountered an error.
+/// Call the iterator's [ParserIterator::finish] method (or [ParserIterator::finish_complete] for
+/// complete parsers) to get the remaining input if successful, or the error value if we encountered
+/// an error.
 ///
 /// On [`Err::Error`], iteration will stop. To instead chain an error up, see [`cut`].
 ///
@@ -901,7 +902,7 @@ where
 }
 
 /// Main structure associated to the [iterator] function.
-pub struct ParserIterator<I, E, F, S = Complete> {
+pub struct ParserIterator<I, E, F, S> {
   iterator: F,
   input: I,
   state: Option<State<E>>,
@@ -911,13 +912,16 @@ pub struct ParserIterator<I, E, F, S = Complete> {
 
 impl<I: Clone, E, F> ParserIterator<I, E, F, Complete> {
   /// Returns the remaining input if parsing was successful, or the error if we encountered an error.
-  pub fn finish(mut self) -> IResult<I, (), E> {
+  /// 
+  /// To be used for Complete parsers
+  pub fn finish_complete(mut self) -> IResult<I, (), E> {
     match self.state.take().unwrap() {
       State::Incomplete(_) | State::Running | State::Done => Ok((self.input, ())),
       State::Failure(e) => Err(Err::Failure(e)),
     }
   }
 }
+
 impl<I: Clone, E, F> ParserIterator<I, E, F, Streaming> {
   /// Returns the remaining input if parsing was successful, or the error if we encountered an error.
   pub fn finish(mut self) -> IResult<I, (), E> {

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -869,9 +869,8 @@ where
 
 /// Creates an iterator from input data and a parser.
 ///
-/// Call the iterator's [ParserIterator::finish] method (or [ParserIterator::finish_complete] for
-/// complete parsers) to get the remaining input if successful, or the error value if we encountered
-/// an error.
+/// Call the iterator's [ParserIterator::finish] method to get the remaining
+/// input if successful, or the error value if we encountered an error.
 ///
 /// On [`Err::Error`], iteration will stop. To instead chain an error up, see [`cut`].
 ///
@@ -888,17 +887,30 @@ where
 /// assert_eq!(parsed, [("abc", 3usize), ("defg", 4), ("hijkl", 5), ("mnopqr", 6)].iter().cloned().collect());
 /// assert_eq!(res, Ok(("123", ())));
 /// ```
-pub fn iterator<Input, Error, F, S>(input: Input, f: F) -> ParserIterator<Input, Error, F, S>
+pub fn iterator<Input, Error, F>(input: Input, f: F) -> ParserIterator<Input, Error, F, Streaming>
 where
   F: Parser<Input>,
-  S: IsStreaming,
   Error: ParseError<Input>,
 {
   ParserIterator {
     iterator: f,
     input,
     state: Some(State::Running),
-    _streaming: PhantomData
+    _streaming: PhantomData,
+  }
+}
+
+/// Same as [iterator] but for complete parsers
+pub fn iterator_complete<Input, Error, F>(input: Input, f: F) -> ParserIterator<Input, Error, F, Complete>
+where
+  F: Parser<Input>,
+  Error: ParseError<Input>,
+{
+  ParserIterator {
+    iterator: f,
+    input,
+    state: Some(State::Running),
+    _streaming: PhantomData,
   }
 }
 
@@ -910,19 +922,7 @@ pub struct ParserIterator<I, E, F, S> {
   _streaming: std::marker::PhantomData<S>
 }
 
-impl<I: Clone, E, F> ParserIterator<I, E, F, Complete> {
-  /// Returns the remaining input if parsing was successful, or the error if we encountered an error.
-  /// 
-  /// To be used for Complete parsers
-  pub fn finish_complete(mut self) -> IResult<I, (), E> {
-    match self.state.take().unwrap() {
-      State::Incomplete(_) | State::Running | State::Done => Ok((self.input, ())),
-      State::Failure(e) => Err(Err::Failure(e)),
-    }
-  }
-}
-
-impl<I: Clone, E, F> ParserIterator<I, E, F, Streaming> {
+impl<I: Clone, E, F, S> ParserIterator<I, E, F, S> {
   /// Returns the remaining input if parsing was successful, or the error if we encountered an error.
   pub fn finish(mut self) -> IResult<I, (), E> {
     match self.state.take().unwrap() {
@@ -937,7 +937,7 @@ impl<Input, Output, Error, F, S> core::iter::Iterator for ParserIterator<Input, 
 where
   F: Parser<Input, Output = Output, Error = Error>,
   Input: Clone,
-  S: IsStreaming
+  S: IsStreaming,
 {
   type Item = Output;
 

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -891,6 +891,7 @@ where
 pub fn iterator<Input, Error, F, S>(input: Input, f: F) -> ParserIterator<Input, Error, F, S>
 where
   F: Parser<Input>,
+  S: IsStreaming,
   Error: ParseError<Input>,
 {
   ParserIterator {
@@ -907,7 +908,6 @@ pub struct ParserIterator<I, E, F, S> {
   input: I,
   state: Option<State<E>>,
   _streaming: std::marker::PhantomData<S>
-
 }
 
 impl<I: Clone, E, F> ParserIterator<I, E, F, Complete> {

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -887,7 +887,7 @@ where
 /// assert_eq!(parsed, [("abc", 3usize), ("defg", 4), ("hijkl", 5), ("mnopqr", 6)].iter().cloned().collect());
 /// assert_eq!(res, Ok(("123", ())));
 /// ```
-pub fn iterator<Input, Error, F>(input: Input, f: F) -> ParserIterator<Input, Error, F>
+pub fn iterator<Input, Error, F, S>(input: Input, f: F) -> ParserIterator<Input, Error, F, S>
 where
   F: Parser<Input>,
   Error: ParseError<Input>,
@@ -896,17 +896,29 @@ where
     iterator: f,
     input,
     state: Some(State::Running),
+    _streaming: PhantomData
   }
 }
 
 /// Main structure associated to the [iterator] function.
-pub struct ParserIterator<I, E, F> {
+pub struct ParserIterator<I, E, F, S = Complete> {
   iterator: F,
   input: I,
   state: Option<State<E>>,
+  _streaming: std::marker::PhantomData<S>
+
 }
 
-impl<I: Clone, E, F> ParserIterator<I, E, F> {
+impl<I: Clone, E, F> ParserIterator<I, E, F, Complete> {
+  /// Returns the remaining input if parsing was successful, or the error if we encountered an error.
+  pub fn finish(mut self) -> IResult<I, (), E> {
+    match self.state.take().unwrap() {
+      State::Incomplete(_) | State::Running | State::Done => Ok((self.input, ())),
+      State::Failure(e) => Err(Err::Failure(e)),
+    }
+  }
+}
+impl<I: Clone, E, F> ParserIterator<I, E, F, Streaming> {
   /// Returns the remaining input if parsing was successful, or the error if we encountered an error.
   pub fn finish(mut self) -> IResult<I, (), E> {
     match self.state.take().unwrap() {
@@ -917,10 +929,11 @@ impl<I: Clone, E, F> ParserIterator<I, E, F> {
   }
 }
 
-impl<Input, Output, Error, F> core::iter::Iterator for ParserIterator<Input, Error, F>
+impl<Input, Output, Error, F, S> core::iter::Iterator for ParserIterator<Input, Error, F, S>
 where
   F: Parser<Input, Output = Output, Error = Error>,
   Input: Clone,
+  S: IsStreaming
 {
   type Item = Output;
 
@@ -928,7 +941,7 @@ where
     if let State::Running = self.state.take().unwrap() {
       let input = self.input.clone();
 
-      match (self.iterator).parse(input) {
+      match (self.iterator).process::<OutputM<Emit, Emit, S>>(input) {
         Ok((i, o)) => {
           self.input = i;
           self.state = Some(State::Running);

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -264,7 +264,7 @@ fn issue_1586_parser_iterator_impl() {
   }
 
   fn parse_input(i: &str) -> impl Iterator<Item = i32> + '_ {
-    iterator(i, parse_line).map(|x| x.parse::<i32>().unwrap())
+    iterator::<_, _, _, nom::Streaming>(i, parse_line).map(|x| x.parse::<i32>().unwrap())
   }
 
   assert_eq!(parse_input("123\n456").collect::<Vec<_>>(), vec![123, 456]);

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -264,7 +264,7 @@ fn issue_1586_parser_iterator_impl() {
   }
 
   fn parse_input(i: &str) -> impl Iterator<Item = i32> + '_ {
-    iterator::<_, _, _, nom::Streaming>(i, parse_line).map(|x| x.parse::<i32>().unwrap())
+    iterator(i, parse_line).map(|x| x.parse::<i32>().unwrap())
   }
 
   assert_eq!(parse_input("123\n456").collect::<Vec<_>>(), vec![123, 456]);


### PR DESCRIPTION
Hello,

This is a proposed solution to #1835 . I do not particularly like it, but it is backwards compatible. My first idea (in a previous commit) was to have a separate `finish` function, but that forces generic arguments on `iterator` when `finish` isn't called.

All tests pass. I did not add new tests. (Changing the test was needed for my first idea).

fixes #1835 