### PR TITLE
Use check output mode in not combinator

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -603,7 +603,7 @@ where
 
   fn process<OM: OutputMode>(&mut self, input: I) -> PResult<OM, I, Self::Output, Self::Error> {
     let i = input.clone();
-    match self.parser.process::<OM>(input) {
+    match self.parser.process::<OutputM<Check, OM::Error, OM::Incomplete>>(input) {
       Ok(_) => Err(Err::Error(OM::Error::bind(|| {
         <F as Parser<I>>::Error::from_error_kind(i, ErrorKind::Not)
       }))),


### PR DESCRIPTION
The `not` combinator doesn't actually use the output of its child parser, so it seems reasonable to force the output mode to `Check` as a performance optimization. In a reasonably complex parser, this has improved by ~10% and up to 25% in some scenarios.