### PR TITLE
Update documentation for anychar

### DIFF
--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -269,8 +269,7 @@ where
   char('\t')(input)
 }
 
-/// Matches one byte as a character. Note that the input type will
-/// accept a `str`, but not a `&[u8]`, unlike many other nom parsers.
+/// Matches one byte as a character.
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 /// # Example

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -251,8 +251,7 @@ where
   }
 }
 
-// Matches one byte as a character. Note that the input type will
-/// accept a `str`, but not a `&[u8]`, unlike many other nom parsers.
+/// Matches one byte as a character.
 ///
 /// # Example
 ///


### PR DESCRIPTION
Documentation for anychar was out-of-date since mentioned limitation was removed in 3.2.0.

Closes #1781.

Tested it with `&[u8]` and it works as expected.