### PR TITLE
Fix "called `Option::unwrap()` on a `None` value" in ParserIterator

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -925,7 +925,7 @@ where
   type Item = Output;
 
   fn next(&mut self) -> Option<Self::Item> {
-    if let State::Running = self.state.take().unwrap() {
+    if let Some(State::Running) = self.state {
       let input = self.input.clone();
 
       match (self.iterator).parse(input) {

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -282,3 +282,26 @@ fn fail_test() {
     Err(Err::Error((b, ErrorKind::Fail)))
   );
 }
+
+#[test]
+fn parser_iterator_test() {
+  use crate::character::complete::alpha1;
+  use crate::sequence::terminated;
+  use crate::IResult;
+
+  let input: &str = "next:test:";
+
+  let mut nom_it = iterator(input, terminated(alpha1, tag(":")));
+
+  assert_eq!(Some("next"), nom_it.next());
+  assert_eq!(Some("test"), nom_it.next());
+
+  // and then None once it's over.
+  assert_eq!(None, nom_it.next());
+
+  // None for more calls
+  assert_eq!(None, nom_it.next());
+
+  let parser_result: IResult<_, _> = nom_it.finish();
+  assert_eq!(Ok(("", ())), parser_result);
+}


### PR DESCRIPTION
Hello

In this example I had the following problem!

```rust
use std::iter::Iterator;

use nom::bytes::complete::tag;
use nom::character::complete::alphanumeric1;
use nom::combinator::iterator;
use nom::sequence::{separated_pair, terminated};
use nom::IResult;


fn main() {

  let data = "key1:value1,key2:value2,";
  let mut nom_it = iterator(
    data,
    terminated(
      separated_pair(alphanumeric1, tag(":"), alphanumeric1),
      tag(","),
    ),
  );

  assert_eq!(Some(("key1", "value1")), nom_it.next());
  assert_eq!(Some(("key2", "value2")), nom_it.next());
  assert_eq!(None, nom_it.next());
  assert_eq!(None, nom_it.next());
  let parser_result: IResult<_, _> = nom_it.finish();
  assert_eq!(Ok(("", ())), parser_result);
}
```

```
`thread 'main' panicked at /home/user/nom/src/combinator/mod.rs:912:29:
called `Option::unwrap()` on a `None` value`
```

This happened because of extra calls to the `next()` function and 
[Here](https://github.com/rust-bakery/nom/blob/main/src/combinator/mod.rs#L928) the `state` variable is set to `None` but is not set in these [conditions](https://github.com/rust-bakery/nom/blob/main/src/combinator/mod.rs#L951)

I think this behavior is incorrect. 
In iterator [std::iter.next()](https://doc.rust-lang.org/nightly/core/iter/trait.Iterator.html#tymethod.next) additional calls to the `next` function will return `None`. I think it would be logical for this iterator to have similar behavior.

I fixed it and added tests for this example!

Please review MR  you have time, thank you!